### PR TITLE
Support for special chars in page names

### DIFF
--- a/lib/gollum/frontend/templates/compare.mustache
+++ b/lib/gollum/frontend/templates/compare.mustache
@@ -1,7 +1,7 @@
 <div class="guide">
   <div class="main">
     <div class="actions">
-      <a href="/{{name}}">&laquo; Back</a>
+      <a href="/{{escaped_name}}">&laquo; Back</a>
     </div>
     <h1>{{title}}: {{before}} &rarr; {{after}}</h1>
     <div id="files">

--- a/lib/gollum/frontend/templates/create.mustache
+++ b/lib/gollum/frontend/templates/create.mustache
@@ -2,7 +2,7 @@
   <a href="/">&laquo; Home</a>
   <h1>{{title}}</h1>
 
-  <form class="new_wiki" method="post" action="/create/{{name}}">
+  <form class="new_wiki" method="post" action="/create/{{escaped_name}}">
     <div>
       <label>
         Title<br />

--- a/lib/gollum/frontend/templates/edit.mustache
+++ b/lib/gollum/frontend/templates/edit.mustache
@@ -1,8 +1,8 @@
 <div class="write">
-  <a href="/{{name}}">&laquo; Back</a>
+  <a href="/{{escaped_name}}">&laquo; Back</a>
   <h1>{{title}}</h1>
 
-  <form class="edit_wiki" method="post" action="/edit/{{name}}">
+  <form class="edit_wiki" method="post" action="/edit/{{escaped_name}}">
     <div>
       <label>
         Title<br />

--- a/lib/gollum/frontend/templates/history.mustache
+++ b/lib/gollum/frontend/templates/history.mustache
@@ -1,10 +1,10 @@
 <div class="guide">
   <div class="main">
     <div class="actions">
-      <a href="/{{name}}">&laquo; Back</a>
+      <a href="/{{escaped_name}}">&laquo; Back</a>
     </div>
     <h1>{{title}}</h1>
-    <form id="history" method="post" action="/compare/{{name}}">
+    <form id="history" method="post" action="/compare/{{escaped_name}}">
       <table class="commits" cellpadding="0" cellspacing="0">
         <tr>
           <th colspan="5">
@@ -17,7 +17,7 @@
               <input name="versions[]" type="checkbox" value="{{id}}" />
             </td>
             <td class="sha">
-              <a href="/{{name}}/{{id}}">{{id7}}</a>
+              <a href="/{{escaped_name}}/{{id}}">{{id7}}</a>
             </td>
             <td nowrap class="author">
               <img src="http://www.gravatar.com/avatar/{{gravatar}}?s=16" alt="Gravatar" />

--- a/lib/gollum/frontend/templates/page.mustache
+++ b/lib/gollum/frontend/templates/page.mustache
@@ -1,7 +1,7 @@
 <div class="guide">
   <div class="main">
     <div class="actions">
-      <a href="/">Home</a> | <a href="/edit/{{name}}">Edit</a>
+      <a href="/">Home</a> | <a href="/edit/{{escaped_name}}">Edit</a>
     </div>
     <h1>{{title}}</h1>
     <div class="content wikistyle gollum {{format}}">
@@ -18,10 +18,10 @@
   <div style="float: left;">
     <small>Last edited by <b>{{author}}</b>, {{date}}</small>
     <div class="actions">
-      <a href="/">Home</a> | <a href="/edit/{{name}}">Edit</a>
+      <a href="/">Home</a> | <a href="/edit/{{escaped_name}}">Edit</a>
     </div>
   </div>
   <div style="float: right;">
-    <a href="/history/{{name}}">View Revision History</a>
+    <a href="/history/{{escaped_name}}">View Revision History</a>
   </div>
 </div>

--- a/lib/gollum/frontend/views/layout.rb
+++ b/lib/gollum/frontend/views/layout.rb
@@ -1,3 +1,5 @@
+require 'cgi'
+
 module Precious
   module Views
     class Layout < Mustache
@@ -5,6 +7,10 @@ module Precious
       alias_method :h, :escape_html
 
       attr_reader :name
+
+      def escaped_name
+        CGI.escape(@name)
+      end
 
       def title
         "Home"

--- a/lib/gollum/markup.rb
+++ b/lib/gollum/markup.rb
@@ -1,4 +1,5 @@
 require 'digest/sha1'
+require 'cgi'
 
 module Gollum
   class Markup
@@ -267,10 +268,10 @@ module Gollum
         %{<a href="#{name}">#{name}</a>}
       else
         if page = @wiki.page(cname)
-          link = ::File.join(@wiki.base_path, Page.cname(page.name))
+          link = ::File.join(@wiki.base_path, CGI.escape(Page.cname(page.name)))
           presence = "present"
         else
-          link = ::File.join(@wiki.base_path, cname)
+          link = ::File.join(@wiki.base_path, CGI.escape(cname))
           presence = "absent"
         end
         %{<a class="internal #{presence}" href="#{link}">#{name}</a>}


### PR DESCRIPTION
Currently, it's possible to create a link to a page containing RFC 1738 special chars (";", "/", "?", ":", "@", "=" and "&"), but it is not possible to create or edit these pages. This commit adds support for these special characters in page names.
