### PR TITLE
Support for dynamic tags

### DIFF
--- a/lib/gollum/markup.rb
+++ b/lib/gollum/markup.rb
@@ -14,6 +14,7 @@ module Gollum
       @version = page.version.id
       @dir     = ::File.dirname(page.path)
       @tagmap  = {}
+      @dynamictagmap  = {}
       @codemap = {}
       @texmap  = {}
     end
@@ -149,12 +150,12 @@ module Gollum
     def extract_dynamic_tags(data)
       data.gsub(/(.?)\{\{(.+?)\}\}([^\[]?)/m) do
         if $1 == "'" && $3 != "'"
-          "{{#{$2}}}#{$3}"
-        elsif $2.include?('}{')
+          "\{\{#{$2}\}\}#{$3}"
+        elsif $2.include?('}{[')
           $&
         else
           id = Digest::SHA1.hexdigest($2)
-          @tagmap[id] = $2
+          @dynamictagmap[id] = $2
           "#{$1}#{id}#{$3}"
         end
       end
@@ -167,7 +168,7 @@ module Gollum
     #
     # Returns the marked up String data.
     def process_dynamic_tags(data)
-      @tagmap.each do |id, tag|
+      @dynamictagmap.each do |id, tag|
         data.gsub!(id, process_dynamic_tag(tag))
       end
       data


### PR DESCRIPTION
I've attempted to take @henrikh's points from #39 and make an actual feature branch (my original pull request was a suggestion/example, not actual request), using {{ }} as syntax for dynamic tags, with a {{pages}} tag for generating an inline list of wiki pages (ala the /_pages route).
