### PR TITLE
Image tags for paths in caps

### DIFF
--- a/lib/gollum/markup.rb
+++ b/lib/gollum/markup.rb
@@ -162,7 +162,7 @@ module Gollum
       name  = parts[0].strip
       path  = if file = find_file(name)
         ::File.join @wiki.base_path, file.path
-      elsif name =~ /^https?:\/\/.+(jpg|png|gif|svg|bmp)$/
+      elsif name =~ /^https?:\/\/.+(jpg|png|gif|svg|bmp)$/i
         name
       end
 

--- a/test/test_markup.rb
+++ b/test/test_markup.rb
@@ -145,6 +145,17 @@ context "Markup" do
     end
   end
 
+  test "image with extension in caps with http url" do
+    ['http', 'https'].each do |scheme|
+      name = "Bilbo Baggins #{scheme}"
+      @wiki.write_page(name, :markdown, "a [[#{scheme}://example.com/bilbo.JPG]] b", commit_details)
+
+      page = @wiki.page(name)
+      output = page.formatted_data
+      assert_equal %{<p>a <img src="#{scheme}://example.com/bilbo.JPG" /> b</p>}, output
+    end
+  end
+
   test "image with absolute path" do
     @wiki = Gollum::Wiki.new(@path, :base_path => '/wiki')
     index = @wiki.repo.index


### PR DESCRIPTION
I noticed that if I write an image tag for an image with a file extension in caps, it is not rendered. For example
    [[http://www.ikea.com/PIAimages/0089190_PE221151_S3.JPG]]

I've added a test to confirm it and made the regexp ignore case.
