### PR TITLE
fatal: corrupt tree file under Windows due to path normalization differences

### DIFF
--- a/lib/gollum/blob_entry.rb
+++ b/lib/gollum/blob_entry.rb
@@ -60,6 +60,7 @@ module Gollum
     #   normalize_dir("foo")   # => "/foo"
     #   normalize_dir("/foo/") # => "/foo"
     #   normalize_dir("/")     # => ""
+    #   normalize_dir("c:/")   # => ""
     #
     # dir - String directory name.
     #
@@ -68,7 +69,7 @@ module Gollum
     def self.normalize_dir(dir)
       if dir
         dir = ::File.expand_path(dir, '/')
-        dir = '' if dir == '/'
+        dir = '' if (dir == '/' || dir =~ /^.:\/$/)
       end
       dir
     end


### PR DESCRIPTION
under windows, if a wiki is located here"

c:\wiki

gollum will form a tree containing ':' as an entry. this is illegal under Windows.
fixing this by identifying drive letters as root and chopping them off.

see further discussion here.
https://github.com/mojombo/grit/issues/issue/50/
