### PR TITLE
Fixing search box location.

### DIFF
--- a/lib/gollum/frontend/public/css/gollum.css
+++ b/lib/gollum/frontend/public/css/gollum.css
@@ -42,7 +42,6 @@ a:hover, a:visited {
     line-height: normal;
     margin: 0;
     padding: 0.08em 0 0 0;
-    width: 50%;
   }
   
   #head ul.actions {


### PR DESCRIPTION
The recent "All Pages" commit, combined with the "#head h1" width of 50% was causing the search box to be rendered on a line below the buttons.  This fixes it.
