### PR TITLE
Added support for LanguageDefinition activate/deactivate functions

### DIFF
--- a/lib/gollum/frontend/public/javascript/editor/gollum.editor.js
+++ b/lib/gollum/frontend/public/javascript/editor/gollum.editor.js
@@ -162,6 +162,9 @@
     },
 
     setActiveLanguage: function( name ) {
+      if(LanguageDefinition.getHookFunctionFor("deactivate")) {
+        LanguageDefinition.getHookFunctionFor("deactivate")();
+      }
       if ( !LanguageDefinition.isLoadedFor(name) ) {
         LanguageDefinition._ACTIVE_LANG = null;
         LanguageDefinition.loadFor( name, function(x, t) {
@@ -180,13 +183,33 @@
             FormatSelector.updateSelected();
           }
 
+          if(LanguageDefinition.getHookFunctionFor("activate")) {
+            LanguageDefinition.getHookFunctionFor("activate")();
+          }
         } );
       } else {
         LanguageDefinition._ACTIVE_LANG = name;
         FunctionBar.refresh();
+
+        if(LanguageDefinition.getHookFunctionFor("activate")) {
+          LanguageDefinition.getHookFunctionFor("activate")();
+        }
       }
     },
 
+    getHookFunctionFor: function(attr, specified_lang) {
+      if ( !specified_lang ) {
+        specified_lang = LanguageDefinition._ACTIVE_LANG;
+      }
+
+      if ( LanguageDefinition.isLoadedFor(specified_lang) &&
+           LanguageDefinition._LANG[specified_lang][attr] &&
+           typeof LanguageDefinition._LANG[specified_lang][attr] == 'function' ) {
+        return LanguageDefinition._LANG[specified_lang][attr];
+      }
+
+      return null;
+    },
 
     /**
      *  gets a definition object for a specified attribute


### PR DESCRIPTION
I've added support for activate/deactivate hook functions in LanguageDefinition so that languages that have a client-side component can setup and teardown UI elements in the editor.

Basically, I'm using Gollum as the basis for a project to allows expert (but non-technical editors) to make changes to semi-structured data in a way that can be tracked, reverted, branched, merged, etc. The semi-structured data format has a LanguageDefinition defined, but it also needs to modify the editor UI when it's selected (and remove those UI elements when unselected).

This hook behavior allows LanguageDefinitions to be more flexible while also making them more modular. And it means all of the functionality I'm adding can be kept outside of core Gollum, getting rid of my need to constantly rebase from origin/master. :-)
