### PR TITLE
default_executable= have been deprecated

### DIFF
--- a/gollum.gemspec
+++ b/gollum.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |s|
   s.require_paths = %w[lib]
 
   s.executables = ["gollum"]
-  s.default_executable = 'gollum'
 
   s.rdoc_options = ["--charset=UTF-8"]
   s.extra_rdoc_files = %w[README.md LICENSE]


### PR DESCRIPTION
Reference: http://blog.segment7.net/2011/05/04/rubygems-1-8-0
