### PR TITLE
Fixed broken preview functionality

### DIFF
--- a/lib/gollum/frontend/public/javascript/editor/gollum.editor.js
+++ b/lib/gollum/frontend/public/javascript/editor/gollum.editor.js
@@ -62,7 +62,7 @@
           // get form fields
           var oldAction = $('#gollum-editor form').attr('action');
           var $form = $($('#gollum-editor form').get(0));
-          $form.attr('action', this.href);
+          $form.attr('action', '/preview');
           $form.attr('target', '_blank');
           $form.submit();
 


### PR DESCRIPTION
This patch fixes the issue mentioned in #141: the preview button no longer working. The code in question appears to have been modified by this commit: github/gollum@05b53462df6fb9f32e656f044de825fe73beeb16
