### PR TITLE
Spacing fix for issue #145

### DIFF
--- a/lib/gollum/frontend/templates/page.mustache
+++ b/lib/gollum/frontend/templates/page.mustache
@@ -14,7 +14,7 @@
   {{>searchbar}}
 </div>
 <div id="wiki-content">
-  <div class="wrap{{#has_footer}} has-footer{{/has_footer}}{{#has_sidebar}} has-rightbar{{/has_sidebar}}">
+<div class="wrap {{#has_footer}} has-footer {{/has_footer}} {{#has_sidebar}}  has-rightbar{{/has_sidebar}}">
   <div id="wiki-body" class="gollum-{{format}}-content">
     <div id="template">
       {{{content}}}


### PR DESCRIPTION
One space to rule them all. Pages with footers/sidebars will not format correctly for me without this.
