### PR TITLE
Remove edit button on preview pages

### DIFF
--- a/lib/gollum/frontend/app.rb
+++ b/lib/gollum/frontend/app.rb
@@ -106,10 +106,11 @@ module Precious
     end
 
     post '/preview' do
-      wiki     = Gollum::Wiki.new(settings.gollum_path, settings.wiki_options)
-      @name    = "Preview"
-      @page    = wiki.preview_page(@name, params[:content], params[:format])
-      @content = @page.formatted_data
+      wiki      = Gollum::Wiki.new(settings.gollum_path, settings.wiki_options)
+      @name     = "Preview"
+      @page     = wiki.preview_page(@name, params[:content], params[:format])
+      @content  = @page.formatted_data
+      @editable = false
       mustache :page
     end
 
@@ -155,6 +156,7 @@ module Precious
         @page = page
         @name = name
         @content = page.formatted_data
+        @editable = true
         mustache :page
       else
         halt 404
@@ -186,6 +188,7 @@ module Precious
         @page = page
         @name = name
         @content = page.formatted_data
+        @editable = true
         mustache :page
       elsif file = wiki.file(name)
         content_type file.mime_type

--- a/lib/gollum/frontend/templates/page.mustache
+++ b/lib/gollum/frontend/templates/page.mustache
@@ -6,8 +6,10 @@
       class="action-all-pages">All Pages</a></li>
     <li class="minibutton" class="jaws">
       <a href="#" id="minibutton-new-page">New Page</a></li>
+    {{#editable}}
     <li class="minibutton"><a href="/edit/{{escaped_name}}"
        class="action-edit-page">Edit Page</a></li>
+    {{/editable}}
     <li class="minibutton"><a href="/history/{{escaped_name}}"
        class="action-page-history">Page History</a></li>
   </ul>

--- a/lib/gollum/frontend/views/page.rb
+++ b/lib/gollum/frontend/views/page.rb
@@ -18,6 +18,10 @@ module Precious
       def date
         @page.version.authored_date.strftime("%Y-%m-%d %H:%M:%S")
       end
+      
+      def editable
+        @editable
+      end
 
       def has_footer
         @footer = (@page.footer || false) if @footer.nil?


### PR DESCRIPTION
Simple patch to stop the edit button being displayed on preview pages. It sometimes gets confusing as to whether you're previewing or viewing a page, especially when the 'Preview' title gets overridden due to other issues.
