### PR TITLE
create japanese page, failed

### DIFF
--- a/lib/gollum/wiki.rb
+++ b/lib/gollum/wiki.rb
@@ -231,7 +231,7 @@ module Gollum
         Committer.new(self, commit)
       end
 
-      committer.add_to_index('', name, format, data)
+      committer.add_to_index('', name, format, data.force_encoding(encoding || Encoding::UTF_8))
 
       committer.after_commit do |index, sha|
         @access.refresh


### PR DESCRIPTION
I created a page in Japanese, have failed.
(MacOSX10.7.1, ruby-1.9.2-p280)
Error is
   Grit::GitRuby::Internal::LooseObjectError at /b
   size mismatch

So, I think that failed to save encoding when write page.
After adding the 'force_encode' to 'write_page', successful.
