### PR TITLE
Forcing encoding to UTF-8 for git tree

### DIFF
--- a/lib/gollum/git_access.rb
+++ b/lib/gollum/git_access.rb
@@ -158,7 +158,9 @@ module Gollum
     def tree!(sha)
       tree  = @repo.git.native(:ls_tree,
         {:r => true, :l => true, :z => true}, sha)
-      tree.force_encoding("UTF-8")
+      if tree.respond_to?(:force_encoding)
+        tree.force_encoding("UTF-8")
+      end
       items = tree.split("\0").inject([]) do |memo, line|
         memo << parse_tree_line(line)
       end


### PR DESCRIPTION
I tried to use gollum with cyrillic filenames in github wiki on my own server and pages didn't work. This helped.

I use:
# uname -a

Linux server.vokrug.ru 2.6.32-5-amd64 #1 SMP Mon Mar 7 21:35:22 UTC 2011 x86_64 GNU/Linux
# ruby --version

ruby 1.9.2p290 (2011-07-09 revision 32553) [x86_64-linux]

gollum has been installed by gem install gollum

I will be happy if you tell me where I was wrong.
