### PR TITLE
Style correction for problem with indenting in code blocks

### DIFF
--- a/lib/gollum/frontend/public/css/template.css
+++ b/lib/gollum/frontend/public/css/template.css
@@ -266,7 +266,7 @@ a.absent {
   background-color: #f8f8f8;
   border: 1px solid #dedede;
   font-size: 13px;
-  padding: 1px 5px;
+  padding: 1px 5px 1px 0;
 
   -moz-border-radius: 3px;
   -webkit-border-radius: 3px;


### PR DESCRIPTION
This style change actually corrects (for me) the issue brought up in issue #129 - the first character in a code block no longer indents, and all lines of the code section line up as they should.
