### PR TITLE
Ability to include other pages within your document.

### DIFF
--- a/lib/gollum/markup.rb
+++ b/lib/gollum/markup.rb
@@ -170,6 +170,8 @@ module Gollum
         html
       elsif html = process_file_link_tag(tag)
         html
+      elsif html = process_page_include_tag(tag)
+        html
       else
         process_page_link_tag(tag)
       end
@@ -291,6 +293,29 @@ module Gollum
         %{<a href="#{path}">#{name}</a>}
       else
         nil
+      end
+    end
+
+    # Attempt to process the tag as a page include tag.
+    #
+    # tag       - The String tag contents (the stuff inside the double
+    #             brackets).
+    #
+    # Returns the String HTML if the tag is a valid page include tag or nil
+    #   if it is not.
+    def process_page_include_tag(tag)
+      parts = tag.split('|')
+      parts.reverse! if @format == :mediawiki
+
+      command, page_name = *parts.compact.map(&:strip)
+
+      if command == "INCLUDE" and !page_name.nil?
+        page, extra = find_page_from_name(page_name)
+        if page
+          page.formatted_data
+        else
+          %{<p><b>INCLUDE <em>#{page_name}</em> NOT FOUND</b></p>}
+        end
       end
     end
 


### PR DESCRIPTION
Syntax:

```
[[INCLUDE|pagename]]
```

We're needing the ability to embed reusable pieces of text within our main documents.  This accomplishes that without going too far off the reservation (I think).  
