### PR TITLE
set :public_folder in frontend app instead of :public

### DIFF
--- a/lib/gollum/frontend/app.rb
+++ b/lib/gollum/frontend/app.rb
@@ -13,9 +13,8 @@ module Precious
     dir = File.dirname(File.expand_path(__FILE__))
 
     # We want to serve public assets for now
-
-    set :public,    "#{dir}/public"
-    set :static,    true
+    set :public_folder, "#{dir}/public"
+    set :static,         true
 
     set :mustache, {
       # Tell mustache where the Views constant lives


### PR DESCRIPTION
A minor patch to remove a deprecation warning from Sinatra.

`:public is no longer used to avoid overloading Module#public, use :public_folder instead`
