### PR TITLE
Remove MathJax

### DIFF
--- a/lib/gollum/frontend/templates/page.mustache
+++ b/lib/gollum/frontend/templates/page.mustache
@@ -41,5 +41,3 @@
   <p id="last-edit">Last edited by <b>{{author}}</b>, {{date}}</p>
 </div>
 </div>
-
-<script type="text/javascript" src="/javascript/MathJax/MathJax.js"></script>


### PR DESCRIPTION
MathJax.js doesn't exist anymore so requesting it results in an error on every page.
