### PR TITLE
Make default markup changeable through sinatra settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,7 +428,20 @@ To delete a page and commit the change:
 
     wiki.delete_page(page, commit)
 
+### RACK
 
+You can also run gollum with any rack-compatible server by placing this config.ru 
+file inside your wiki repository. This allows you to utilize any Rack middleware 
+like Rack::Auth, OmniAuth, etc.   
+
+    #!/usr/bin/env ruby
+    require 'rubygems'
+    require 'gollum/frontend/app'
+    
+    gollum_path = File.expand_path(File.dirname(__FILE__)) # CHANGE THIS TO POINT TO YOUR OWN WIKI REPO
+    Precious::App.set(:default_markup, :markdown) # set your favorite markup language
+    run Precious::App
+ 
 ## CONTRIBUTE
 
 If you'd like to hack on Gollum, start by forking my repo on GitHub:

--- a/lib/gollum/frontend/app.rb
+++ b/lib/gollum/frontend/app.rb
@@ -15,7 +15,8 @@ module Precious
     # We want to serve public assets for now
     set :public_folder, "#{dir}/public"
     set :static,         true
-
+    set :default_markup, :markdown
+    
     set :mustache, {
       # Tell mustache where the Views constant lives
       :namespace => Precious,

--- a/lib/gollum/frontend/templates/create.mustache
+++ b/lib/gollum/frontend/templates/create.mustache
@@ -10,6 +10,8 @@
 </div>
 <script type="text/javascript">
 jQuery(document).ready(function() {
-  $.GollumEditor({ NewFile: true });
+  $.GollumEditor({ NewFile: true, MarkupType: '{{default_markup}}' });
 });
 </script>
+
+{{something}}

--- a/lib/gollum/frontend/views/create.rb
+++ b/lib/gollum/frontend/views/create.rb
@@ -39,6 +39,10 @@ module Precious
       def formats
         super(:markdown)
       end
+      
+      def default_markup
+        Precious::App.settings.default_markup
+      end 
     end
   end
 end


### PR DESCRIPTION
This commit lets users change the default markup language of gollum by changing a new Precious::App sinatra setting called `default_markup`. Here's how you'd use this in `config.ru`:

``` ruby
require 'rubygems'
require '../gollum/lib/gollum/frontend/app'

gollum_path = File.expand_path(File.dirname(__FILE__)) 

Precious::App.set(:gollum_path, gollum_path)
Precious::App.set(:default_markup, :textile)
run Precious::App
```
