### PR TITLE
Fix `undefined method 'new' for Redcarpet:Module`

### DIFF
--- a/gollum.gemspec
+++ b/gollum.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.add_dependency('mustache', [">= 0.11.2", "< 1.0.0"])
   s.add_dependency('sanitize', "~> 2.0.0")
   s.add_dependency('nokogiri', "~> 1.4")
-  s.add_dependency('redcarpet')
+  s.add_dependency('redcarpet', "~> 1.17.2")
 
   s.add_development_dependency('RedCloth')
   s.add_development_dependency('mocha')


### PR DESCRIPTION
Since this problem is [affecting users](http://stackoverflow.com/questions/8395347/gollum-wiki-undefined-method-new-for-redcarpetmodule), it seems that a working version of `redcarpet` should be specified.
