### PR TITLE
Added test for ASCII characters in code blocks created with back ticks.

### DIFF
--- a/test/test_markup.rb
+++ b/test/test_markup.rb
@@ -422,6 +422,14 @@ context "Markup" do
     compare(content, output)
   end
 
+  test "code blocks with ascii characters" do
+    content = "a\n\n```\n├─foo\n```\n\nb"
+    output = "<p>a</p>\n\n<div class=\"highlight\"><pre>" +
+             "<span class=\"n\">├─foo</span>" +
+             "\n</pre>\n</div>\n\n<p>b</p>"
+    compare(content, output)
+  end
+
   test "code with wiki links" do
     content = <<-END
 booya


### PR DESCRIPTION
Noticed that ASCII characters in code blocks created using back ticks are not rendered correctly on the Github wiki. Here's an example:

https://github.com/polarblau/polarblau.github.com/wiki/Encoding-issues-in-code-blocks

Same goes apparently for umlauts (and likely for some other stuff, too). 
It seems that this might be related: https://github.com/github/gollum/issues/147

_(On a side note: I had to reproduce this patch in order to be able to run the tests: https://github.com/bdewey/org-ruby/commit/1704057b#diff-0. Maybe someone has the same issue.)_
