### PR TITLE
Serve Gravatars via SSL

### DIFF
--- a/lib/gollum/frontend/templates/history.mustache
+++ b/lib/gollum/frontend/templates/history.mustache
@@ -29,7 +29,7 @@
         </td>
         <td class="author">
           <a href="javascript:void(0)">
-            <img src="http://www.gravatar.com/avatar/{{gravatar}}?s=16"
+            <img src="https://secure.gravatar.com/avatar/{{gravatar}}?s=16"
              alt="avatar: {{author}}" class="mini-gravatar">
             <span class="username">{{author}}</span>
           </a>


### PR DESCRIPTION
From the Gravatar documentation at http://en.gravatar.com/site/implement/images

> If you're displaying Gravatars on a page that is being served over SSL (e.g. the page URL starts with HTTPS), then you'll want to serve your Gravatars via SSL as well, otherwise you'll get annoying security warnings in most browsers. To do this, simply change the URL for your Gravatars so that is starts with:
> 
> https://secure.gravatar.com/...
