### PR TITLE
Fix missing desc in Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -79,6 +79,7 @@ end
 #
 #############################################################################
 
+desc 'Create a release build'
 task :release => :build do
   unless `git branch` =~ /^\* master$/
     puts "You must be on the master branch to release!"
@@ -91,12 +92,14 @@ task :release => :build do
   sh "gem push pkg/#{name}-#{version}.gem"
 end
 
+desc 'Build gem'
 task :build => :gemspec do
   sh "mkdir -p pkg"
   sh "gem build #{gemspec_file}"
   sh "mv #{gem_file} pkg"
 end
 
+desc 'Validate gemspec'
 task :gemspec => :validate do
   # read spec file and split out manifest section
   spec = File.read(gemspec_file)
@@ -125,6 +128,7 @@ task :gemspec => :validate do
   puts "Updated #{gemspec_file}"
 end
 
+desc 'Validate lib files and version file'
 task :validate do
   libfiles = Dir['lib/*'] - ["lib/#{name}.rb", "lib/#{name}"]
   unless libfiles.empty?


### PR DESCRIPTION
The Rakefile is missing descriptions for tasks which prevents them from being listed in the `rake -T` output.
