### PR TITLE
Add id to whitelisted attributes. Fixes issue #277.

### DIFF
--- a/lib/gollum/sanitization.rb
+++ b/lib/gollum/sanitization.rb
@@ -30,7 +30,7 @@ module Gollum
                 'compact', 'coords', 'datetime', 'dir',
                 'disabled', 'enctype', 'for', 'frame',
                 'headers', 'height', 'hreflang',
-                'hspace', 'ismap', 'label', 'lang',
+                'hspace', 'id', 'ismap', 'label', 'lang',
                 'longdesc', 'maxlength', 'media', 'method',
                 'multiple', 'name', 'nohref', 'noshade',
                 'nowrap', 'prompt', 'readonly', 'rel', 'rev',

--- a/test/test_markup.rb
+++ b/test/test_markup.rb
@@ -546,29 +546,29 @@ np.array([[2,2],[1,3]],np.float)
     compare(content, output, 'org')
   end
 
-  # test "id with prefix ok" do
-  #   content = "h2(example#wiki-foo). xxxx"
-  #   output = %(<h2 class="example" id="wiki-foo">xxxx</h2>)
-  #   compare(content, output, :textile)
-  # end
+  test "id with prefix ok" do
+    content = "h2(example#wiki-foo). xxxx"
+    output = %(<h2 class="example" id="wiki-foo">xxxx</h2>)
+    compare(content, output, :textile)
+  end
 
-  # test "id prefix added" do
-  #   content = "h2(#foo). xxxx[1]\n\nfn1.footnote"
-  #   output = "<h2 id=\"wiki-foo\">xxxx" +
-  #            "<sup class=\"footnote\" id=\"wiki-fnr1\"><a href=\"#wiki-fn1\">1</a></sup></h2>" +
-  #            "\n<p class=\"footnote\" id=\"wiki-fn1\"><a href=\"#wiki-fnr1\"><sup>1</sup></a> footnote</p>"
-  #   compare(content, output, :textile)
-  # end
+  test "id prefix added" do
+    content = "h2(#foo). xxxx[1]\n\nfn1.footnote"
+    output = "<h2 id=\"wiki-foo\">xxxx" +
+             "<sup class=\"footnote\" id=\"wiki-fnr1\"><a href=\"#wiki-fn1\">1</a></sup></h2>" +
+             "\n<p class=\"footnote\" id=\"wiki-fn1\"><a href=\"#wiki-fnr1\"><sup>1</sup></a> footnote</p>"
+    compare(content, output, :textile)
+  end
 
-  # test "name prefix added" do
-  #   content = "abc\n\n__TOC__\n\n==Header==\n\nblah"
-  #   compare content, '', :mediawiki, [
-  #     /id="wiki-toc"/,
-  #     /href="#wiki-Header"/,
-  #     /id="wiki-Header"/,
-  #     /name="wiki-Header"/
-  #   ]
-  # end
+  test "name prefix added" do
+    content = "abc\n\n__TOC__\n\n==Header==\n\nblah"
+    compare content, '', :mediawiki, [
+      /id="wiki-toc"/,
+      /href="#wiki-Header"/,
+      /id="wiki-Header"/,
+      /name="wiki-Header"/
+    ]
+  end
 
   #########################################################################
   #


### PR DESCRIPTION
The commit cc96786ac056dc297264620fa0cade1e39802ec9 broke internal links from reST pages. (For example table of contents.) Issue #277 discusses this.

I added id to whitelisted attributes which seems to fix this. The xss vulnerability is still covered (the javascript-protocol still gets ripped out) and the commented tests covering id-renaming now work again.
