### PR TITLE
Removed search box margin and modified its height

### DIFF
--- a/lib/gollum/frontend/public/gollum/css/gollum.css
+++ b/lib/gollum/frontend/public/gollum/css/gollum.css
@@ -586,7 +586,6 @@ ul.actions {
 /* @control searchbar */
 #head #searchbar {
   float: right;
-  margin: 1em 0 0 0;
   padding: 0;
   overflow: hidden;
 }
@@ -607,7 +606,7 @@ ul.actions {
     float: left;
     font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
     font-size: 1.2em;
-    height: 1.8em;
+    height: 2em;
 
     -webkit-focus-ring: none;
   }


### PR DESCRIPTION
The wiki's search box is at a different level than the rest of the controls in the header for a local wiki of mine. i'm no designer, so here's some simple CSS changes as a suggestion.
