### PR TITLE
fix Rack config.ru documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,6 +454,7 @@ like Rack::Auth, OmniAuth, etc.
     require 'gollum/frontend/app'
 
     gollum_path = File.expand_path(File.dirname(__FILE__)) # CHANGE THIS TO POINT TO YOUR OWN WIKI REPO
+    Precious::App.set(:gollum_path, gollum_path)
     Precious::App.set(:default_markup, :markdown) # set your favorite markup language
     run Precious::App
 


### PR DESCRIPTION
Missing a line which sets the gollum_path

see https://github.com/tecnh/gollum/wiki/Gollum-and-Passenger
