### PR TITLE
Fix for #52 - Disable internal link processing for asciidoc

### DIFF
--- a/lib/gollum/markup.rb
+++ b/lib/gollum/markup.rb
@@ -116,6 +116,9 @@ module Gollum
     #
     # Returns the placeholder'd String data.
     def extract_tags(data)
+      if @format == :asciidoc
+        return data
+      end
       data.gsub!(/(.?)\[\[(.+?)\]\]([^\[]?)/m) do
         if $1 == "'" && $3 != "'"
           "[[#{$2}]]#{$3}"

--- a/test/test_markup.rb
+++ b/test/test_markup.rb
@@ -589,6 +589,19 @@ np.array([[2,2],[1,3]],np.float)
   end
 
   #########################################################################
+  # Asciidoc
+  #########################################################################
+
+  test "asciidoc header" do 
+    compare("= Book Title\n\n== Heading", '<div class="sect1"><h2 id="wiki-_heading">Heading</h2><div class="sectionbody"></div></div>', 'asciidoc')
+  end
+
+  test "internal links with asciidoc" do 
+    compare("= Book Title\n\n[[anid]]\n== Heading", '<div class="sect1"><h2 id="wiki-anid">Heading</h2><div class="sectionbody"></div></div>', 'asciidoc')
+  end
+
+
+  #########################################################################
   #
   # Helpers
   #


### PR DESCRIPTION
It appears that Asciidoc and Gollum have incompatible syntaxes for links. This patch disables Gollum's tag extraction for asciidoc files so that asciidoc documents don't get mangled.

Related Issue: https://github.com/github/gollum/issues/52
