### PR TITLE
Disable internal link processing for asciidoc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,5 @@ rvm:
   - rbx-2.0
 notifications:
   disabled: true
+before_install:
+ - sudo apt-get install -y asciidoc

--- a/lib/gollum/markup.rb
+++ b/lib/gollum/markup.rb
@@ -116,6 +116,9 @@ module Gollum
     #
     # Returns the placeholder'd String data.
     def extract_tags(data)
+      if @format == :asciidoc
+        return data
+      end
       data.gsub!(/(.?)\[\[(.+?)\]\]([^\[]?)/m) do
         if $1 == "'" && $3 != "'"
           "[[#{$2}]]#{$3}"

--- a/test/test_markup.rb
+++ b/test/test_markup.rb
@@ -589,6 +589,19 @@ np.array([[2,2],[1,3]],np.float)
   end
 
   #########################################################################
+  # Asciidoc
+  #########################################################################
+
+  test "asciidoc header" do 
+    compare("= Book Title\n\n== Heading", '<div class="sect1"><h2 id="wiki-_heading">Heading</h2><div class="sectionbody"></div></div>', 'asciidoc')
+  end
+
+  test "internal links with asciidoc" do 
+    compare("= Book Title\n\n[[anid]]\n== Heading", '<div class="sect1"><h2 id="wiki-anid">Heading</h2><div class="sectionbody"></div></div>', 'asciidoc')
+  end
+
+
+  #########################################################################
   #
   # Helpers
   #


### PR DESCRIPTION
This is a resubmit of pull request #303. Now with .travis.yml changes.

asciidoc's representation of section identifiers interferes with
Gollum's page linking. This disables Gollum's page link tag
extraction for asciidoc files.

Adds "apt-get install -y asciidoc" to .travis.yml so tests pass
on @travis-ci.
