### PR TITLE
Gollum using very old version of wikicloth

### DIFF
--- a/gollum.gemspec
+++ b/gollum.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('org-ruby', '~>0.6.2')
   s.add_development_dependency('shoulda')
   s.add_development_dependency('rack-test')
-  s.add_development_dependency('wikicloth', '~> 0.6.3')
+  s.add_development_dependency('wikicloth')
   s.add_development_dependency('rake', '~> 0.9.2')
 
   # = MANIFEST =


### PR DESCRIPTION
For some reason gollum was depending on an old version of wikicloth.  There seems to be no issues with the new version so I removed the version requirement.
