### PR TITLE
searchbar fix for ie9

### DIFF
--- a/lib/gollum/frontend/public/gollum/css/gollum.css
+++ b/lib/gollum/frontend/public/gollum/css/gollum.css
@@ -639,8 +639,8 @@ ul.actions {
     -webkit-focus-ring: none;
   }
 
-  .ie #head #searchbar #searchbar-fauxtext input#search-query {
-    padding: 0.4em 0 0 0.5em;
+  .ie8 #head #searchbar #searchbar-fauxtext input#search-query {
+    padding: 0.5em 0 0 0.5em;
   }
 
   #head #searchbar #searchbar-fauxtext input#search-query.ph {


### PR DESCRIPTION
Fixes IE9 issue mentioned in https://github.com/github/gollum/pull/310#issuecomment-5492657

Tested in IE8 and IE9.  No guarantees for other IE versions.  =P
