### PR TITLE
Fix LooseObjectError by upgrading to grit 2.5.

### DIFF
--- a/gollum.gemspec
+++ b/gollum.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.rdoc_options = ["--charset=UTF-8"]
   s.extra_rdoc_files = %w[README.md LICENSE]
 
-  s.add_dependency('grit', "~> 2.4.1")
+  s.add_dependency('grit', "~> 2.5.0")
   s.add_dependency('github-markup', [">= 0.7.0", "< 1.0.0"])
   s.add_dependency('github-markdown')
   s.add_dependency('pygments.rb', "~> 0.2.0")


### PR DESCRIPTION
Error occurs when running gollum tests using Ruby 1.9 with a broken version of grit.

https://github.com/mojombo/grit/issues/65
