### PR TITLE
Pass :is_bare to Grit where appropriate

### DIFF
--- a/lib/gollum/git_access.rb
+++ b/lib/gollum/git_access.rb
@@ -9,10 +9,10 @@ module Gollum
     # page_file_dir - String the directory in which all page files reside
     #
     # Returns this instance.
-    def initialize(path, page_file_dir = nil)
+    def initialize(path, page_file_dir = nil, bare = false)
       @page_file_dir = page_file_dir
       @path = path
-      @repo = Grit::Repo.new(path)
+      @repo = Grit::Repo.new(path, { :is_bare => bare })
       clear
     end
 

--- a/lib/gollum/wiki.rb
+++ b/lib/gollum/wiki.rb
@@ -151,8 +151,9 @@ module Gollum
         path             = path.path
       end
       @path          = path
+      @repo_is_bare  = options[:repo_is_bare]
       @page_file_dir = options[:page_file_dir]
-      @access        = options[:access]       || GitAccess.new(path, @page_file_dir)
+      @access        = options[:access]       || GitAccess.new(path, @page_file_dir, @repo_is_bare)
       @base_path     = options[:base_path]    || "/"
       @page_class    = options[:page_class]   || self.class.page_class
       @file_class    = options[:file_class]   || self.class.file_class


### PR DESCRIPTION
Gitosis is not longer officially supported as of Ubuntu 12.04 and no official package is available, so everyone has to switch to Gitolite _sigh_.

Gitolite initialises bare repositories, and as far as I can tell, will not work with normal repositories (unlike Gitosis).

Grit (and therefore Gollum 2.0) won't work with bare repositories unless the `:is_bare` option is passed to Grit::Repo.new.

This patch exposes is_bare via the wiki_options setting in app.rb/sinatra.

The setting can then be toggled in your gollum config file using:

``` ruby
Precious::App.settings.wiki_options[:repo_is_bare] = true
```

Allowing Gollum to work with gitolited repositories :)
