### PR TITLE
Redirect from root to /Home, fixes #250

### DIFF
--- a/lib/gollum/frontend/app.rb
+++ b/lib/gollum/frontend/app.rb
@@ -39,7 +39,7 @@ module Precious
     end
 
     get '/' do
-      show_page_or_file('Home')
+      redirect File.join(settings.wiki_options[:base_path].to_s, 'Home')
     end
 
     get '/edit/*' do

--- a/test/test_app.rb
+++ b/test/test_app.rb
@@ -167,6 +167,20 @@ context "Frontend" do
     assert_equal page1.version.sha, page2.version.sha
   end
 
+  test "redirects from 'base_path' or 'base_path/' to 'base_path/Home'" do
+    Precious::App.set(:wiki_options, {})
+    get "/"
+    assert_match "http://example.org/Home", last_response.headers['Location']
+
+    Precious::App.set(:wiki_options, { :base_path => '/wiki' })
+    get "/"
+    assert_match "http://example.org/wiki/Home", last_response.headers['Location']
+
+    Precious::App.set(:wiki_options, { :base_path => '/wiki/' })
+    get "/"
+    assert_match "http://example.org/wiki/Home", last_response.headers['Location']
+  end
+
   def app
     Precious::App
   end


### PR DESCRIPTION
One solution for the relative links created by the formatting engines (Markdown, Textile, etc) would be to treat `Home` as an other page, redirecting from `/` to `/Home`.

From what I can see on GitHub.com, that would require disabling GitHub's redirect from `/wiki/Home` to `/wiki`.

Fix for #250.
