### PR TITLE
Use grit with force_encoding('ascii-8bit')

### DIFF
--- a/lib/gollum/committer.rb
+++ b/lib/gollum/committer.rb
@@ -104,7 +104,9 @@ module Gollum
         end
       end
 
-      index.add(fullpath.force_encoding('ascii-8bit'), @wiki.normalize(data))
+      fullpath = fullpath.force_encoding('ascii-8bit') if fullpath.respond_to?(:force_encoding)
+
+      index.add(fullpath, @wiki.normalize(data))
     end
 
     # Update the given file in the repository's working directory if there
@@ -129,11 +131,13 @@ module Gollum
             ::File.join(dir, @wiki.page_file_name(name, format))
           end
 
+        path = path.force_encoding('ascii-8bit') if path.respond_to?(:force_encoding)
+
         Dir.chdir(::File.join(@wiki.repo.path, '..')) do
           if file_path_scheduled_for_deletion?(index.tree, path)
-            @wiki.repo.git.rm({'f' => true}, '--', path.force_encoding('ascii-8bit'))
+            @wiki.repo.git.rm({'f' => true}, '--', path)
           else
-            @wiki.repo.git.checkout({}, 'HEAD', '--', path.force_encoding('ascii-8bit'))
+            @wiki.repo.git.checkout({}, 'HEAD', '--', path)
           end
         end
       end
@@ -212,7 +216,7 @@ module Gollum
 
     # Proxies methods t
     def method_missing(name, *args)
-      args.map! { |item| item.force_encoding('ascii-8bit') }
+      args.map! { |item| item.respond_to?(:force_encoding) ? item.force_encoding('ascii-8bit') : item }
       index.send(name, *args)
     end
   end

--- a/test/test_unicode.rb
+++ b/test/test_unicode.rb
@@ -1,6 +1,10 @@
 # ~*~ encoding: utf-8 ~*~
 require File.expand_path(File.join(File.dirname(__FILE__), "helper"))
 
+def utf8(str)
+  str.respond_to?(:force_encoding) ? str.force_encoding('utf-8') : str
+end
+
 context "Unicode Support" do
   setup do
     @path = cloned_testpath("examples/revert.git")
@@ -16,7 +20,7 @@ context "Unicode Support" do
 
     page = @wiki.page("한글 test")
     assert_equal Gollum::Page, page.class
-    assert_equal "# 한글", page.raw_data.force_encoding('utf-8')
+    assert_equal "# 한글", utf8(page.raw_data)
   end
 
   test "unicode with existing format rules" do
@@ -57,27 +61,27 @@ context "Frontend Unicode support" do
     assert last_response.ok?
 
     page = @wiki.page('한글')
-    assert_equal '한글 text', page.raw_data.force_encoding('utf-8')
+    assert_equal '한글 text', utf8(page.raw_data)
     assert_equal 'def', page.version.message
   end
 
   test "heavy use 1" do
-    post "/create", :content => '한글 text'.force_encoding('ascii-8bit'), :page => "PG",
+    post "/create", :content => '한글 text', :page => "PG",
       :format => 'markdown', :message => 'def'
     follow_redirect!
     assert last_response.ok?
 
     @wiki.update_page(@wiki.page('PG'), nil, nil, '다른 text', {})
     page = @wiki.page('PG')
-    assert_equal '다른 text', page.raw_data.force_encoding('utf-8')
+    assert_equal '다른 text', utf8(page.raw_data)
 
-    post '/edit/PG', :content => '바뀐 text'.force_encoding('ascii-8bit'), :message => 'ghi'
+    post '/edit/PG', :content => '바뀐 text', :message => 'ghi'
     follow_redirect!
     assert last_response.ok?
 
     @wiki = Gollum::Wiki.new(@path)
     page = @wiki.page('PG')
-    assert_equal '바뀐 text', page.raw_data.force_encoding('utf-8')
+    assert_equal '바뀐 text', utf8(page.raw_data)
     assert_equal 'ghi', page.version.message
   end
 
@@ -90,7 +94,7 @@ context "Frontend Unicode support" do
     @wiki.update_page(@wiki.page('한글'), nil, nil, '다른 text', {})
     @wiki = Gollum::Wiki.new(@path)
     page = @wiki.page('한글')
-    assert_equal '다른 text', page.raw_data.force_encoding('utf-8')
+    assert_equal '다른 text', utf8(page.raw_data)
 
     post '/edit/' + CGI.escape('한글'), :content => '바뀐 text',
       :format => 'markdown', :message => 'ghi'
@@ -99,7 +103,7 @@ context "Frontend Unicode support" do
 
     @wiki = Gollum::Wiki.new(@path)
     page = @wiki.page('한글')
-    assert_equal '바뀐 text', page.raw_data.force_encoding('utf-8')
+    assert_equal '바뀐 text', utf8(page.raw_data)
     assert_equal 'ghi', page.version.message
   end
 


### PR DESCRIPTION
because current grit handles all internal git functions with 'ascii-8bit', which can cause encoding error if we try to add some files which contains non-latin characters.

this patch forces encoding to ascii-8bit to work-around encoding error when I try to add some pages which includes non-latin characters(especially Korean characters I tested)

this patch may be useless if gollum will uses rugged soon. if so just close this request.
