### PR TITLE
[New] Support `$` and `$$` as formula delimiters.

### DIFF
--- a/lib/gollum/markup.rb
+++ b/lib/gollum/markup.rb
@@ -125,13 +125,13 @@ module Gollum
     # Returns the placeholder'd String data.
     def extract_tex(data)
       # Random string to escape the `$` character (might be overkill)
-      hash = "@#{rand(36**5).to_s(36)}@"
+      esc = "/%%/"
       data.gsub(/\\\[\s*(.*?)\s*\\\]/m) do
         tag = CGI.escapeHTML($1)
         id  = Digest::SHA1.hexdigest(tag)
         @texmap[id] = [:block, tag]
         id
-      end.gsub(/'\$/, hash). # Replace `'$` by the hash generated earlier in order to escape it
+      end.gsub(/'\$/, esc). # Replace `'$` with the `esc` string in order to escape it
         gsub(/\$\$\s*(.*?)\s*\$\$/m) do
           tag = CGI.escapeHTML($1)
           id  = Digest::SHA1.hexdigest(tag)
@@ -147,7 +147,7 @@ module Gollum
         id  = Digest::SHA1.hexdigest(tag)
         @texmap[id] = [:inline, tag]
         id
-      end.gsub(/#{hash}/, '$') # replace the hash back to `$`
+      end.gsub(/#{esc}/, '$') # replace the `esc` string back to `$`
     end
 
     # Process all TeX from the texmap and replace the placeholders with the


### PR DESCRIPTION
Although the standard formula delimiters for latex formulas is currently
`\(` and `\[`, the `$` syntax has an advantage from the point of view of
writing speed, very important if we want to use _gollum_ as a writing
tool.

The code includes support for escaping of the `$` symbol by using the
gollum escape symbol `'`.
