### PR TITLE
Fix #376.

### DIFF
--- a/lib/gollum/markup.rb
+++ b/lib/gollum/markup.rb
@@ -525,7 +525,7 @@ module Gollum
     #
     # Returns the placeholder'd String data.
     def extract_wsd(data)
-      data.gsub(/^\{\{\{ ?(.+?)\r?\n(.+?)\r?\n\}\}\}\r?$/m) do
+      data.gsub(/^\{\{\{\{\{\{ ?(.+?)\r?\n(.+?)\r?\n\}\}\}\}\}\}\r?$/m) do
         id = Digest::SHA1.hexdigest($2)
         @wsdmap[id] = { :style => $1, :code => $2 }
         id

--- a/test/test_markup.rb
+++ b/test/test_markup.rb
@@ -491,7 +491,7 @@ np.array([[2,2],[1,3]],np.float)
   #########################################################################
 
   test "sequence diagram blocks" do
-    content = "a\n\n{{{default\nalice->bob: Test\n}}}\n\nb"
+    content = "a\n\n{{{{{{default\nalice->bob: Test\n}}}}}}\n\nb"
     output = /.*<img src="http:\/\/www\.websequencediagrams\.com\/\?img=\w{9}" \/>.*/
 
     index = @wiki.repo.index


### PR DESCRIPTION
New syntax for sequence diagrams is {{{{{{ }}}}}}.
