### PR TITLE
Hacky fix for encoding issues

### DIFF
--- a/lib/gollum/frontend/views/history.rb
+++ b/lib/gollum/frontend/views/history.rb
@@ -15,8 +15,8 @@ module Precious
             :id7      => v.id[0..6],
             :num      => i,
             :selected => @page.version.id == v.id,
-            :author   => v.author.name.force_encoding('UTF-8'),
-            :message  => v.message.force_encoding('UTF-8'),
+            :author   => v.author.name.respond_to?(:force_encoding) ? v.author.name.force_encoding('UTF-8') : v.author.name,
+            :message  => v.message.respond_to?(:force_encoding) ? v.message.force_encoding('UTF-8') : v.message,
             :date     => v.committed_date.strftime("%B %d, %Y"),
             :gravatar => Digest::MD5.hexdigest(v.author.email) }
         end

--- a/lib/gollum/frontend/views/page.rb
+++ b/lib/gollum/frontend/views/page.rb
@@ -17,7 +17,7 @@ module Precious
         page_versions = @page.versions
         first = page_versions ? page_versions.first : false
         return DEFAULT_AUTHOR unless first
-        first.author.name.force_encoding('UTF-8')
+        first.author.name.respond_to?(:force_encoding) ? first.author.name.force_encoding('UTF-8') : first.author.name
       end
 
       def date


### PR DESCRIPTION
gollum works fine, until you get someone using it with UTF8 chars in their email or committer ID, then it explodes...

The problem is that Grit does not set an encoding on the strings that it creates from the repo, and when you try and concatenate that with strings with known encodings in mustache you get issues.

This should really be fixed in Grit, not gollum, but as Grit appears to be largely unsupported these days, seems like this is the best place for it.
