### PR TITLE
Update the Wiki.search function to make the results counts 'additive'.

### DIFF
--- a/lib/gollum/wiki.rb
+++ b/lib/gollum/wiki.rb
@@ -468,25 +468,23 @@ module Gollum
       args = [{}, '-i', '-c', query, @ref, '--']
       args << '--' << @page_file_dir if @page_file_dir
 
-      results = @repo.git.grep(*args).split("\n").map! do |line|
+      results = {}
+
+      @repo.git.grep(*args).split("\n").each do |line|
         result = line.split(':')
         file_name = result[1].gsub( ::File.extname(result[1]), '' )
-
-        {
-          :count  => result[2].to_i,
-          :name   => file_name
-        }
+        results[file_name] = result[2].to_i
       end
 
       # Use git ls-files '*query*' to search for file names. Grep only searches file content.
-      results += @repo.git.ls_files({}, "*#{ query }*").split("\n").map! do |line|
-        {
-          :count  => 1,
-          :name   => line
-        }
+      @repo.git.ls_files({}, "*#{ query }*").split("\n").each do |line|
+        file_name = line.gsub( ::File.extname(line), '' )
+        results[file_name] += 1;
       end
 
-      results
+      results.map do |key,val|
+        { :count => val, :name => key }
+      end
     end
 
     # Public: All of the versions that have touched the Page.

--- a/test/test_wiki.rb
+++ b/test/test_wiki.rb
@@ -437,6 +437,13 @@ context "page_file_dir option" do
     assert_equal "docs/foo", results[0][:name]
   end
 
+  test "search results should make the content/filename search additive" do
+    # This file contains the word 'foo' and is called 'foo', so it should
+    # have a count of 2, not 1...
+    results = @wiki.search("foo")
+    assert_equal 2, results[0][:count]
+  end
+
   teardown do
     FileUtils.rm_r(@path)
   end


### PR DESCRIPTION
i.e. so if we have a file named 'foo' that also contains the word 'foo' is should report 2 matches, not 1.
