### PR TITLE
Add a method that returns a given page name scoped to a directory

### DIFF
--- a/lib/gollum/page.rb
+++ b/lib/gollum/page.rb
@@ -364,9 +364,9 @@ module Gollum
     # version - The String version ID to find.
     #
     # Returns a Gollum::Page or nil if the page could not be found.
-    def find(name, version)
+    def find(name, version, dir = nil)
       map = @wiki.tree_map_for(version.to_s)
-      if page = find_page_in_tree(map, name)
+      if page = find_page_in_tree(map, name, dir)
         page.version    = version.is_a?(Grit::Commit) ?
           version : @wiki.commit_for(version)
         page.historical = page.version.to_s == version.to_s

--- a/lib/gollum/wiki.rb
+++ b/lib/gollum/wiki.rb
@@ -199,6 +199,18 @@ module Gollum
       @page_class.new(self).find(name, version)
     end
 
+    # Public: Get the formatted page for a given page name scoped to a
+    # directory.
+    #
+    # name    - The human or canonical String page name of the wiki page.
+    # dir     - The directory String relative to the repo.
+    # version - The String version ID to find (default: @ref).
+    #
+    # Returns a Gollum::Page or nil if no matching page was found.
+    def scoped_page(name, dir, version = @ref)
+      @page_class.new(self).find(name, version || @ref, dir)
+    end
+
     # Public: Get the static file for a given name.
     #
     # name    - The full String pathname to the file.

--- a/test/test_wiki.rb
+++ b/test/test_wiki.rb
@@ -94,6 +94,22 @@ context "Wiki" do
     assert_match    "b/_Sidebar.md", diff
     assert_no_match regex, diff
   end
+
+  test "gets scoped page from specified directory" do
+    @path = cloned_testpath('examples/lotr.git')
+    begin
+      wiki = Gollum::Wiki.new(@path)
+      index = wiki.repo.index
+      index.read_tree 'master'
+      index.add('Foobar/Elrond.md', 'Baz')
+      index.commit 'Add Foobar/Elrond.', [wiki.repo.commits.last], Grit::Actor.new('Tom Preston-Werner', 'tom@github.com')
+
+      assert_equal 'Rivendell/Elrond.md', wiki.scoped_page('Elrond', 'Rivendell').path
+      assert_equal 'Foobar/Elrond.md', wiki.scoped_page('Elrond', 'Foobar').path
+    ensure
+      FileUtils.rm_rf(@path)
+    end
+  end
 end
 
 context "Wiki page previewing" do


### PR DESCRIPTION
We're using this to build a wiki where pages are scoped to certain groups of users. We're doing this by structuring the wiki with a directory per group. Using this new `scoped_page` method we are able to access non-unique pages based on the directory they are in.

Tests are all passing.
