### PR TITLE
Fix page deletion when using relative url root

### DIFF
--- a/lib/gollum/frontend/public/gollum/javascript/gollum.js
+++ b/lib/gollum/frontend/public/gollum/javascript/gollum.js
@@ -3,8 +3,12 @@ $(document).ready(function() {
   $('#delete-link').click( function(e) {
     var ok = confirm($(this).data('confirm'));
     if ( ok ) {
+      // Get pagename with leading '/'
       var loc = window.location;
-      loc = baseUrl + '/delete' + loc.pathname
+      var pathname = loc.pathname;
+      var slashIndex = pathname.lastIndexOf('/');
+      var pageName = pathname.substr(slashIndex);
+      loc = baseUrl + '/delete' + pageName;
       window.location = loc;
     }
     // Don't navigate on cancel.


### PR DESCRIPTION
Page deletion does not work when deploying gollum to base url root.
