### PR TITLE
Fix titles created with the "New" button

### DIFF
--- a/lib/gollum/frontend/app.rb
+++ b/lib/gollum/frontend/app.rb
@@ -172,7 +172,7 @@ module Precious
     end
 
     get '/create/*' do
-      wikip = wiki_page(params[:splat].first)
+      wikip = wiki_page(params[:splat].first.gsub('+', '-'))
       @name = wikip.name.to_url
       @path = wikip.path
 


### PR DESCRIPTION
Previously, a page created with the 'New' button would get all of its
spaces turned into the + symbol when submitted, which Gollum would then
convert into "-plus-" in the title. So, for example, a request to create
a page called "Test page" would instead get "test plus page".

This change changes + to - in the parameter received by /create/.
