### PR TITLE
Fix bug with missing variable 'ext'

### DIFF
--- a/lib/gollum/committer.rb
+++ b/lib/gollum/committer.rb
@@ -96,9 +96,13 @@ module Gollum
 
         tree.blobs.each do |blob|
           next if page_path_scheduled_for_deletion?(index.tree, fullpath)
-          file = blob.name.downcase.sub(/\.\w+$/, '')
-          file_ext = ::File.extname(blob.name).sub(/^\./, '')
-          if downpath == file && !(allow_same_ext && file_ext == ext)
+          
+          existing_file = blob.name.downcase.sub(/\.\w+$/, '')
+          existing_file_ext = ::File.extname(blob.name).sub(/^\./, '')
+
+          new_file_ext = ::File.extname(path).sub(/^\./, '')
+
+          if downpath == existing_file && !(allow_same_ext && new_file_ext == existing_file_ext)
             raise DuplicatePageError.new(dir, blob.name, path)
           end
         end


### PR DESCRIPTION
We see this error pop up on .com pretty often; it looks like some code got refactored or something and introduced this bug.  I've had the bug fix ready for a while, but I forgot to send the PR. :)
