### PR TITLE
Move require "uri_encode_component"

### DIFF
--- a/lib/gollum.rb
+++ b/lib/gollum.rb
@@ -20,6 +20,7 @@ require File.expand_path('../gollum/markup', __FILE__)
 require File.expand_path('../gollum/sanitization', __FILE__)
 require File.expand_path('../gollum/tex', __FILE__)
 require File.expand_path('../gollum/web_sequence_diagram', __FILE__)
+require File.expand_path('../gollum/frontend/uri_encode_component', __FILE__)
 
 module Gollum
   VERSION = '2.1.7'

--- a/lib/gollum/frontend/app.rb
+++ b/lib/gollum/frontend/app.rb
@@ -9,7 +9,6 @@ require 'gollum/frontend/views/layout'
 require 'gollum/frontend/views/editable'
 require 'gollum/frontend/views/has_page'
 
-require File.expand_path '../uri_encode_component', __FILE__
 require File.expand_path '../helpers', __FILE__
 
 # Fix to_url


### PR DESCRIPTION
I have a bug when use gollum without app server.

``` ruby

# lib/gollum/markup.rb

def process_headers(doc)
      toc = nil
      doc.css('h1,h2,h3,h4,h5,h6').each do |h|
        id = encodeURIComponent(h.content.gsub(' ','-'))
  # ...
end
```

But, `encodeURIComponent` is defined in `lib/gollum/frontend/uri_encode_component.rb` and requieres only in `lib/gollum/frontend/app.rb`.

So if I don't start app I have not get this file required and gollum will raise `undefined method `encodeURIComponent' for #<Gollum::Markup:0x007fd92fe59e70>`
