### PR TITLE
Graphviz support. Fix #138

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,9 +523,11 @@ Your Rack middleware can pass author details to Gollum in a Hash in the session 
 ## WINDOWS FILENAME VALIDATION
 Note that filenames on windows must not contain any of the following characters `\ / : * ? " < > |`. See [this support article](http://support.microsoft.com/kb/177506) for details.
 
-## LIB.SO ERROR
+## GRAPHVIZ
 
-`Could not open library 'lib.so'` may be solved by installing `python-devel` on Fedora or `python-dev` on Ubuntu. Gentoo requires a rubypython [patch](https://gist.github.com/2802480) to use python2.7.
+Pass the location of Graphviz's dot executable to gollum to enable graphviz support.
+
+`gollum --dot /usr/bin/dot wiki`
 
 ## CONTRIBUTE
 

--- a/bin/gollum
+++ b/bin/gollum
@@ -68,6 +68,10 @@ opts = OptionParser.new do |opts|
   opts.on("--mathjax", "Enables mathjax.") do
     wiki_options[:mathjax] = true
   end
+
+  opts.on("--dot [PATH]", "Path to graphviz dot.") do |path|
+    wiki_options[:dot] = path
+  end
 end
 
 # Read command line options into `options` hash

--- a/lib/gollum/frontend/app.rb
+++ b/lib/gollum/frontend/app.rb
@@ -280,6 +280,13 @@ module Precious
       halt 404
     end
 
+    # graphviz image
+    get %r{tmp/([0-9a-f]{40})\.png} do
+      file = ::File.open ::File.expand_path ::File.join wiki_new.path, "tmp/#{params[:captures][0]}.png"
+      # Use Sinatra's send_file because the pngs are not in git.
+      send_file file, :type => 'image/png'
+    end
+
     get %r{/(.+?)/([0-9a-f]{40})} do
       file_path = params[:captures][0]
       version   = params[:captures][1]

--- a/lib/gollum/wiki.rb
+++ b/lib/gollum/wiki.rb
@@ -180,6 +180,7 @@ module Gollum
       @live_preview  = options.fetch(:live_preview, true)
       @universal_toc = options.fetch(:universal_toc, false)
       @mathjax = options[:mathjax] || false
+      @dot = options[:dot] || false
     end
 
     # Public: check whether the wiki's git repo exists on the filesystem.
@@ -587,6 +588,10 @@ module Gollum
 
     # Toggles mathjax.
     attr_reader :mathjax
+
+    # Provides GraphViz dot location
+    # False if not set
+    attr_reader :dot
 
     # Normalize the data.
     #


### PR DESCRIPTION
I added basic graphviz support and tested on Ubuntu.
## 
- The renderer is currently hardcoded to `dot`. If this approach to graphviz support is good, then adding [configurable rendering](http://www.mediawiki.org/wiki/Extension:GraphViz) should be easy. A generic `--graphviz [PATH]` would specify the base path for all the renders and `--dot` would be removed.
## 
- There are no unit tests yet.
## 

```
Graph viz.

<graphviz>
digraph viz {a->b}
</graphviz>
```

![](https://github.com/downloads/bootstraponline/meta/graphviz.png)
