### PR TITLE
Gollum search results now displayed in a deterministic order

### DIFF
--- a/lib/gollum/frontend/app.rb
+++ b/lib/gollum/frontend/app.rb
@@ -306,7 +306,8 @@ module Precious
     get '/search' do
       @query = params[:q]
       wiki = wiki_new
-      @results = wiki.search(@query).sort_by{ |item| item[:count] }.reverse
+      # Sort wiki search results by count (desc) and then by name (asc)
+      @results = wiki.search(@query).sort{ |a, b| (a[:count] <=> b[:count]).nonzero? || b[:name] <=> a[:name] }.reverse
       @name = @query
       mustache :search
     end


### PR DESCRIPTION
Gollum's search results are in a seemingly random order. This pull request changes this behavior to sort the results in descending order by the number of hits a page result has.
