### PR TITLE
Fileview hover fix

### DIFF
--- a/lib/gollum/file_view.rb
+++ b/lib/gollum/file_view.rb
@@ -22,7 +22,7 @@ module Gollum
     def new_page page
       name = page.name
       url  = url_for_page page
-      %Q(  <li class="file"><a href="#{url}">#{name}</a></li>\n)
+      %Q(  <li class="file"><a href="#{url}"><span class="icon"></span>#{name}</a></li>\n)
     end
 
     def new_folder folder_path
@@ -89,7 +89,7 @@ module Gollum
         <li>
           <label>#{::File.dirname(page.path)}</label> <input type="checkbox" #{@checked} />
           <ol>
-            #{new_page page}
+          #{new_page page}
          </ol>
         </li>
         HTML

--- a/lib/gollum/frontend/public/gollum/css/_styles.css
+++ b/lib/gollum/frontend/public/gollum/css/_styles.css
@@ -72,16 +72,23 @@ ol.tree
   }
     li.file a
     {
-      background: url(../images/fileview/document.png) 0 0 no-repeat;
       color: #fff;
-      padding-left: 21px;
       text-decoration: none;
-      display: block;
+      display: inline-block;
     }
-    li.file a[href *= '.pdf']  { background: url(../images/fileview/document.png) 0 0 no-repeat; }
-    li.file a[href *= '.html']  { background: url(../images/fileview/document.png) 0 0 no-repeat; }
-    li.file a[href $= '.css']  { background: url(../images/fileview/document.png) 0 0 no-repeat; }
-    li.file a[href $= '.js']    { background: url(../images/fileview/document.png) 0 0 no-repeat; }
+      li.file a span.icon
+      {
+        width: 14px;
+        height: 18px;
+        background: url(../images/fileview/document.png) 0 0 no-repeat;
+        display: inline-block;
+        margin-right: 7px;
+        vertical-align: text-top;
+      }
+      li.file a[href *= '.pdf'] span.icon { background: url(../images/fileview/document.png) 0 0 no-repeat; }
+      li.file a[href *= '.html'] span.icon { background: url(../images/fileview/document.png) 0 0 no-repeat; }
+      li.file a[href $= '.css'] span.icon { background: url(../images/fileview/document.png) 0 0 no-repeat; }
+      li.file a[href $= '.js']  span.icon { background: url(../images/fileview/document.png) 0 0 no-repeat; }
   li input
   {
     position: absolute;

--- a/test/file_view/1_file.txt
+++ b/test/file_view/1_file.txt
@@ -1,3 +1,3 @@
 <ol class="tree">
-  <li class="file"><a href="0">0</a></li>
+  <li class="file"><a href="0"><span class="icon"></span>0</a></li>
 </ol>

--- a/test/file_view/1_file_1_folder.txt
+++ b/test/file_view/1_file_1_folder.txt
@@ -2,7 +2,7 @@
         <li>
           <label>folder0</label> <input type="checkbox" checked />
           <ol>
-            <li class="file"><a href="folder0/0">0</a></li>
+            <li class="file"><a href="folder0/0"><span class="icon"></span>0</a></li>
          </ol>
         </li>
 </ol>

--- a/test/file_view/1_folder.txt
+++ b/test/file_view/1_folder.txt
@@ -2,7 +2,7 @@
         <li>
           <label>.</label> <input type="checkbox" checked />
           <ol>
-            <li class="file"><a href="folder0">folder0</a></li>
+            <li class="file"><a href="folder0"><span class="icon"></span>folder0</a></li>
          </ol>
         </li>
 </ol>

--- a/test/file_view/2_files_2_folders.txt
+++ b/test/file_view/2_files_2_folders.txt
@@ -2,11 +2,11 @@
       <li>
         <label>folder0</label> <input type="checkbox" checked />
         <ol>
-  <li class="file"><a href="folder0/0">0</a></li>
+  <li class="file"><a href="folder0/0"><span class="icon"></span>0</a></li>
         </ol>
       </li>
       <li>
         <label>folder1</label> <input type="checkbox" checked />
         <ol>
-  <li class="file"><a href="folder1/1">1</a></li>
+  <li class="file"><a href="folder1/1"><span class="icon"></span>1</a></li>
 </ol>

--- a/test/file_view/2_files_2_folders_1_root.txt
+++ b/test/file_view/2_files_2_folders_1_root.txt
@@ -1,13 +1,13 @@
 <ol class="tree">
-  <li class="file"><a href="root">root</a></li>
+  <li class="file"><a href="root"><span class="icon"></span>root</a></li>
       <li>
         <label>folder0</label> <input type="checkbox" checked />
         <ol>
-  <li class="file"><a href="folder0/0">0</a></li>
+  <li class="file"><a href="folder0/0"><span class="icon"></span>0</a></li>
         </ol>
       </li>
       <li>
         <label>folder1</label> <input type="checkbox" checked />
         <ol>
-  <li class="file"><a href="folder1/1">1</a></li>
+  <li class="file"><a href="folder1/1"><span class="icon"></span>1</a></li>
 </ol>

--- a/test/file_view/nested_folders.txt
+++ b/test/file_view/nested_folders.txt
@@ -8,13 +8,13 @@
       <li>
         <label>folder2</label> <input type="checkbox" checked />
         <ol>
-  <li class="file"><a href="folder0/folder1/folder2/0">0</a></li>
+  <li class="file"><a href="folder0/folder1/folder2/0"><span class="icon"></span>0</a></li>
         </ol>
       </li>
       <li>
         <label>folder3</label> <input type="checkbox" checked />
         <ol>
-  <li class="file"><a href="folder0/folder1/folder3/1">1</a></li>
+  <li class="file"><a href="folder0/folder1/folder3/1"><span class="icon"></span>1</a></li>
         </ol>
       </li>
         </ol>
@@ -24,5 +24,5 @@
       <li>
         <label>folder4</label> <input type="checkbox" checked />
         <ol>
-  <li class="file"><a href="folder4/2">2</a></li>
+  <li class="file"><a href="folder4/2"><span class="icon"></span>2</a></li>
 </ol>


### PR DESCRIPTION
With a sufficiently large filename (my case was 30 characters) the `a:hover` css is not applied correctly. The padding on the `a` element causes the highlighting to affect up to the last `21px`. This pull request fixes this.

Commits:
1. `_styles.css` had dos line endings. This got fixed. Aside: There are two more files with dos line endings, somewhere in filepreview land.
2. The `<li class='file'>...</li>` template was duplicated, it is now one item.
3. CSS changes to fix the aforementioned problem.

This branch causes tests to fail with an extraneous `\n` at the end of the test output. I haven't been able to figure out what is causing it. I'm hoping someone else will see what I've clearly missed.
