### PR TITLE
Changed history date to use authored date instead.

### DIFF
--- a/lib/gollum/frontend/views/history.rb
+++ b/lib/gollum/frontend/views/history.rb
@@ -19,7 +19,7 @@ module Precious
             :selected => @page.version.id == v.id,
             :author   => v.author.name.respond_to?(:force_encoding) ? v.author.name.force_encoding('UTF-8') : v.author.name,
             :message  => v.message.respond_to?(:force_encoding) ? v.message.force_encoding('UTF-8') : v.message,
-            :date     => v.committed_date.strftime("%B %d, %Y"),
+            :date     => v.authored_date.strftime("%B %d, %Y"),
             :gravatar => Digest::MD5.hexdigest(v.author.email) }
         end
       end


### PR DESCRIPTION
The date time fields in the history view show the commit date. This is inconsistent for two reasons:
1. The page view shows the last authored date.
2. The `git log` behavior is to also show the authored date.

I have changed the default behavior because I believe that is more correct. If desired we can make this optional (or change default) with either:
1. add both to dom, `display:none` and allow users to override with `custom.css`.
2. Make an option flag 
