### PR TITLE
On window popup, focus the first text-field, if any.

### DIFF
--- a/lib/gollum/frontend/public/gollum/javascript/gollum.dialog.js
+++ b/lib/gollum/frontend/public/gollum/javascript/gollum.dialog.js
@@ -233,6 +233,7 @@
                 $('#gollum-dialog-dialog').animate({ opacity: 1 }, {
                 duration: 500
                 });
+                $($('#gollum-dialog-dialog input[type="text"]').get(0)).focus();
               }
             });
           }


### PR DESCRIPTION
The **new** and **rename** buttons do not focus their text fields on popup. I believe usability would be improved with this functionality.

I did notice the the `gollum.dialog.js` file there was some code that conditionally set the focus based on some `$.facebox` attribute. I didn't see any other references to this so I don't know what it is from. Aside from being added by Joshua Peek in commit 755c3030.
