### PR TITLE
Testing now supports selecting a specific test

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -69,7 +69,7 @@ task :default => :test
 require 'rake/testtask'
 Rake::TestTask.new(:test) do |test|
   test.libs << 'lib' << 'test' << '.'
-  test.pattern = 'test/**/test_*.rb'
+  test.test_files = FileList['test/**/test_*.rb']
   test.verbose = true
 end
 


### PR DESCRIPTION
This change makes the test framework permit selecting a single test to run. Useful when trying to modify a feature and needing to quickly run a single test suite. The default behavior of course is not changed.

See: http://rake.rubyforge.org/classes/Rake/TestTask.html

Usage:

```
rake test TEST=test/test_foo.rb
```
