### PR TITLE
Modified gitcode to allow syntax highlighting of arbitrary files

### DIFF
--- a/test/test_gitcode.rb
+++ b/test/test_gitcode.rb
@@ -34,6 +34,66 @@ context "gitcode" do
     assert_equal g.contents, %{<ol class=\"tree\">\n  <li class=\"file\">\n    <a href=\"0\"><span class=\"icon\"></span>0</a>\n  </li>\n</ol>\n}
   end
 
+  test "gitcode relative local file" do
+    @wiki.write_page("Bilbo Baggins", :markdown, "a\n```python:file-exists.py```\nb", commit_details)
+    page = @wiki.page('Bilbo Baggins')
+
+    index = @wiki.repo.index
+    index.add("file-exists.py", "import sys\n\nprint sys.maxint\n")
+    index.commit("Add file-exists.py")
+
+    @wiki.clear_cache
+
+    output = page.formatted_data
+    assert_equal %Q{<p>a\n</p><div class="highlight"><pre><span class="kn">import</span> <span class="nn">sys</span>\n\n<span class="k">print</span> <span class="n">sys</span><span class="o">.</span><span class="n">maxint</span>\n</pre></div>\n\n<p>b</p>}, output
+  end
+
+  test "gitcode relative local file in subdir" do
+    index = @wiki.repo.index
+    index.add("foo/file-exists.py", "import sys\n\nprint sys.maxint\n")
+    index.commit("Add file-exists.py")
+
+    @wiki.write_page("Pippin", :markdown, "a\n```python:file-exists.py```\nb", commit_details, 'foo')
+
+    page = @wiki.paged('Pippin', 'foo')
+    output = page.formatted_data
+    assert_equal %Q{<p>a\n</p><div class="highlight"><pre><span class="kn">import</span> <span class="nn">sys</span>\n\n<span class="k">print</span> <span class="n">sys</span><span class="o">.</span><span class="n">maxint</span>\n</pre></div>\n\n<p>b</p>}, output
+  end
+
+  test "gitcode relative no file" do
+    @wiki.write_page("Bilbo Baggins", :markdown, "a\n```python:no-file-exists.py```\nb", commit_details)
+    page = @wiki.page('Bilbo Baggins')
+    output = page.formatted_data
+    assert_equal %Q{<p>a\nFile not found: no-file-exists.py\nb</p>}, output
+  end
+
+  test "gitcode absolute local file" do
+    @wiki.write_page("Bilbo Baggins", :markdown, "a\n```python:/monkey/file-exists.py```\nb", commit_details)
+    page = @wiki.page('Bilbo Baggins')
+
+    index = @wiki.repo.index
+    index.add("monkey/file-exists.py", "import sys\n\nprint sys.platform\n")
+    index.commit("Add monkey/file-exists.py")
+    @wiki.clear_cache
+
+    output = page.formatted_data
+    assert_equal %Q{<p>a\n</p><div class="highlight"><pre><span class="kn">import</span> <span class="nn">sys</span>\n\n<span class="k">print</span> <span class="n">sys</span><span class="o">.</span><span class="n">platform</span>\n</pre></div>\n\n<p>b</p>}, output
+  end
+
+  test "gitcode absolute no file" do
+    @wiki.write_page("Bilbo Baggins", :markdown, "a\n```python:/monkey/no-file-exists.py```\nb", commit_details)
+    page = @wiki.page('Bilbo Baggins')
+    output = page.formatted_data
+    assert_equal %Q{<p>a\nFile not found: /monkey/no-file-exists.py\nb</p>}, output
+  end
+
+  test "gitcode error generates santized html" do
+    @wiki.write_page("Bilbo Baggins", :markdown, "a\n```python:<script>foo</script>```\nb", commit_details)
+    page = @wiki.page('Bilbo Baggins')
+    output = page.formatted_data
+    assert_equal %Q{<p>a\nFile not found: &lt;script&gt;foo&lt;/script&gt;\nb</p>}, output
+  end
+
   teardown do
     @cleanup.call
   end

--- a/test/test_markup.rb
+++ b/test/test_markup.rb
@@ -582,24 +582,13 @@ np.array([[2,2],[1,3]],np.float)
     assert_match /\(\[\[/, rendered, "#{markup_class} parses out wiki links\n#{rendered}"
   end
 
-  test "embed code is escaped" do
-    @wiki.write_page("script", :markdown, "a <script></script> b", commit_details)
-    @wiki.write_page("page", :markdown, "```html:script```", commit_details)
-
-    output_script = @wiki.page("script").formatted_data
-    output_page = @wiki.page("page").formatted_data
-
-    assert_equal %Q{<p>a  b</p>}, output_script
-    assert_equal %Q{<div class=\"highlight\"><pre><span class=\"nt\">&lt;p&gt;</span>a  b<span class=\"nt\">&lt;/p&gt;</span>\n</pre></div>}, output_page
-  end
-
   test "embed code page absolute link" do
     @wiki.write_page("base", :markdown, "a\n!base\b", commit_details)
     @wiki.write_page("a", :markdown, "a\n```html:/base```\b", commit_details)
 
     page = @wiki.page("a")
     output = page.formatted_data
-    assert_equal %Q{<p>a\n</p><div class=\"highlight\"><pre><span class=\"nt\">&lt;p&gt;</span>a\n!base<span class=\"nt\">&lt;/p&gt;</span>\n</pre></div>\n}, output
+    assert_equal %Q{<p>a\nFile not found: /base</p>}, output
   end
 
   test "embed code page relative link" do
@@ -608,7 +597,7 @@ np.array([[2,2],[1,3]],np.float)
 
     page = @wiki.page("a")
     output = page.formatted_data
-    assert_equal %Q{<p>a\n</p><div class=\"highlight\"><pre><span class=\"nt\">&lt;p&gt;</span>a\n!rel<span class=\"nt\">&lt;/p&gt;</span>\n</pre></div>\n}, output
+    assert_equal %Q{<p>a\nFile not found: base</p>}, output
   end
 
   test "code block in unsupported language" do

--- a/test/wiki_factory.rb
+++ b/test/wiki_factory.rb
@@ -1,8 +1,8 @@
 class WikiFactory
-  def self.create p
+  def self.create p, opt={}
     path = testpath "examples/test.git"
     Grit::Repo.init_bare(path)
-    Gollum::Wiki.default_options = {:universal_toc => false}
+    Gollum::Wiki.default_options = {:universal_toc => false}.merge(opt)
     cleanup = Proc.new { FileUtils.rm_r File.join(File.dirname(__FILE__), *%w[examples test.git]) }
     wiki = Gollum::Wiki.new(path)
     # set 'wiki-' prefix on ids for tests


### PR DESCRIPTION
The current functionality of the gitcode/embed logic is unclear.  It behaves differently for local files vs. raw.github.com files. For reference: https://github.com/github/gollum#github-syntax-highlighting
- **Good:** A user can embed raw.github.com file contents with syntax highlighting.
- **Unclear:** A user can embed the html source of a local _rendered_ wiki-page.
- **Fail:** Crashes when attempting to embed a local non-wiki file such as `foo.py`.
- **Fail:** Crashes when a wiki-page is referred to with an extension.
- **Fail:** Crashes on URIs that do not exist in the repository.

So, a user _cannot_ embed a file stored in the local repository, even though that is what the raw.github.com functionality does. Is the intended use case for the local rendered wiki-page functionality to demo a template? Since it is rendered into HTML, it doesn't work in that case.

I propose that we remove the _unclear_ and _fail_ behaviors listed above. Instead provide the following:
- A user can embed a file stored in the local repository with syntax highlighting in a wiki page.
- Invalid references replaced with `<p>File not found: #{uri}</p>`.

**Note:** This commit currently allows a user to specify a wiki page for embedding, it will include the page's source with the syntax highlighting. My feelings on this behavior are mixed.

Look in `test/test_markup.rb` for the deviations from current behavior.
