### PR TITLE
Pass the value of --host parameter to Rack::Server

### DIFF
--- a/bin/gollum
+++ b/bin/gollum
@@ -185,6 +185,6 @@ else
       end
     end
     # Rack::Handler does not work with Ctrl + C. Use Rack::Server instead.
-    Rack::Server.new(:app => MapGollum.new(base_path), :Port => options['port']).start
+    Rack::Server.new(:app => MapGollum.new(base_path), :Port => options['port'], :Host => options['bind']).start
   end
 end


### PR DESCRIPTION
bin/gollum accepts "--host" option, but it seems to be ignored.
I changed the argument of Rack::Server.new to use the value of "--host".
