### PR TITLE
Proposed fix for issue 96

### DIFF
--- a/lib/gollum/frontend/app.rb
+++ b/lib/gollum/frontend/app.rb
@@ -282,10 +282,6 @@ module Precious
       mustache :compare
     end
 
-    get %r{^/(javascript|css|images)} do
-      halt 404
-    end
-
     get %r{/(.+?)/([0-9a-f]{40})} do
       file_path = params[:captures][0]
       version   = params[:captures][1]


### PR DESCRIPTION
Proposed fix for: https://github.com/github/gollum/issues/96

It appears that the problem was all content in javascript, css, and images folders was hard-coded to return 404s. Is there a good reason for this?

Commenting out the hard-coded 404 associated with those 3 directories solves the problem.

-Shane
