### PR TITLE
Fixed custom.css to apply to all views

### DIFF
--- a/lib/gollum/frontend/app.rb
+++ b/lib/gollum/frontend/app.rb
@@ -85,6 +85,7 @@ module Precious
       @base_url = url('/', false).chomp('/')
       # above will detect base_path when it's used with map in a config.ru
       settings.wiki_options.merge!({ :base_path => @base_url })
+      @css = settings.wiki_options[:css]
     end
 
     get '/' do

--- a/lib/gollum/frontend/templates/file_view.mustache
+++ b/lib/gollum/frontend/templates/file_view.mustache
@@ -5,6 +5,7 @@
   <link rel="stylesheet" type="text/css" href="{{base_url}}/css/gollum.css" media="all">
   <link rel="stylesheet" type="text/css" href="{{base_url}}/css/template.css" media="all">
   <link rel="stylesheet" type="text/css" href="{{base_url}}/css/_styles.css" media="all">
+  {{#css}}<link rel="stylesheet" type="text/css" href="{{base_url}}/custom.css" media="all">{{/css}}
   <title>{{title}}</title>
 </head>
 <body>

--- a/lib/gollum/frontend/views/layout.rb
+++ b/lib/gollum/frontend/views/layout.rb
@@ -23,6 +23,11 @@ module Precious
       def base_url
         @base_url
       end
+
+      def css # custom css
+        @css
+      end
+
     end
   end
 end

--- a/lib/gollum/frontend/views/page.rb
+++ b/lib/gollum/frontend/views/page.rb
@@ -89,10 +89,6 @@ module Precious
         @mathjax
       end
 
-      def css # custom css
-        @css
-      end
-
       def use_identicon
         @page.wiki.user_icons == 'identicon'
       end


### PR DESCRIPTION
Currently custom.css only applies the to a couple of the views. This change makes custom.css file apply to all views.

@bootstraponline, would you please verify that setting custom.css via the wiki_options as I have done is correct?  https://github.com/dekimsey/gollum/commit/2b910167f418d479210fa502b48aebf507915db7#L0R88 It works but I wasn't sure if this was the correct way to do it.
