### PR TITLE
Fix /pages css to the correct path for images

### DIFF
--- a/lib/gollum/frontend/public/gollum/css/gollum.css
+++ b/lib/gollum/frontend/public/gollum/css/gollum.css
@@ -699,14 +699,14 @@ ul.actions {
 
 #pages li a.file,
 #pages li a.folder {
-    background-image: url(/images/fileview/document.png);
+    background-image: url(../images/fileview/document.png);
     background-position: 0 1px;
     background-repeat: no-repeat;
     padding-left: 20px;
 }
 
 #pages li a.folder {
-    background-image: url(/images/fileview/folder-horizontal.png);
+    background-image: url(../images/fileview/folder-horizontal.png);
 }
 
 #pages .breadcrumb {


### PR DESCRIPTION
Fix the 404's for `li` element images on the `/pages` view.
