### PR TITLE
Change textarea font in page editor to be the same as GitHub

### DIFF
--- a/lib/gollum/frontend/views/page.rb
+++ b/lib/gollum/frontend/views/page.rb
@@ -116,7 +116,7 @@ module Precious
       # Finds header node inside Nokogiri::HTML document.
       #
       def find_header_node(doc)
-        case self.format
+        case @page.format
           when :asciidoc
             doc.css("div#gollum-root > div#header > h1:first-child")
           when :org


### PR DESCRIPTION
Using a non monospace font for the texteditor area is really problematic, as it messes up table cell alignment, and really picky renderers won't display the tables properly.
