### PR TITLE
Fix redirects to index_pages for subdirs

### DIFF
--- a/lib/gollum/frontend/app.rb
+++ b/lib/gollum/frontend/app.rb
@@ -89,7 +89,7 @@ module Precious
 
     get '/' do
       page_dir = settings.wiki_options[:page_file_dir].to_s
-      redirect clean_url(::File.join(@base_url, page_dir, 'Home'))
+      redirect clean_url(::File.join(@base_url, page_dir, wiki_new.index_page))
     end
 
     # path is set to name if path is nil.
@@ -98,12 +98,12 @@ module Precious
     #   extract_path will trim path to 'a'
     # name, path, version
     def wiki_page(name, path = nil, version = nil, exact = true)
+      wiki = wiki_new
+      
       path = name if path.nil?
-      name = extract_name(name)
+      name = extract_name(name) || wiki.index_page
       path = extract_path(path)
       path = '/' if exact && path.nil?
-
-      wiki = wiki_new
 
       OpenStruct.new(:wiki => wiki, :page => wiki.paged(name, path, exact, version),
                      :name => name, :path => path)
@@ -123,6 +123,7 @@ module Precious
       wikip = wiki_page(params[:splat].first)
       @name = wikip.name
       @path = wikip.path
+      
       wiki = wikip.wiki
       if page = wikip.page
         if wiki.live_preview && page.format.to_s.include?('markdown') && supported_useragent?(request.user_agent)
@@ -379,9 +380,10 @@ module Precious
     end
 
     def show_page_or_file(fullpath)
-      name         = extract_name(fullpath)
-      path         = extract_path(fullpath) || '/'
-      wiki         = wiki_new
+      wiki = wiki_new
+
+      name = extract_name(fullpath) || wiki.index_page
+      path = extract_path(fullpath) || '/'
 
       if page = wiki.paged(name, path, exact = true)
         @page = page

--- a/lib/gollum/frontend/helpers.rb
+++ b/lib/gollum/frontend/helpers.rb
@@ -12,6 +12,12 @@ module Precious
 
     # Extract the 'page' name from the file_path
     def extract_name(file_path)
+      if file_path[-1, 1] == "/"
+        return nil
+      end
+      
+      # File.basename is too eager to please and will return the last 
+      # component of the path even if it ends with a directory separator.
       ::File.basename(file_path)
     end
 

--- a/lib/gollum/wiki.rb
+++ b/lib/gollum/wiki.rb
@@ -144,6 +144,9 @@ module Gollum
     # Sets page title to value of first h1
     # Defaults to false
     attr_reader :h1_title
+    
+    # Gets the custom index page for / and subdirs (e.g. foo/)
+    attr_reader :index_page
 
     # Public: Initialize a new Gollum Repo.
     #
@@ -168,6 +171,11 @@ module Gollum
     #           :show_all      - Show all files in file view, not just valid pages.
     #                            Default: false
     #           :collapse_tree - Start with collapsed file view. Default: false
+    #           :css           - Include the custom.css file from the repo.
+    #           :h1_title      - Concatenate all h1's on a page to form the
+    #                            page title.
+    #           :index_page    - The default page to retrieve or create if the 
+    #                            a directory is accessed.
     #
     # Returns a fresh Gollum::Repo.
     def initialize(path, options = {})
@@ -203,7 +211,7 @@ module Gollum
       @collapse_tree        = options.fetch :collapse_tree, false
       @css                  = options.fetch :css, false
       @h1_title             = options.fetch :h1_title, false
-
+      @index_page           = options.fetch :index_page, 'Home'
       @user_icons           = ['gravatar', 'identicon'].include?( options[:user_icons] ) ?
                               options[:user_icons] : 'none'
     end

--- a/test/test_app.rb
+++ b/test/test_app.rb
@@ -252,6 +252,24 @@ context "Frontend" do
     assert last_response.ok?
   end
 
+  test "accessing non-existant directory redirects to create index page" do
+    get "/foo/"
+
+    follow_redirect!
+    assert_equal "/create/foo/Home", last_request.fullpath
+    assert last_response.ok?
+  end
+
+  test "accessing redirectory redirects to index page" do
+    post "/create", :content => 'abc', :page => 'Home', :path => '/foo/',
+      :format => 'markdown', :message => 'foo'
+
+    assert_equal "http://example.org/foo/home", last_response.headers['Location']
+   
+    follow_redirect!
+    assert last_response.ok?
+  end
+
   test "edit redirects to create on non-existant page" do
     name = "E"
     get "/edit/#{name}"


### PR DESCRIPTION
Another minor fix.

If you tried to access

`/foo/`

you got redirected to

`/create/foo/foo`

I'm not sure if this was by design, but i'm guessing not.

Now it'll redirect to `wiki_options[:index_page]` which defaults to `Home`.

Also added tests for this.
