### PR TITLE
Fix Create New Page and Rename Page dialogs redirect behaviour

### DIFF
--- a/lib/gollum/frontend/public/gollum/javascript/gollum.js
+++ b/lib/gollum/frontend/public/gollum/javascript/gollum.js
@@ -24,7 +24,10 @@ function htmlEscape( str ) {
 function abspath(path, name){
   // Make sure the given path starts at the root.
   if(name[0] != '/'){
-    name = '/' + path + '/' + name;
+    name = '/' + name;
+    if (path) {
+      name = '/' + path + name;
+    }
   }
   var name_parts = name.split('/');
   var newPath = name_parts.slice(0, -1).join('/');


### PR DESCRIPTION
The Create New Page and Rename Page dialogs exhibit problematic redirect behaviour in some cases when the entered page name is not an absolute path.

Examples are:
- Attempting to create page B from http://localhost:4567/A redirects to B/
- Attempting to rename page to A/B from http://localhost:4567/A redirects to http://localhost:4567/rename/A 

This pull request modifies the `abspath` JavaScript function added in #598 to handle the case when the `path` argument is empty.
