### PR TITLE
Added read-only option.

### DIFF
--- a/bin/gollum
+++ b/bin/gollum
@@ -84,6 +84,9 @@ opts = OptionParser.new do |opts|
   opts.on("--collapse-tree", "Collapse file view tree. By default, expanded tree is shown.") do
     wiki_options[:collapse_tree] = true
   end
+  opts.on("--read-only", "Disables ability to edit wiki in web client.") do
+    wiki_options[:read_only] = true
+  end
   opts.on("--h1-title", "Sets page title to value of first h1") do
     wiki_options[:h1_title] = true
   end

--- a/lib/gollum/frontend/templates/compare.mustache
+++ b/lib/gollum/frontend/templates/compare.mustache
@@ -8,8 +8,10 @@
     </li>
     <li class="minibutton"><a href="{{base_url}}/{{escaped_url_path}}"
        class="action-view-page">View Page</a></li>
+    {{#not_read_only}}
     <li class="minibutton"><a href="{{base_url}}/edit/{{escaped_url_path}}"
        class="action-edit-page">Edit Page</a></li>
+    {{/not_read_only}}
     <li class="minibutton"><a href="{{base_url}}/history/{{escaped_url_path}}"
        class="action-page-history">Page History</a></li>
   </ul>

--- a/lib/gollum/frontend/templates/history.mustache
+++ b/lib/gollum/frontend/templates/history.mustache
@@ -7,8 +7,10 @@
     </li>
     <li class="minibutton"><a href="{{base_url}}/{{escaped_url_path}}"
        class="action-view-page">View Page</a></li>
+    {{#not_read_only}}
     <li class="minibutton"><a href="{{base_url}}/edit/{{escaped_url_path}}"
        class="action-edit-page">Edit Page</a></li>
+    {{/not_read_only}}
   </ul>
 </div>
 <div id="wiki-history">

--- a/lib/gollum/frontend/templates/page.mustache
+++ b/lib/gollum/frontend/templates/page.mustache
@@ -18,6 +18,7 @@ Mousetrap.bind(['e'], function( e ) {
       class="action-all-pages">All</a></li>
     <li class="minibutton"><a href="{{base_url}}/fileview"
     class="action-all-pages">Files</a></li>
+    {{#not_read_only}}
     <li class="minibutton" class="jaws">
       <a href="#" id="minibutton-new-page">New</a></li>
     {{#editable}}
@@ -26,6 +27,7 @@ Mousetrap.bind(['e'], function( e ) {
     <li class="minibutton"><a href="{{base_url}}/edit/{{escaped_url_path}}"
        class="action-edit-page">Edit</a></li>
     {{/editable}}
+    {{/not_read_only}}
     <li class="minibutton"><a href="{{base_url}}/history/{{escaped_url_path}}"
        class="action-page-history">History</a></li>
   </ul>
@@ -68,9 +70,11 @@ Mousetrap.bind(['e'], function( e ) {
 </div>
 <div id="footer">
   <p id="last-edit">Last edited by <b>{{author}}</b>, {{date}}</p>
+  {{#not_read_only}}
   <p>
     <a id="delete-link" href="{{base_url}}/{{escaped_url_path}}" data-confirm="Are you sure you want to delete this page?"><span>Delete this Page</span></a>
   </p>
+  {{/not_read_only}}
 </div>
 </div>
 

--- a/lib/gollum/frontend/templates/pages.mustache
+++ b/lib/gollum/frontend/templates/pages.mustache
@@ -7,9 +7,11 @@
     </li>
     <li class="minibutton"><a href="{{base_url}}/"
        class="action-edit-page">Home</a></li>
+    {{#not_read_only}}
     <li class="minibutton" class="jaws">
     <a href="#" id="minibutton-new-page">New</a>
     </li>
+    {{/not_read_only}}
   </ul>
 </div>
 <div id="pages">

--- a/lib/gollum/wiki.rb
+++ b/lib/gollum/wiki.rb
@@ -174,6 +174,7 @@ module Gollum
     #           :show_all      - Show all files in file view, not just valid pages.
     #                            Default: false
     #           :collapse_tree - Start with collapsed file view. Default: false
+    #           :read_only     - Disables ability to edit wiki in web client.
     #           :css           - Include the custom.css file from the repo.
     #           :h1_title      - Concatenate all h1's on a page to form the
     #                            page title.
@@ -215,6 +216,7 @@ module Gollum
       @mathjax              = options.fetch :mathjax, false
       @show_all             = options.fetch :show_all, false
       @collapse_tree        = options.fetch :collapse_tree, false
+      @read_only            = options.fetch :read_only, false
       @css                  = options.fetch :css, false
       @h1_title             = options.fetch :h1_title, false
       @index_page           = options.fetch :index_page, 'Home'
@@ -699,6 +701,9 @@ module Gollum
 
     # Start with collapsed file view. Default: false
     attr_reader :collapse_tree
+
+    # Enables read-only mode.
+    attr_reader :read_only
 
     # Normalize the data.
     #


### PR DESCRIPTION
I had one major issue with Gollum the way it is currently. It would not allow one to disable editing of the wiki via the web interface. I had a problem with this as it allows anyone on the web to go and miss up my wiki without an approval process or identification as to who they were.

My plan is to put my wiki on github or some other git repository system and allow people to add to the wiki via pull requests and patches. More control as to who can do what and also does not allow any stranger to just go and spam the wiki.

Hope you incorporate my changes in Gollum. I know other people are wanting this.
