### PR TITLE
Update working directory when creating new page in subdirectory

### DIFF
--- a/lib/gollum/wiki.rb
+++ b/lib/gollum/wiki.rb
@@ -321,7 +321,7 @@ module Gollum
 
       committer.after_commit do |index, sha|
         @access.refresh
-        index.update_working_dir('', filename, format)
+        index.update_working_dir(dir, filename, format)
       end
 
       multi_commit ? committer : committer.commit

--- a/test/test_wiki.rb
+++ b/test/test_wiki.rb
@@ -362,6 +362,11 @@ context "Wiki sync with working directory" do
     assert_equal "Hi", File.read(File.join(@path, "New-Page.md"))
   end
 
+  test "write a page in subdirectory" do
+    @wiki.write_page("New Page", :markdown, "Hi", commit_details, "Subdirectory")
+    assert_equal "Hi", File.read(File.join(@path, "Subdirectory", "New-Page.md"))
+  end
+
   test "update a page with same name and format" do
     @wiki.write_page("New Page", :markdown, "Hi", commit_details)
     page = @wiki.page("New Page")


### PR DESCRIPTION
This fixes a bug where an empty subdirectory path was being passed to `index.update_working_dir` with the effect that new pages in subdirectories would fail to be checked out to the working directory. A subsequent `git status` on the wiki repository would report the new page as having been deleted.
