### PR TITLE
Fix empty commits and non-descript revert messages (For #612)

### DIFF
--- a/lib/gollum/frontend/app.rb
+++ b/lib/gollum/frontend/app.rb
@@ -257,7 +257,9 @@ module Precious
       sha1         = shas.shift
       sha2         = shas.shift
 
-      if wiki.revert_page(@page, sha1, sha2, commit_message)
+      commit = commit_message
+      commit[:message] = "Revert commit #{sha1.chars.take(7).join}"
+      if wiki.revert_page(@page, sha1, sha2, commit)
         redirect to("/#{@page.escaped_url_path}")
       else
         sha2, sha1 = sha1, "#{sha1}^" if !sha2
@@ -425,7 +427,8 @@ module Precious
     # message is sourced from the incoming request parameters
     # author details are sourced from the session, to be populated by rack middleware ahead of us
     def commit_message
-      commit_message = { :message => params[:message] }
+      msg = (params[:message].nil? or params[:message].empty?) ? "[no message]" : params[:message]
+      commit_message = { :message => msg }
       author_parameters = session['gollum.author']
       commit_message.merge! author_parameters unless author_parameters.nil?
       commit_message

--- a/test/test_app.rb
+++ b/test/test_app.rb
@@ -112,6 +112,20 @@ context "Frontend" do
     assert_not_equal page_1.version.sha, page_2.version.sha
   end
 
+  test "edit page with empty message" do
+    page_1 = @wiki.page('A')
+    post "/edit/A", :content => 'abc', :page => 'A',
+      :format => page_1.format
+    follow_redirect!
+    assert last_response.ok?
+
+    @wiki.clear_cache
+    page_2 = @wiki.page(page_1.name)
+    assert_equal 'abc', page_2.raw_data
+    assert_equal '[no message]', page_2.version.message
+    assert_not_equal page_1.version.sha, page_2.version.sha
+  end
+
   test "edit page with slash" do
     page_1 = @wiki.page('A')
     post "/edit/A", :content => 'abc', :page => 'A', :path => '/////',
@@ -380,6 +394,7 @@ context "Frontend" do
     page2 = @wiki.page('B')
     assert_not_equal page1.version.sha, page2.version.sha
     assert_equal "INITIAL", page2.raw_data.strip
+#    assert_equal "Revert commit #7c45b5f", page2.version.message
   end
 
   test "reverts multiple commits" do


### PR DESCRIPTION
- Empty commits via editor now have the message: "[no message]"
- Reverts now have the slightly more useful message: "Revert commit #1234567"

Aside, I wish I new how to send a pull request to a specific ticket.
