### PR TITLE
Fix symlink base path, don't allow in bare repos

### DIFF
--- a/lib/gollum/file.rb
+++ b/lib/gollum/file.rb
@@ -44,8 +44,8 @@ module Gollum
     def raw_data
       return nil unless @blob
 
-      if @blob.is_symlink
-        new_path = @blob.symlink_target(self.path)
+      if !@wiki.repo.bare && @blob.is_symlink
+        new_path = @blob.symlink_target(::File.join(@wiki.repo.path, '..', self.path))
         return IO.read(new_path) if new_path
       end
 

--- a/lib/gollum/page.rb
+++ b/lib/gollum/page.rb
@@ -182,8 +182,8 @@ module Gollum
     def raw_data
       return nil unless @blob
 
-      if @blob.is_symlink
-        new_path = @blob.symlink_target(::File.join(@wiki.repo.path, self.path))
+      if !@wiki.repo.bare && @blob.is_symlink
+        new_path = @blob.symlink_target(::File.join(@wiki.repo.path, '..', self.path))
         return IO.read(new_path) if new_path
       end
 

--- a/test/test_app.rb
+++ b/test/test_app.rb
@@ -485,11 +485,13 @@ context "Frontend with lotr" do
   # .
   # ├── Bilbo-Baggins.md
   # ├── Data.csv
+  # |-- Data-Two.csv -> Data.csv
   # ├── Gondor
   # │   ├── Boromir.md
   # │   ├── _Footer.md
   # │   ├── _Header.md
   # │   └── _Sidebar.md
+  # |-- Hobbit.md -> Bilbo-Baggins.md
   # ├── Home.textile
   # ├── Mordor
   # │   ├── Eye-Of-Sauron.md
@@ -526,6 +528,11 @@ context "Frontend with lotr" do
 
     assert !body.include?("Bilbo Baggins"), "/pages/Mordor/ should NOT include the page 'Bilbo Baggins'"
     assert body.include?("Eye Of Sauron"), "/pages/Mordor/ should include the page 'Eye Of Sauron'"
+  end
+
+  test "symbolic link pages" do
+    get "/Hobbit"
+    assert_match /Bilbo Baggins/, last_response.body
   end
 
   # base path requires 'map' in a config.ru to work correctly.

--- a/test/test_file.rb
+++ b/test/test_file.rb
@@ -21,21 +21,25 @@ context "File" do
     assert_equal commit.author.name, file.version.author.name
   end
 
+  test "accessing tree" do
+    assert_nil @wiki.file("Mordor")
+  end
+end
+
+context "File with checkout" do
+  setup do
+    @path = cloned_testpath("examples/lotr.git")
+    @wiki = Gollum::Wiki.new(@path)
+  end
+
+  teardown do
+    FileUtils.rm_rf(@path)
+  end
+
   test "symbolic link" do
     commit = @wiki.repo.commits.first
     file   = @wiki.file("Data-Two.csv")
 
-    # Since we don't have a checkout here (bare repos in testing), these
-    # symbolic links won't resolve.  Stub IO.read to simulate the behavior
-    # and make sure all is working well.
-    path_to_link = File.expand_path(File.join('..', '..', 'Data.csv'), __FILE__)
-    File.expects(:file?).with(path_to_link).returns(true)
-    IO.expects(:read).with(path_to_link).returns('symlink test')
-
-    assert_equal file.raw_data, 'symlink test'
-  end
-
-  test "accessing tree" do
-    assert_nil @wiki.file("Mordor")
+    assert_match /^FirstName,LastName\n/, file.raw_data
   end
 end

--- a/test/test_page.rb
+++ b/test/test_page.rb
@@ -34,23 +34,6 @@ context "Page" do
     assert_nil @wiki.page('Bilbo_Baggins')
   end
 
-  test "get existing page with symbolic link" do
-    page = @wiki.page("Hobbit")
-    assert_equal Gollum::Page, page.class
-    assert_equal 'Hobbit.md', page.path
-    assert_equal :markdown, page.format
-
-    # Since we don't have a checkout here (bare repos in testing), these
-    # symbolic links won't resolve.  Stub IO.read to simulate the behavior
-    # and make sure all is working well.
-    path_to_link = File.expand_path(File.join('..', 'examples', 'lotr.git', 'Bilbo-Baggins.md'), __FILE__)
-    File.expects(:file?).with(path_to_link).returns(true).at_least_once
-    IO.expects(:read).with(path_to_link).returns("# Bilbo Baggins\n\nBilbo Baggins").at_least_once
-
-    assert page.raw_data =~ /^# Bilbo Baggins\n\nBilbo Baggins/
-    assert page.formatted_data =~ %r{<h1>Bilbo Baggins<a class="anchor" id="Bilbo-Baggins" href="#Bilbo-Baggins"></a></h1>\n\n<p>Bilbo Baggins}
-  end
-
   test "get existing page where filename contains whitespace, with hypen" do
     assert_equal @wiki.page('Samwise Gamgee').path, @wiki.page('Samwise-Gamgee').path
   end
@@ -211,6 +194,26 @@ context "Page" do
     assert_equal "", Gollum::BlobEntry.normalize_dir("c:/")
     assert_equal "/foo", Gollum::BlobEntry.normalize_dir("foo")
     assert_equal "/foo", Gollum::BlobEntry.normalize_dir("/foo")
+  end
+end
+
+context "with a checkout" do
+  setup do
+    @path = cloned_testpath("examples/lotr.git")
+    @wiki = Gollum::Wiki.new(@path)
+  end
+
+  teardown do
+    FileUtils.rm_rf(@path)
+  end
+
+  test "get existing page with symbolic link" do
+    page = @wiki.page("Hobbit")
+    assert_equal Gollum::Page, page.class
+    assert page.raw_data =~ /^# Bilbo Baggins\n\nBilbo Baggins/
+    assert page.formatted_data =~ %r{<h1>Bilbo Baggins<a class="anchor" id="Bilbo-Baggins" href="#Bilbo-Baggins"></a></h1>\n\n<p>Bilbo Baggins}
+    assert_equal 'Hobbit.md', page.path
+    assert_equal :markdown, page.format
   end
 end
 


### PR DESCRIPTION
Sorry to hit you with one more commit on this, but I decided the way I'd cobbled together the tests was too big of a hack.  Here's one with actual checkouts using the `cloned_testpath` helper, and including a test for the Sinatra app.  I also disabled symbolic links on bare repositories, because that's obviously the correct decision.  All of that flushed out a bug in the File class, which I squashed.  I'm officially 100% confident that this now works the way it should.

Now I promise I'm done, because I've been putting off my other work far too long this evening!  Thanks for your help, and for moving development forward on this!
