### PR TITLE
Add option for custom js (like custom css)

### DIFF
--- a/README.md
+++ b/README.md
@@ -548,9 +548,11 @@ Note that filenames on windows must not contain any of the following characters 
 
 Gollum optionally takes a `--config file`. See [config.rb](https://github.com/gollum/gollum/blob/master/config.rb) for an example.
 
-## CUSTOM CSS
+## CUSTOM CSS/JS
 
 The `--css` flag will inject `custom.css` from the root of your git repository into each page. `custom.css` must be commited to git or you will get a 302 redirect to the create page.
+
+The `--js` flag will inject `custom.js` from the root of your git repository into each page. `custom.js` must be commited to git or you will get a 302 redirect to the create page.
 
 ## CONTRIBUTE
 

--- a/bin/gollum
+++ b/bin/gollum
@@ -49,6 +49,10 @@ opts = OptionParser.new do |opts|
     wiki_options[:css] = true
   end
 
+  opts.on("--js", "Inject custom js. Uses custom.js from root repository") do
+    wiki_options[:js] = true
+  end
+
   opts.on("--page-file-dir [PATH]", "Specify the sub directory for all page files (default: repository root).") do |path|
     wiki_options[:page_file_dir] = path
   end

--- a/lib/gollum/frontend/app.rb
+++ b/lib/gollum/frontend/app.rb
@@ -85,6 +85,7 @@ module Precious
       # above will detect base_path when it's used with map in a config.ru
       settings.wiki_options.merge!({ :base_path => @base_url })
       @css = settings.wiki_options[:css]
+      @js = settings.wiki_options[:js]
     end
 
     get '/' do

--- a/lib/gollum/frontend/templates/file_view.mustache
+++ b/lib/gollum/frontend/templates/file_view.mustache
@@ -6,6 +6,7 @@
   <link rel="stylesheet" type="text/css" href="{{base_url}}/css/template.css" media="all">
   <link rel="stylesheet" type="text/css" href="{{base_url}}/css/_styles.css" media="all">
   {{#css}}<link rel="stylesheet" type="text/css" href="{{base_url}}/custom.css" media="all">{{/css}}
+  {{#js}}<script type="text/javascript" src="{{base_url}}/custom.js"></script>{{/js}}
   <title>{{title}}</title>
 </head>
 <body>

--- a/lib/gollum/frontend/templates/layout.mustache
+++ b/lib/gollum/frontend/templates/layout.mustache
@@ -43,6 +43,7 @@
   (d.head || d.getElementsByTagName('head')[0]).appendChild(j);
   }(document));
   </script>{{/mathjax}}
+  {{#js}}<script type="text/javascript" src="{{base_url}}/custom.js"></script>{{/js}}
 
   <title>{{title}}</title>
 </head>

--- a/lib/gollum/frontend/views/layout.rb
+++ b/lib/gollum/frontend/views/layout.rb
@@ -28,6 +28,10 @@ module Precious
         @css
       end
 
+      def js # custom js
+        @js
+      end
+
     end
   end
 end

--- a/test/test_app.rb
+++ b/test/test_app.rb
@@ -461,6 +461,30 @@ context "Frontend" do
     assert_equal 'jkl', author.email
   end
 
+  test "do not add custom.js by default" do
+    page = 'nocustom'
+    text = 'nope none'
+
+    @wiki.write_page(page, :markdown, text,
+                     { :name => 'user1', :email => 'user1' });
+
+    get page
+    assert_no_match /custom.js/, last_response.body
+  end
+
+  test "add custom.js if setting" do
+    Precious::App.set(:wiki_options, { :js => true })
+    page = 'yaycustom'
+    text = 'customized!'
+
+    @wiki.write_page(page, :markdown, text,
+                     { :name => 'user1', :email => 'user1' });
+
+    get page
+    assert_match /custom.js/, last_response.body
+    Precious::App.set(:wiki_options, { :js => nil })
+  end
+
   def app
     Precious::App
   end


### PR DESCRIPTION
- Add a new 'js' flag to indicate you want to embed a file named 'custom.js'
  which should exist at the root of the wiki
