### PR TITLE
[[_]] float clearing tag experiment

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,12 @@ specified, default alignment is `left`.
 
     [[gollum.png|float]]
 
+By default text will fill up all the space around the image. To control how
+much should show up use this tag to stop and start a new block so that
+additional content doesn't fill in.
+
+    [[_]]
+
 To specify a max-width, use the `width=` option. Units must be specified in
 either `px` or `em`.
 

--- a/lib/gollum/frontend/public/gollum/css/gollum.css
+++ b/lib/gollum/frontend/public/gollum/css/gollum.css
@@ -729,3 +729,4 @@ ul.actions {
   padding: 0.25em;
 }
 
+.clearfloats { clear:both }

--- a/lib/gollum/markup.rb
+++ b/lib/gollum/markup.rb
@@ -236,6 +236,8 @@ module Gollum
     def process_tag(tag)
       if tag =~ /^_TOC_$/
         %{[[#{tag}]]}
+      elsif tag =~ /^_$/
+        %{<div class="clearfloats"></div>}
       elsif html = process_image_tag(tag)
         html
       elsif html = process_file_link_tag(tag)


### PR DESCRIPTION
Hiya,
This is trying to address https://github.com/gollum/gollum/issues/653

Automatic clearing on page headers is beyond me, but I did an experiment with a special [[_]] gollum tag to add at the end of text to display, seems to work great so far !

I don't know much about the code base so there may be implications i'm not aware of. Hope this helps !
