### PR TITLE
Tweak TeX math delimiters

### DIFF
--- a/lib/gollum/templates/layout.mustache
+++ b/lib/gollum/templates/layout.mustache
@@ -31,8 +31,8 @@
   <script type="text/x-mathjax-config">
   MathJax.Hub.Config({
     tex2jax: {
-      inlineMath:  [ ['$','$'],   ['\\(','\\)']],
-      displayMath: [ ['$$','$$'], ['\[','\]'] ],
+      inlineMath:  [ ['\\(','\\)'] ],
+      displayMath: [ ['$$','$$'], ['\\[','\\]'] ],
       processEscapes: true
     },
     TeX: { extensions: ["autoload-all.js"] }});


### PR DESCRIPTION
The current MathJax configuration binds `[` and `]` as TeX-mode inline math delimiters.  Not only does this mean you can't enable MathJax and use single brackets in your pages (yipe!), but this isn't even how TeX math mode works; `\[` and `\]` are the proper TeX math delimiters.

I've also removed the single-dollarsign delimiters for inline math.  As [the MathJax folks themselves note,](http://docs.mathjax.org/en/latest/tex.html) this causes really weird behavior:

> For example, with single-dollar delimiters, ”... the cost is $2.50 for the first one, and $2.00 for each additional one ...” would cause the phrase “2.50 for the first one, and” to be treated as mathematics since it falls between dollar signs.

This fixes both of those strange behaviors.
