### PR TITLE
Fix library dependancy issue when running with config.ru

### DIFF
--- a/lib/gollum/app.rb
+++ b/lib/gollum/app.rb
@@ -6,6 +6,7 @@ require 'mustache/sinatra'
 require 'useragent'
 require 'stringex'
 
+require 'gollum'
 require 'gollum/views/layout'
 require 'gollum/views/editable'
 require 'gollum/views/has_page'


### PR DESCRIPTION
I'm runnig gollum head with the sample config.ru
https://github.com/gollum/gollum#rack
But when I create page, I'm getting following error.

```
NoMethodError - undefined method `encodeURIComponent' for #<Precious::App:0x007fb0b51e5d58>
        /Users/foo/gollum/lib/gollum/app.rb:413:in `show_page_or_file'
        /Users/foo/gollum/lib/gollum/app.rb:385:in `block in <class:App>'
        /Users/foo/.rbenv/versions/1.9.3-p392/lib/ruby/gems/1.9.1/gems/sinatra-1.4.2/lib/
se.rb:1415:in `call'
...
```

It is hard to write test. But this error is reproducible with comment out this line. https://github.com/gollum/gollum/blob/master/test/helper.rb#L16
