### PR TITLE
Fix missing new/rename buttons

### DIFF
--- a/lib/gollum/public/gollum/javascript/gollum.js
+++ b/lib/gollum/public/gollum/javascript/gollum.js
@@ -146,7 +146,7 @@ $(document).ready(function() {
   }
 
   if ($('#minibutton-rename-page').length) {
-    $('#minibutton-rename-page').removeClass('jaws');
+    $('#minibutton-rename-page').parent().removeClass('jaws');
     $('#minibutton-rename-page').click(function(e) {
       e.preventDefault();
 
@@ -190,7 +190,7 @@ $(document).ready(function() {
   }
 
   if ($('#minibutton-new-page').length) {
-    $('#minibutton-new-page').removeClass('jaws');
+    $('#minibutton-new-page').parent().removeClass('jaws');
     $('#minibutton-new-page').click(function(e) {
       e.preventDefault();
 


### PR DESCRIPTION
I've noticed the rename and new buttons have disappeared.

Looking through the Javascript I realized that the `.jaws` class hides these buttons unless Javascript is enabled. [gollum.js#193](https://github.com/gollum/gollum/blob/master/lib/gollum/public/gollum/javascript/gollum.js#L193) [gollum.js#149](https://github.com/gollum/gollum/blob/master/lib/gollum/public/gollum/javascript/gollum.js#L149)
Example for the new button:

```
174    if ($('#minibutton-new-page').length) {
175      $('#minibutton-new-page').removeClass('jaws');
176      $('#minibutton-new-page').click(function(e) {
177        e.preventDefault();
```

However the [template code](https://github.com/gollum/gollum/blob/master/lib/gollum/templates/page.mustache#L21) is:

```
21      <li class="minibutton jaws">
22        <a href="#" id="minibutton-new-page">New</a></li>
23      {{#editable}}
24      <li class="minibutton jaws">
25        <a href="#" id="minibutton-rename-page">Rename</a></li>
```

This can never match. The fix is obviously easy. Attached pull request is obvious.

My question is, how in the hell did that happen? I've tried running up and down the blame and examining the git log in detail but I cannot figure out when the issue was introduced. Or more accurately, the answer I came up with doesn't make much sense. 

According to `git log -u 8fd8a56`, my new/rename button commit didn't have line 175 from the javascript. However, if I `checkout 8fd8a56`, it is there. In fact, `git blame` says it has been there for two years. The first time it shows up in the log, is during Jamie's rename. `git log -u 1f79126 lib/gollum/frontend/public/gollum/javascript/gollum.js`

I'm seriously confused as to why git log's patch do not correctly reflect the contents of the tree.

Or perhaps I made some really, really, bad tea this morning.

I've made this simple fix a pull request, because I am confused as to why I cannot figure out where this change was introduced. Another pair of eyes would be helpful.
