### PR TITLE
Add bottom margin to hr elements

### DIFF
--- a/lib/gollum/public/gollum/css/template.css
+++ b/lib/gollum/public/gollum/css/template.css
@@ -124,7 +124,8 @@ a.absent {
 .markdown-body ol,
 .markdown-body dl,
 .markdown-body table,
-.markdown-body pre {
+.markdown-body pre,
+.markdown-body hr {
   margin: 0px 0;
   margin-bottom: 15px;
 }


### PR DESCRIPTION
This gives some more consistent spacing, and looks better.

Before:

![screen shot 2013-05-08 at 5 08 26 pm](https://f.cloud.github.com/assets/99231/480059/a4405d62-b823-11e2-9c7c-4a9da94c2e18.png)

After:

![screen shot 2013-05-08 at 5 08 48 pm](https://f.cloud.github.com/assets/99231/480058/a43a6092-b823-11e2-8ef2-3b2869f05e2f.png)
