### PR TITLE
Typo in page.mustache

### DIFF
--- a/lib/gollum/templates/page.mustache
+++ b/lib/gollum/templates/page.mustache
@@ -77,4 +77,4 @@ Mousetrap.bind(['e'], function( e ) {
 <form name="rename" method="POST" action="{{base_url}}/rename/{{escaped_url_path}}">
   <input type="hidden" name="rename"/>
   <input type="hidden" name="message"/>
-</from>
+</form>


### PR DESCRIPTION
There was a typo (last line) in the rename form so it wasn't closed properly making the page w3c invalid. 
