### PR TITLE
Use correct path for uploadFile action even when current page is in a folder.

### DIFF
--- a/lib/gollum/public/gollum/javascript/gollum.dialog.js
+++ b/lib/gollum/public/gollum/javascript/gollum.dialog.js
@@ -95,7 +95,7 @@
 
       var id = fieldAttributes.id || 'upload';
       var name = fieldAttributes.name || 'file';
-      var action = fieldAttributes.action || 'uploadFile';
+      var action = fieldAttributes.action || '/uploadFile';
 
       html += '<form method=post enctype="multipart/form-data" ' +
         'action="' + action + '" ' + 'id="' + id + '">';


### PR DESCRIPTION
Without this fix, the upload form POSTs to /current-page/uploadFile, resulting in a 404 error from Sinatra.
