### PR TITLE
Change pages display to handle non-wiki file types with --show_all enabled

### DIFF
--- a/lib/gollum/views/pages.rb
+++ b/lib/gollum/views/pages.rb
@@ -47,7 +47,13 @@ module Precious
                 folder_link
               end
             elsif page_path != ".gitkeep"
-              %{<li><a href="#{@base_url}/#{page.escaped_url_path}" class="file">#{page.name}</a></li>}
+              if (defined? page.format) 
+                # If page is in a normal wiki format 
+                %{<li><a href="#{@base_url}/#{page.escaped_url_path}" class="file">#{page.name}</a></li>}
+              else
+                # If page isn't in a normal wiki format
+                %{<li><a href="#{@base_url}/#{page.escaped_url_path}/#{page.name}" class="file">#{page.name}</a></li>}
+              end
             end
           }.compact.join("\n")
         else


### PR DESCRIPTION
Wanted to be able to show non-markdown (image, etc.) files in /pages display.

Deals with issue: #704 I think.
