### PR TITLE
Fix version specifiers

### DIFF
--- a/gollum.gemspec
+++ b/gollum.gemspec
@@ -24,14 +24,14 @@ Gem::Specification.new do |s|
   s.rdoc_options = ["--charset=UTF-8"]
   s.extra_rdoc_files = %w[README.md LICENSE]
 
-  s.add_dependency 'gollum-lib', '~> 1.0.9'
+  s.add_dependency 'gollum-lib', '~> 1.0', '>= 1.0.9'
   s.add_dependency 'github-markdown', '~> 0.5.5'
-  s.add_dependency 'sinatra', '~> 1.4.3'
+  s.add_dependency 'sinatra', '~> 1.4', '>= 1.4.3'
   s.add_dependency 'mustache', ['>= 0.99.4', '< 1.0.0']
   s.add_dependency 'useragent', '~> 0.8.2'
 
   s.add_development_dependency 'rack-test', '~> 0.6.2'
-  s.add_development_dependency 'shoulda', ['>= 3.4.0', '< 3.5.0']
+  s.add_development_dependency 'shoulda', '~> 3.4.0'
   s.add_development_dependency 'minitest-reporters', '~> 0.14.16'
 
   # = MANIFEST =


### PR DESCRIPTION
Adjusted the version specs on the two gems that explicitly state they are
SemVer compliant, and fixed up the one dependency that correctly _could_ have
used `~>` but didn't.
