### PR TITLE
Base upload button action on home page url

### DIFF
--- a/lib/gollum/public/gollum/javascript/gollum.js
+++ b/lib/gollum/public/gollum/javascript/gollum.js
@@ -155,7 +155,8 @@ $(document).ready(function() {
         fields: [
           {
             type:   'file',
-            context: 'Your uploaded file will be accessible at /uploads/[filename]'
+            context: 'Your uploaded file will be accessible at /uploads/[filename]',
+            action: $('.action-home-page').first().attr('href') + 'uploadFile'
           }
         ],
         OK: function( res ) {


### PR DESCRIPTION
The action for the upload button is currently fixed at '/uploadFile'. For applications where Gollum is mounted at a path other than `/` this doesn't work. This change bases the path for the action on the href of the homepage button which is `base_url` from `app.rb`. 
