### PR TITLE
Status of GitHub Wikis

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ gollum -- A wiki built on top of Git
 
 ## DESCRIPTION
 
-Gollum is a simple wiki system built on top of Git that powers GitHub Wikis.
+Gollum is a simple wiki system built on top of Git.
 
 Gollum wikis are simply Git repositories that adhere to a specific format.
 Gollum pages may be written in a variety of formats and can be edited in a


### PR DESCRIPTION
GitHub is currently running on a 2 year old version of gollum. We are actively working on updating it and will be rolling out a bunch of bugfixes this week, but gollum has changed significantly over the past two years and we can't simply adopt the latest version.

For now it will help reduce confusion for both contributors to gollum and GitHub users if we don't claim that this code powers GitHub Wikis. Maybe someday we can make that claim again, but we've got a lot of work to do between now and then.

I would suggest closing all issues that are specific to GitHub and encourage users to [contact GitHub support](https://github.com/contact) to report any issues. Here are all the existing issues that seem to be specific to GitHub.
- https://github.com/gollum/gollum/issues/759
- https://github.com/gollum/gollum/issues/238
- https://github.com/gollum/gollum/issues/123
- https://github.com/gollum/gollum/issues/666
- https://github.com/gollum/gollum/issues/759
- https://github.com/gollum/gollum/issues/752
- https://github.com/gollum/gollum/issues/618
- https://github.com/gollum/gollum/issues/587
- https://github.com/gollum/gollum/issues/520
- https://github.com/gollum/gollum/issues/471
- https://github.com/gollum/gollum/issues/468
- https://github.com/gollum/gollum/issues/451
- https://github.com/gollum/gollum/issues/420
- https://github.com/gollum/gollum/issues/288
- https://github.com/gollum/gollum/issues/280
- https://github.com/gollum/gollum/issues/236
- https://github.com/gollum/gollum/issues/224
- https://github.com/gollum/gollum/issues/175
- https://github.com/gollum/gollum/issues/96
