### PR TITLE
Fixes crash if "delete page" was selected in preview of page that being created

### DIFF
--- a/lib/gollum/app.rb
+++ b/lib/gollum/app.rb
@@ -255,7 +255,9 @@ module Precious
       name = wikip.name
       wiki = wikip.wiki
       page = wikip.page
-      wiki.delete_page(page, { :message => "Destroyed #{name} (#{page.format})" })
+      unless page.nil?
+        wiki.delete_page(page, { :message => "Destroyed #{name} (#{page.format})" })
+      end
 
       redirect to('/')
     end


### PR DESCRIPTION
Hi,

While taking gollum for a spin i have encountered a crash:

Steps to reproduce;
1. Select "new" -> "Ok"
2. Select "preview"
3. Select "Delete this Page"
4. crash on "wiki.delete_page(page, { :message => "Destroyed #{name} (#{page.format})" })"

Best Regards
