### PR TITLE
fixes crash when selected "history" in preview of page being created

### DIFF
--- a/lib/gollum/app.rb
+++ b/lib/gollum/app.rb
@@ -341,8 +341,12 @@ module Precious
     get '/history/*' do
       @page        = wiki_page(params[:splat].first).page
       @page_num    = [params[:page].to_i, 1].max
-      @versions    = @page.versions :page => @page_num
-      mustache :history
+      unless @page.nil?
+        @versions    = @page.versions :page => @page_num
+        mustache :history
+      else
+        redirect to("/")
+      end
     end
 
     post '/compare/*' do
@@ -454,6 +458,7 @@ module Precious
 
         # Extensions and layout data
         @editable = true
+        @page_exists = !page.versions.empty?
         @toc_content = wiki.universal_toc ? @page.toc_data : nil
         @mathjax  = wiki.mathjax
         @h1_title = wiki.h1_title

--- a/lib/gollum/templates/page.mustache
+++ b/lib/gollum/templates/page.mustache
@@ -30,8 +30,11 @@ Mousetrap.bind(['e'], function( e ) {
     <li class="minibutton"><a href="{{base_url}}/edit/{{escaped_url_path}}"
        class="action-edit-page">Edit</a></li>
     {{/editable}}
+    {{#page_exists}}
+    <li class="minibutton jaws">
     <li class="minibutton"><a href="{{base_url}}/history/{{escaped_url_path}}"
        class="action-page-history">History</a></li>
+    {{/page_exists}}
   </ul>
 </div>
 <div id="wiki-content">

--- a/lib/gollum/views/page.rb
+++ b/lib/gollum/views/page.rb
@@ -43,6 +43,10 @@ module Precious
         @editable
       end
 
+      def page_exists
+        @page_exists
+      end
+
       def allow_uploads
         @allow_uploads
       end


### PR DESCRIPTION
Hi,

While taking gollum for a spin i have encountered a crash 2nd:

Steps to reproduce;
1. Select "new" -> "Ok"
2. Select "preview"
3. Select "History"
4. crash on "@versions    = @page.versions :page => @page_num"

I have also removed "history" button when we are displaying preview of page that is being created as it serves no purpose.

Best Regards
