### PR TITLE
Allow for $ characters on front-end editor

### DIFF
--- a/lib/gollum/public/gollum/javascript/editor/gollum.editor.js
+++ b/lib/gollum/public/gollum/javascript/editor/gollum.editor.js
@@ -546,9 +546,12 @@
              typeof definitionObject.replace == 'string' ) {
           debug('Running replacement - using ' + definitionObject.replace);
           var rt = definitionObject.replace;
+
+          repText = escape( repText );
           repText = repText.replace( searchExp, rt );
           // remove backreferences
           repText = repText.replace( /\$[\d]/g, '' );
+          repText = unescape( repText );
 
           if ( repText === '' ) {
             debug('Search string is empty');


### PR DESCRIPTION
In the javascript editor, '$' characters were getting stomped on when
trying to remove backreferences after doing transformations on text
(Bolding, Italicizing, etc.).  This can be fixed by first escaping the
string to be transformed and then unescaping it afterwards.
