### PR TITLE
First rough attempt at a global latest changes overview.

### DIFF
--- a/lib/gollum/app.rb
+++ b/lib/gollum/app.rb
@@ -351,6 +351,13 @@ module Precious
       end
     end
 
+    get '/latest_changes' do
+      @wiki = wiki_new
+      max_count = defined?(Gollum::Wiki::MAX_COUNT) ? Gollum::Wiki::MAX_COUNT : 10
+      @versions = @wiki.latest_changes({:max_count => max_count})
+      mustache :latest_changes
+    end
+    
     post '/compare/*' do
       @file     = params[:splat].first
       @versions = params[:versions] || []

--- a/lib/gollum/templates/latest_changes.mustache
+++ b/lib/gollum/templates/latest_changes.mustache
@@ -1,0 +1,38 @@
+<div id="wiki-wrapper" class="history">
+<div id="head">
+  <h1><strong>{{title}}</strong></h1>
+  <ul class="actions">
+    <li class="minibutton"><a href="{{base_url}}/{{escaped_url_path}}"
+       class="action-view-page">Home</a></li>
+  </ul>
+</div>
+<div id="wiki-history">
+
+  <form name="compare-versions" id="version-form" method="post"
+   action="{{base_url}}/compare/{{escaped_url_path}}">
+  <fieldset>
+  <table>
+    <tbody>
+
+      {{#versions}}
+      <tr>
+        <td class="author">
+            {{>author_template}}
+        </td>
+        <td class="commit-name">
+          <span class="time-elapsed" title="{{date_full}}">{{date}}:</span>&nbsp;
+          {{message}}
+          [{{id7}}]
+        </td>
+      </tr>
+      {{/versions}}
+
+    </tbody>
+  </table>
+  </fieldset>
+  </form>
+</div>
+<div id="footer">
+
+</div>
+</div>

--- a/lib/gollum/templates/page.mustache
+++ b/lib/gollum/templates/page.mustache
@@ -34,6 +34,9 @@ Mousetrap.bind(['e'], function( e ) {
     <li class="minibutton jaws">
     <li class="minibutton"><a href="{{base_url}}/history/{{escaped_url_path}}"
        class="action-page-history">History</a></li>
+	<li class="minibutton jaws">
+    <li class="minibutton"><a href="{{base_url}}/latest_changes"
+       class="action-page-history">Latest Changes</a></li>
     {{/page_exists}}
   </ul>
 </div>

--- a/lib/gollum/views/latest_changes.rb
+++ b/lib/gollum/views/latest_changes.rb
@@ -1,0 +1,72 @@
+module Precious
+  module Views
+    class LatestChanges < Layout
+
+      attr_reader :wiki
+
+      def title
+        "Latest Changes (Globally)"
+      end
+
+      def versions
+        i = @versions.size + 1
+        @versions.map do |v|
+          i -= 1
+          { :id        => v.id,
+            :id7       => v.id[0..6],
+            :num       => i,
+            :author    => v.author.name.respond_to?(:force_encoding) ? v.author.name.force_encoding('UTF-8') : v.author.name,
+            :message   => v.message.respond_to?(:force_encoding) ? v.message.force_encoding('UTF-8') : v.message,
+            :date      => v.authored_date.strftime("%B %d, %Y"),
+            :gravatar  => Digest::MD5.hexdigest(v.author.email.strip.downcase),
+            :identicon => self._identicon_code(v.author.email),
+            :date_full => v.authored_date,
+          }
+        end
+      end
+
+      # http://stackoverflow.com/questions/9445760/bit-shifting-in-ruby
+      def left_shift int, shift
+        r = ((int & 0xFF) << (shift & 0x1F)) & 0xFFFFFFFF
+        # 1>>31, 2**32
+        (r & 2147483648) == 0 ? r : r - 4294967296
+      end
+
+      def string_to_code string
+        # sha bytes
+        b = [Digest::SHA1.hexdigest(string)[0, 20]].pack('H*').bytes.to_a
+        # Thanks donpark's IdenticonUtil.java for this.
+        # Match the following Java code
+        # ((b[0] & 0xFF) << 24) | ((b[1] & 0xFF) << 16) |
+        #	 ((b[2] & 0xFF) << 8) | (b[3] & 0xFF)
+
+        return left_shift(b[0], 24) |
+            left_shift(b[1], 16) |
+            left_shift(b[2], 8) |
+            b[3] & 0xFF
+      end
+
+      def _identicon_code(blob)
+        string_to_code blob + @request.host
+      end
+
+      def use_identicon
+        @wiki.user_icons == 'identicon'
+      end
+
+      def partial(name)
+        if name == :author_template
+          self.class.partial("history_authors/#{@wiki.user_icons}")
+        else
+          super
+        end
+      end
+
+      def previous_link
+      end
+
+      def next_link
+      end
+    end
+  end
+end

--- a/test/test_latest_changes_view.rb
+++ b/test/test_latest_changes_view.rb
@@ -1,0 +1,30 @@
+# ~*~ encoding: utf-8 ~*~
+require File.expand_path(File.join(File.dirname(__FILE__), 'helper'))
+require File.expand_path '../../lib/gollum/views/latest_changes', __FILE__
+
+context "Precious::Views::LatestChanges" do
+  include Rack::Test::Methods
+  
+  def app
+    Precious::App
+  end
+  
+  setup do
+    @path = cloned_testpath("examples/lotr.git")
+    @wiki = Gollum::Wiki.new(@path)
+    Precious::App.set(:gollum_path, @path)
+    Precious::App.set(:wiki_options, {})
+  end
+
+  test "displays_latest_changes" do
+    get('/latest_changes')
+    body = last_response.body
+    assert body.include?('<span class="username">Charles Pence</span>'), "/latest_changes should include the Author Charles Pence"
+    assert body.include?('4c45c2b'), "/latest_changes should include commit #4c45c2b"
+    assert !body.include?('4c45c2g'), "latest_changes should not include commit #4c45c2g"
+  end
+  
+  teardown do
+    FileUtils.rm_rf(@path)
+  end
+end


### PR DESCRIPTION
In response to https://github.com/gollum/gollum/issues/707. @sunny @dometto @schmunk42 @maxchill This gives a very basic overview of the latest changes in the wiki / git repo (based on the history view). There's no view (yet) to inspect the commits, but the table does give an impression of activity. Please see this as a first proposal to be worked (but not necessarily by me). I would welcome PRs that improve on this code.
