### PR TITLE
Disqus comment support added to gollum

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ run Precious::App
 
 Your Rack middleware can pass author details to Gollum in a Hash in the session under the 'gollum.author' key.
 
+Your gollum app can have Disqus based commenting support. Fill `set :disqus_shortname, 'your_disqus_shortname'` in lib/gollum/app.rb with your disqus shortname.
+
 ## CONFIG FILE
 
 Gollum optionally takes a `--config file`. See [config.rb](https://github.com/gollum/gollum/blob/master/config.rb) for an example.

--- a/lib/gollum/app.rb
+++ b/lib/gollum/app.rb
@@ -63,6 +63,7 @@ module Precious
     set :public_folder, "#{dir}/public/gollum"
     set :static, true
     set :default_markup, :markdown
+    set :disqus_shortname, '' # enter your forum shortname in '' to enable diqus or leave just like this to ignore disqus
 
     set :mustache, {
         # Tell mustache where the Views constant lives

--- a/lib/gollum/templates/disqus.mustache
+++ b/lib/gollum/templates/disqus.mustache
@@ -1,0 +1,18 @@
+{{#has_disqus}}
+<div id="disqus">
+   <div id="disqus_thread"></div>
+    <script type="text/javascript">
+        /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
+        var disqus_shortname = '{{{disqus_shortname}}}'; // required: replace example with your forum shortname
+
+        /* * * DON'T EDIT BELOW THIS LINE * * */
+        (function() {
+            var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
+            dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
+            (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+        })();
+    </script>
+    <noscript>Please enable JavaScript to view the <a href="http://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
+    <a href="http://disqus.com" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a>
+</div>
+{{/has_disqus}}

--- a/lib/gollum/templates/page.mustache
+++ b/lib/gollum/templates/page.mustache
@@ -63,6 +63,7 @@ Mousetrap.bind(['e'], function( e ) {
       {{{content}}}
     </div>
   </div>
+
   {{#has_footer}}
   <div id="wiki-footer" class="gollum-{{footer_format}}-content">
     <div id="footer-content" class="markdown-body">
@@ -73,6 +74,9 @@ Mousetrap.bind(['e'], function( e ) {
   </div>
 
 </div>
+
+{{> disqus}}
+
 <div id="footer">
   <p id="last-edit">Last edited by <b>{{author}}</b>, {{date}}</p>
   <p>

--- a/lib/gollum/views/page.rb
+++ b/lib/gollum/views/page.rb
@@ -68,6 +68,14 @@ module Precious
         has_header && @header.format.to_s
       end
 
+      def has_disqus
+        Precious::App.settings.respond_to?(:disqus_shortname) && !Precious::App.settings.disqus_shortname.empty?
+      end
+ 
+      def disqus_shortname
+        Precious::App.settings.disqus_shortname
+      end
+
       def has_footer
         @footer = (@page.footer || false) if @footer.nil?
         !!@footer


### PR DESCRIPTION
The enables a user to use Disqus comment support.
- if the setting `set :disqus_shortname, ''` is left blank in `lib/gollum/app.rb`. It does nothing.
- when it is filled with your disqus shortname, your pages gets disqus comment support.
