### PR TITLE
Fix MathJax CDN URL

### DIFF
--- a/lib/gollum/templates/layout.mustache
+++ b/lib/gollum/templates/layout.mustache
@@ -42,7 +42,7 @@
   </script>
   <script>(function(d,j){
   j = d.createElement('script');
-  j.src = 'https://c328740.ssl.cf1.rackcdn.com/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML';
+  j.src = '//cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML';
   (d.head || d.getElementsByTagName('head')[0]).appendChild(j);
   }(document));
   </script>{{/mathjax}}


### PR DESCRIPTION
According to the [MathJax Blog](http://www.mathjax.org/changes-to-the-mathjax-cdn/), MathJax will retire the `rackcdn` CDN address at the end of this month. Updated the layout to use the new CDN URL, and also made it so that the URL is HTTP/HTTPS agnostic, following the [MathJax docs](http://docs.mathjax.org/en/latest/start.html#secure-access-to-the-cdn).
