### PR TITLE
Disable live preview on mobile/Android devices

### DIFF
--- a/lib/gollum/app.rb
+++ b/lib/gollum/app.rb
@@ -56,6 +56,7 @@ module Precious
 
     def supported_useragent?(user_agent)
       ua = UserAgent.parse(user_agent)
+      return false if ["Android", "Mobile"].include? ua.platform
       @@min_ua.detect { |min| ua >= min }
     end
 


### PR DESCRIPTION
The live editor behaves badly with mobile keyboards in that it inserts each
modification of the current word as a new word, e.g. when writing "Tea", what
will be written in the document is something like "TTeTea", getting even worse
when deleting characters afterwards, as a backspace will result in the total
result "TTeTeaTe".

Furthermore, if working in the more phone-like portrait mode, the horizontal
space is far too small for the two panes.
