### PR TITLE
Run gollum via docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
-# TODO:
-# * git-push via cron should be done from different container
+# Build as:
+#   docker build -t gollum .
+# Run as:
+#   docker run --rm -p 4567:4567 -v ~/mywiki:/data gollum
 
 FROM google/ruby
 
@@ -17,9 +19,7 @@ RUN bundle install
 ADD . /app
 RUN bundle install
 
-# Mount the git repo as /data volume
 VOLUME /data
-EXPOSE 4567
 ENV BUNDLE_GEMFILE /app/Gemfile
 WORKDIR /data
-CMD ["bundle", "exec", "gollum"]
+ENTRYPOINT ["bundle", "exec", "gollum"]


### PR DESCRIPTION
Docker is increasingly becoming a popular tool of choice among the devops community. Running gollum is now much simpler using docker. This PR contains the Dockerfile to build a gollum docker image. I suggest the maintainers to create an automated (trusted) build in Docker Hub, possibly building off release tags instead of git master, thereby providing users of this simpler deployment method, which is essentially an one-line command on any machine with docker installed:

```
docker run -p 4567:4567 -v ~/mywiki:/data gollum
```

I can squash the commits if this PR will be merged.
