### PR TITLE
Update --allow-uploads help text in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Options:
         --ref [REF]                  Specify the repository ref to use (default: master).
         --no-live-preview            Disables livepreview.
         --live-preview               Enables livepreview.
-        --allow-uploads              Allows file uploads.
+        --allow-uploads [MODE]       Allows file uploads. Modes: dir (default, store all uploads in the same directory), page (store each upload at the same location as the page).
         --mathjax                    Enables mathjax.
         --user-icons [SOURCE]        Set the history user icons. Valid values: gravatar, identicon, none. Default: none.
         --show-all                   Shows all files in file view. By default only valid pages are shown.


### PR DESCRIPTION
Update output from `gollum --help` in README to add info for the new `[MODE]` flag to `--allow-uploads`.
