### PR TITLE
Use backtick for inline code and rename ASCIIDoc by AsciiDoc

### DIFF
--- a/lib/gollum/public/gollum/javascript/editor/langs/asciidoc.js
+++ b/lib/gollum/public/gollum/javascript/editor/langs/asciidoc.js
@@ -1,11 +1,11 @@
 /**
- *  ASCIIDoc Language Definition
+ *  AsciiDoc Language Definition
  *
  */
 
 (function($) {
 
-var ASCIIDoc = {
+var AsciiDoc = {
 
   'function-bold' :         {
                               search: /(^[\n]+)([\n\s]*)/g,
@@ -102,20 +102,20 @@ var ASCIIDoc = {
 
 };
 
-$.GollumEditor.defineLanguage('asciidoc', ASCIIDoc);
+$.GollumEditor.defineLanguage('asciidoc', AsciiDoc);
 
 
-var ASCIIDocHelp = [
+var AsciiDocHelp = [
   {
     menuName: 'Text Formatting',
     content: [
       {
         menuName: 'Headers',
-        data: '<p>ASCIIDoc headers can be written in two ways: with differing underlines or with different indentation using <code>=</code> (equals sign). ASCIIDoc supports headings 1-4. The editor will automatically use the <code>=</code> notation. To create a level one header, prefix your line with one <code>=</code>. Level two headers are created with <code>==</code> and so on.</p>'
+        data: '<p>AsciiDoc headers can be written in two ways: with differing underlines or with different indentation using <code>=</code> (equals sign). AsciiDoc supports headings 1-4. The editor will automatically use the <code>=</code> notation. To create a level one header, prefix your line with one <code>=</code>. Level two headers are created with <code>==</code> and so on.</p>'
       },
       {
         menuName: 'Bold / Italic',
-        data: '<p>To display text as <strong>bold</strong>, wrap the text in <code>*</code> (asterisks). To display text as <em>italic</em>, wrap the text in <code>_</code> (underscores). To create <code>monospace</code> text, wrap the text in <code>+</code> (plus signs).'
+        data: '<p>To display text as <strong>bold</strong>, wrap the text in <code>*</code> (asterisks). To display text as <em>italic</em>, wrap the text in <code>_</code> (underscores). To create <code>monospace</code> text, wrap the text in <code>`</code> (backtick).'
       },
       {
         menuName: 'Scripts',
@@ -123,7 +123,7 @@ var ASCIIDocHelp = [
       },
       {
         menuName: 'Special Characters',
-        data: '<p>ASCIIDoc will automatically convert textual representations of commonly-used special characters. For example, <code>(R)</code> becomes &reg;, <code>(C)</code> becomes &copy; and <code>(TM)</code> becomes &trade;.</p>'
+        data: '<p>AsciiDoc will automatically convert textual representations of commonly-used special characters. For example, <code>(R)</code> becomes &reg;, <code>(C)</code> becomes &copy; and <code>(TM)</code> becomes &trade;.</p>'
       }
     ]
   },
@@ -132,7 +132,7 @@ var ASCIIDocHelp = [
     content: [
       {
         menuName: 'Paragraphs',
-        data: '<p>ASCIIDoc allows paragraphs to have optional titles or icons to denote special sections. To make a normal paragraph, simply add a line between blocks and a new paragraph will start. If you want to title your paragraphs, adda line prefixed by <code>.</code> (full stop). An example paragraph with optional title is displayed below:<br><br><code>.Optional Title<br><br>This is my paragraph. It is two sentences long.</code></p>'
+        data: '<p>AsciiDoc allows paragraphs to have optional titles or icons to denote special sections. To make a normal paragraph, simply add a line between blocks and a new paragraph will start. If you want to title your paragraphs, adda line prefixed by <code>.</code> (full stop). An example paragraph with optional title is displayed below:<br><br><code>.Optional Title<br><br>This is my paragraph. It is two sentences long.</code></p>'
       },
       {
         menuName: 'Source Blocks',
@@ -157,12 +157,12 @@ var ASCIIDocHelp = [
       },
       {
         menuName: 'Images',
-        data: '<p>Images in ASCIIDoc work much like hyperlinks, but image URLs are prefixed with <code>image:</code>. For example, to link to an image at <code>images/icons/home.png</code>, write <code>image:images/icons/home.png</code>. Alt text can be added by appending the text to the URI in <code>[</code> (brackets).</p>'
+        data: '<p>Images in AsciiDoc work much like hyperlinks, but image URLs are prefixed with <code>image:</code>. For example, to link to an image at <code>images/icons/home.png</code>, write <code>image:images/icons/home.png</code>. Alt text can be added by appending the text to the URI in <code>[</code> (brackets).</p>'
       }
     ]
   }
 ];
 
-$.GollumEditor.defineHelp('asciidoc', ASCIIDocHelp);
+$.GollumEditor.defineHelp('asciidoc', AsciiDocHelp);
 
 })(jQuery);


### PR DESCRIPTION
Asciidoctor 1.5.0 is now using backtick for inline code. Update the documentation accordingly and rename ASCIIDoc by AsciiDoc.
