### PR TITLE
Add function to disable editing, resolves #879

### DIFF
--- a/bin/gollum
+++ b/bin/gollum
@@ -22,6 +22,7 @@ options      = { 'port' => 4567, 'bind' => '0.0.0.0' }
 wiki_options = {
     :live_preview  => false,
     :allow_uploads => false,
+    :allow_editing => true,
 }
 
 opts = OptionParser.new do |opts|
@@ -74,6 +75,10 @@ opts = OptionParser.new do |opts|
 
   opts.on("--ref [REF]", "Specify the repository ref to use (default: master).") do |ref|
     wiki_options[:ref] = ref
+  end
+
+  opts.on("--no-edit", "Restricts editing capability through frontend.")  do
+    wiki_options[:allow_editing] = false
   end
 
   opts.on("--no-live-preview", "Disables livepreview.") do

--- a/lib/gollum/app.rb
+++ b/lib/gollum/app.rb
@@ -13,6 +13,8 @@ require 'gollum/views/has_page'
 
 require File.expand_path '../helpers', __FILE__
 
+require 'gollum/editing_auth'
+
 #required to upload bigger binary files
 Gollum::set_git_timeout(120)
 Gollum::set_git_max_filesize(190 * 10**6)
@@ -42,6 +44,7 @@ module Precious
   class App < Sinatra::Base
     register Mustache::Sinatra
     include Precious::Helpers
+    use Precious::EditingAuth
 
     dir     = File.dirname(File.expand_path(__FILE__))
 
@@ -92,6 +95,7 @@ module Precious
       @css = settings.wiki_options[:css]
       @js  = settings.wiki_options[:js]
       @mathjax_config = settings.wiki_options[:mathjax_config]
+      @allow_editing = settings.wiki_options[:allow_editing]
     end
 
     get '/' do
@@ -106,7 +110,6 @@ module Precious
     # name, path, version
     def wiki_page(name, path = nil, version = nil, exact = true)
       wiki = wiki_new
-
       path = name if path.nil?
       name = extract_name(name) || wiki.index_page
       path = extract_path(path)
@@ -127,6 +130,7 @@ module Precious
     end
 
     get '/edit/*' do
+      block_editing unless @allow_editing
       wikip = wiki_page(params[:splat].first)
       @name = wikip.name
       @path = wikip.path
@@ -252,6 +256,7 @@ module Precious
     end
 
     get '/delete/*' do
+      block_editing unless @allow_editing
       wikip = wiki_page(params[:splat].first)
       name  = wikip.name
       wiki  = wikip.wiki
@@ -264,6 +269,7 @@ module Precious
     end
 
     get '/create/*' do
+      block_editing unless @allow_editing
       wikip = wiki_page(params[:splat].first.gsub('+', '-'))
       @name = wikip.name.to_url
       @path = wikip.path
@@ -477,6 +483,11 @@ module Precious
           file.raw_data
         end
       else
+        unless @allow_editing
+          @message = "The page you are looking is not exist."
+          status 404
+          return mustache :error
+        end
         page_path = [path, name].compact.join('/')
         redirect to("/create/#{clean_url(encodeURIComponent(page_path))}")
       end
@@ -489,6 +500,13 @@ module Precious
       format  = (format || page.format).to_sym
       content ||= page.raw_data
       wiki.update_page(page, name, format, content.to_s, commit)
+    end
+
+    def block_editing
+      # Block some GET pages that is making editing or unnecessary when editing is disabled.
+      @message = "You can't do it. Editing is disabled."
+      status 403
+      halt mustache :error
     end
 
     private

--- a/lib/gollum/editing_auth.rb
+++ b/lib/gollum/editing_auth.rb
@@ -1,0 +1,34 @@
+module Precious
+  class EditingAuth  < Sinatra::Base
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      @env = env
+      # Blocks all potentially editable pages. Use EditingAuth::whitelist_pages to unblock pages.
+      unless (env["REQUEST_METHOD"] == "GET") || App::settings.wiki_options[:allow_editing]
+        return block unless excluded_page?
+      end
+      @app.call(env)
+    end
+
+    def block
+      [403, {'Content-Type' => 'text/html', 'Content-Length' => '9'}, ['Forbidden']]
+    end
+
+    def excluded_page?
+      return false if env["REQUEST_PATH"].nil?
+      whitelist_pages.any? do |whitelisted_page|
+        env["REQUEST_PATH"].include? whitelisted_page
+      end
+    end
+
+  private
+    # List pages paths as str that you want to whitelist.
+    # Pages will be compared with env["REQUEST_PATH"] using String::include? method.
+    def whitelist_pages
+      return ["/compare/"]
+    end
+  end
+end

--- a/lib/gollum/templates/compare.mustache
+++ b/lib/gollum/templates/compare.mustache
@@ -8,8 +8,10 @@
     </li>
     <li class="minibutton"><a href="{{base_url}}/{{escaped_url_path}}"
        class="action-view-page">View Page</a></li>
-    <li class="minibutton"><a href="{{base_url}}/edit/{{escaped_url_path}}"
-       class="action-edit-page">Edit Page</a></li>
+    {{#allow_editing}}
+      <li class="minibutton"><a href="{{base_url}}/edit/{{escaped_url_path}}"
+         class="action-edit-page">Edit Page</a></li>
+    {{/allow_editing}}
     <li class="minibutton"><a href="{{base_url}}/history/{{escaped_url_path}}"
        class="action-page-history">Page History</a></li>
   </ul>
@@ -25,11 +27,13 @@
   <ul class="actions">
     <li class="minibutton"><a href="{{base_url}}/history/{{escaped_url_path}}"
        class="action-page-history">Back to Page History</a></li>
-    <li class="minibutton">
-      <form name="gollum-revert" action="{{base_url}}/revert/{{escaped_url_path}}/{{before}}/{{after}}" method="post" id="gollum-revert-form">
-      <a href="#" class="gollum-revert-button">Revert Changes</a>
-      </form>
-    </li>
+    {{#allow_editing}}
+      <li class="minibutton">
+        <form name="gollum-revert" action="{{base_url}}/revert/{{escaped_url_path}}/{{before}}/{{after}}" method="post" id="gollum-revert-form">
+        <a href="#" class="gollum-revert-button">Revert Changes</a>
+        </form>
+      </li>
+    {{/allow_editing}}
   </ul>
   {{/show_revert}}
 
@@ -52,9 +56,11 @@
     <li class="minibutton"><a href="{{base_url}}/history/{{escaped_url_path}}"
        class="action-page-history">Back to Page History</a></li>
     {{#show_revert}}
-    <li class="minibutton">
-      <a href="#" class="gollum-revert-button">Revert Changes</a>
-    </li>
+    {{#allow_editing}}
+      <li class="minibutton">
+        <a href="#" class="gollum-revert-button">Revert Changes</a>
+      </li>
+    {{/allow_editing}}
     {{/show_revert}}
     <li class="minibutton"><a href="#">Back to Top</a></li>
   </ul>

--- a/lib/gollum/templates/history.mustache
+++ b/lib/gollum/templates/history.mustache
@@ -7,8 +7,10 @@
     </li>
     <li class="minibutton"><a href="{{base_url}}/{{escaped_url_path}}"
        class="action-view-page">View Page</a></li>
-    <li class="minibutton"><a href="{{base_url}}/edit/{{escaped_url_path}}"
-       class="action-edit-page">Edit Page</a></li>
+    {{#allow_editing}}
+      <li class="minibutton"><a href="{{base_url}}/edit/{{escaped_url_path}}"
+         class="action-edit-page">Edit Page</a></li>
+    {{/allow_editing}}
   </ul>
 </div>
 <div id="wiki-history">

--- a/lib/gollum/templates/page.mustache
+++ b/lib/gollum/templates/page.mustache
@@ -18,18 +18,28 @@ Mousetrap.bind(['e'], function( e ) {
       class="action-all-pages">All</a></li>
     <li class="minibutton"><a href="{{base_url}}/fileview"
     class="action-fileview">Files</a></li>
-    <li class="minibutton jaws">
-      <a href="#" id="minibutton-new-page">New</a></li>
-    {{#allow_uploads}}
-    <li class="minibutton jaws">
-      <a href="#" id="minibutton-upload-page">Upload</a></li>
-    {{/allow_uploads}}
-    {{#editable}}
-    <li class="minibutton jaws">
-      <a href="#" id="minibutton-rename-page">Rename</a></li>
-    <li class="minibutton"><a href="{{base_url}}/edit/{{escaped_url_path}}"
-       class="action-edit-page">Edit</a></li>
-    {{/editable}}
+    {{#allow_editing}}
+      <li class="minibutton jaws">
+        <a href="#" id="minibutton-new-page">New</a></li>
+    {{/allow_editing}}
+    {{#allow_editing}}
+      {{#allow_uploads}}
+      <li class="minibutton jaws">
+        <a href="#" id="minibutton-upload-page">Upload</a></li>
+      {{/allow_uploads}}
+    {{/allow_editing}}
+    {{#allow_editing}}
+      {{#editable}}
+        <li class="minibutton jaws">
+          <a href="#" id="minibutton-rename-page">Rename</a></li>
+      {{/editable}}
+    {{/allow_editing}}
+    {{#allow_editing}}
+      {{#editable}}
+        <li class="minibutton"><a href="{{base_url}}/edit/{{escaped_url_path}}"
+           class="action-edit-page">Edit</a></li>
+      {{/editable}}
+    {{/allow_editing}}
     {{#page_exists}}
     <li class="minibutton jaws">
     <li class="minibutton"><a href="{{base_url}}/history/{{escaped_url_path}}"
@@ -75,9 +85,11 @@ Mousetrap.bind(['e'], function( e ) {
 </div>
 <div id="footer">
   <p id="last-edit">Last edited by <b>{{author}}</b>, {{date}}</p>
-  <p>
-    <a id="delete-link" href="{{base_url}}/{{escaped_url_path}}" data-confirm="Are you sure you want to delete this page?"><span>Delete this Page</span></a>
-  </p>
+  {{#allow_editing}}
+    <p>
+      <a id="delete-link" href="{{base_url}}/{{escaped_url_path}}" data-confirm="Are you sure you want to delete this page?"><span>Delete this Page</span></a>
+    </p>
+  {{/allow_editing}}
 </div>
 </div>
 

--- a/lib/gollum/templates/pages.mustache
+++ b/lib/gollum/templates/pages.mustache
@@ -7,9 +7,10 @@
     </li>
     <li class="minibutton"><a href="{{base_url}}/"
        class="action-home-page">Home</a></li>
-    <li class="minibutton jaws">
-    <a href="#" id="minibutton-new-page">New</a>
-    </li>
+    {{#allow_editing}}
+      <li class="minibutton jaws">
+      <a href="#" id="minibutton-new-page">New</a></li>
+    {{/allow_editing}}
   </ul>
 </div>
 <div id="pages">

--- a/lib/gollum/views/compare.rb
+++ b/lib/gollum/views/compare.rb
@@ -3,7 +3,7 @@ module Precious
     class Compare < Layout
       include HasPage
 
-      attr_reader :page, :diff, :versions, :message
+      attr_reader :page, :diff, :versions, :message, :allow_editing
 
       def title
         "Comparison of #{@page.title}"

--- a/lib/gollum/views/history.rb
+++ b/lib/gollum/views/history.rb
@@ -3,7 +3,7 @@ module Precious
     class History < Layout
       include HasPage
 
-      attr_reader :page, :page_num
+      attr_reader :page, :page_num, :allow_editing
 
       def title
         @page.title

--- a/lib/gollum/views/page.rb
+++ b/lib/gollum/views/page.rb
@@ -47,6 +47,10 @@ module Precious
         @page_exists
       end
 
+      def allow_editing
+        @allow_editing
+      end
+
       def allow_uploads
         @allow_uploads
       end

--- a/lib/gollum/views/pages.rb
+++ b/lib/gollum/views/pages.rb
@@ -3,7 +3,7 @@ require "pathname"
 module Precious
   module Views
     class Pages < Layout
-      attr_reader :results, :ref
+      attr_reader :results, :ref, :allow_editing
 
       def title
         "All pages in #{@ref}"

--- a/test/test_allow_editing.rb
+++ b/test/test_allow_editing.rb
@@ -1,0 +1,80 @@
+# ~*~ encoding: utf-8 ~*~
+require File.expand_path(File.join(File.dirname(__FILE__), 'helper'))
+
+context "Precious::Views::Editing" do
+  include Rack::Test::Methods
+  setup do
+    examples = testpath "examples"
+    @path    = File.join(examples, "test.git")
+    Precious::App.set(:gollum_path, @path)
+    FileUtils.cp_r File.join(examples, "revert.git"), @path, :remove_destination => true
+    @wiki = Gollum::Wiki.new(@path)
+  end
+
+  teardown do
+    FileUtils.rm_r(File.join(File.dirname(__FILE__), *%w[examples test.git]))
+  end
+
+  test "creating page is blocked" do
+    Precious::App.set(:wiki_options, { allow_editing: false})
+    post "/create", :content => 'abc', :page => "D",
+         :format             => 'markdown', :message => 'def'
+    assert !last_response.ok?
+
+    page = @wiki.page('D')
+    assert page.nil?
+  end
+
+
+  test "frontend links for editing are not blocked" do
+    Precious::App.set(:wiki_options, { allow_editing: true, allow_uploads: true })
+    get '/A'
+
+    assert_match /Delete this Page/, last_response.body, "'Delete this Page' link is blocked in page template"
+    assert_match /New/,              last_response.body, "'New' button is blocked in page template"
+    assert_match /Upload/,           last_response.body, "'Upload' link is blocked in page template"
+    assert_match /Rename/,           last_response.body, "'Rename' link is blocked in page template"
+    assert_match /Edit/,             last_response.body, "'Edit' link is blocked in page template"
+
+    get '/pages'
+
+    assert_match /New/, last_response.body, "'New' link is blocked in pages template"
+
+    get '/history/A'
+
+    assert_match /Edit/, last_response.body, "'Edit' link is blocked in history template"
+
+    get '/compare/A/fc66539528eb96f21b2bbdbf557788fe8a1196ac..b26b791cb7917c4f37dd9cb4d1e0efb24ac4d26f'
+
+    assert_match /Edit Page/,             last_response.body, "'Edit Page' link is blocked in compare template"
+    assert_match /Revert Changes/,        last_response.body, "'Revert Changes' link is blocked in compare template"
+  end
+
+  test "frontend links for editing blocked" do
+    Precious::App.set(:wiki_options, { allow_editing: false })
+    get '/A'
+
+    assert_no_match /Delete this Page/, last_response.body, "'Delete this Page' link not blocked in page template"
+    assert_no_match /New/,              last_response.body, "'New' button not blocked in page template"
+    assert_no_match /Upload/,           last_response.body, "'Upload' link not blocked in page template"
+    assert_no_match /Rename/,           last_response.body, "'Rename' link not blocked in page template"
+    assert_no_match /Edit/,             last_response.body, "'Edit' link not blocked in page template"
+
+    get '/pages'
+
+    assert_no_match /New/, last_response.body, "'New' link not blocked in pages template"
+
+    get '/history/A'
+
+    assert_no_match /Edit/, last_response.body, "'Edit' link not blocked in history template"
+
+    get '/compare/A/fc66539528eb96f21b2bbdbf557788fe8a1196ac..b26b791cb7917c4f37dd9cb4d1e0efb24ac4d26f'
+
+    assert_no_match /Edit Page/,             last_response.body, "'Edit Page' link not blocked in compare template"
+    assert_no_match /Revert Changes/,        last_response.body, "'Revert Changes' link not blocked in compare template"
+  end
+
+  def app
+    Precious::App
+  end
+end

--- a/test/test_app.rb
+++ b/test/test_app.rb
@@ -8,7 +8,7 @@ context "Frontend" do
     @path = cloned_testpath("examples/revert.git")
     @wiki = Gollum::Wiki.new(@path)
     Precious::App.set(:gollum_path, @path)
-    Precious::App.set(:wiki_options, {})
+    Precious::App.set(:wiki_options, {allow_editing: true})
   end
 
   teardown do


### PR DESCRIPTION
It works like next.
If editing is blocked all requests except GET is blocked as 403 HTTP CODE with message 'Forbidden'.

```
unless (env["REQUEST_METHOD"] == "GET") || App::settings.wiki_options[:allow_editing]
    return [403, {'Content-Type' => 'text/html', 'Content-Length' => '9'}, ['Forbidden']]
end
```

If editing is blocked and user try to access not existing page, app as alternative to redirect to creation page shown error page with message that says "The page doesn't exist"

```
def show_page_or_file(fullpath)
...#loooking if page exist etc.
else #until page not found and then
    unless @allow_editing
        @message = "The page you are looking is not exist."
        status 404
        return mustache :error
    end #so it's shown clear answer for user who is get lost
    page_path = [path, name].compact.join('/')
    redirect to("/create/#{clean_url(encodeURIComponent(page_path))}")
end
```

Also it's blocking other get requests that is unnecessary when editing blocked.

```
@message = "You can't do it. Editing is disabled."
status 403
halt mustache :error

#so for those who used CRUD would receive nice error
```
