### PR TITLE
Implement git adapter CLI flag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Options:
         --host [HOST]                Hostname or IP address to listen on (default 0.0.0.0).
         --version                    Display current version.
         --config [CONFIG]            Path to additional configuration file
+        --adapter [ADAPTER]          Git adapter to use in the backend. Defaults to grit.
         --irb                        Start an irb process with gollum loaded for the current wiki.
         --css                        Inject custom css. Uses custom.css from root repository
         --js                         Inject custom js. Uses custom.js from root repository

--- a/bin/gollum
+++ b/bin/gollum
@@ -45,6 +45,10 @@ opts = OptionParser.new do |opts|
     options['config'] = config
   end
 
+  opts.on("--adapter [ADAPTER]", "Git adapter to use in the backend. Defaults to grit.") do |adapter|
+    Gollum::GIT_ADAPTER = adapter
+  end
+
   opts.on("--irb", "Start an irb process with gollum loaded for the current wiki.") do
     options['irb'] = true
   end


### PR DESCRIPTION
CLI option to specify which adapter should be used by `gollum-lib`.
