### PR TITLE
feature / 629 breadcrumbs

### DIFF
--- a/lib/gollum/public/gollum/css/gollum.css
+++ b/lib/gollum/public/gollum/css/gollum.css
@@ -839,11 +839,16 @@ ul.actions {
     background-image: url(../images/fileview/folder-horizontal.png);
 }
 
-#pages .breadcrumb {
+#pages .breadcrumb, #wiki-content .breadcrumb {
   border-top: 1px solid #ddd;
   border-bottom: 1px solid #ddd;
   margin: 1em 0;
   padding: 0.25em;
+}
+
+#wiki-content .breadcrumb {
+  border-top: none;
+  margin-top: 0;
 }
 
 .clearfloats {

--- a/lib/gollum/templates/page.mustache
+++ b/lib/gollum/templates/page.mustache
@@ -37,6 +37,9 @@ Mousetrap.bind(['e'], function( e ) {
     {{/page_exists}}
   </ul>
 </div>
+<div class="breadcrumb">
+  {{{breadcrumb}}}
+</div>
 <div id="wiki-content">
 <div class="{{#has_header}}has-header{{/has_header}}{{#has_footer}} has-footer{{/has_footer}}{{#has_sidebar}} has-sidebar has-{{bar_side}}bar{{/has_sidebar}}{{#has_toc}} has-toc{{/has_toc}}">
   {{#has_toc}}

--- a/lib/gollum/templates/page.mustache
+++ b/lib/gollum/templates/page.mustache
@@ -37,10 +37,10 @@ Mousetrap.bind(['e'], function( e ) {
     {{/page_exists}}
   </ul>
 </div>
+<div id="wiki-content">
 <div class="breadcrumb">
   {{{breadcrumb}}}
 </div>
-<div id="wiki-content">
 <div class="{{#has_header}}has-header{{/has_header}}{{#has_footer}} has-footer{{/has_footer}}{{#has_sidebar}} has-sidebar has-{{bar_side}}bar{{/has_sidebar}}{{#has_toc}} has-toc{{/has_toc}}">
   {{#has_toc}}
   <div id="wiki-toc-main">

--- a/lib/gollum/views/page.rb
+++ b/lib/gollum/views/page.rb
@@ -18,7 +18,7 @@ module Precious
       def breadcrumb
         # Not sure exactly why @path is not available here
         path       = Pathname.new(@page.path)
-        breadcrumb = [%{<a href="#{@base_url}/">Home</a>}]
+        breadcrumb = [%{<a href="#{@base_url}/">home</a>}]
         path.descend do |crumb|
           title = crumb.basename
 

--- a/lib/gollum/views/page.rb
+++ b/lib/gollum/views/page.rb
@@ -1,3 +1,5 @@
+require "pathname"
+
 module Precious
   module Views
     class Page < Layout
@@ -11,6 +13,25 @@ module Precious
       def title
         h1 = @h1_title ? page_header_from_content(@content) : false
         h1 || @page.url_path_title
+      end
+
+      def breadcrumb
+        # Not sure exactly why @path is not available here
+        path       = Pathname.new(@page.path)
+        breadcrumb = [%{<a href="#{@base_url}/">Home</a>}]
+        path.descend do |crumb|
+          title = crumb.basename
+
+          # We reached the end of the trail
+          if title == path.basename
+            # Split the extension from the filename, it looks better!
+            breadcrumb << path.basename(path.extname)
+          else
+            breadcrumb << %{<a href="#{@base_url}/#{crumb}">#{title}</a>}
+          end
+        end
+
+        breadcrumb.join(" / ")
       end
 
       def page_header

--- a/lib/gollum/views/page.rb
+++ b/lib/gollum/views/page.rb
@@ -18,7 +18,11 @@ module Precious
       def breadcrumb
         # Not sure exactly why @path is not available here
         path       = Pathname.new(@page.path)
-        breadcrumb = [%{<a href="#{@base_url}/">home</a>}]
+
+        # Always expose a link to the root of the wiki
+        breadcrumb = [%{<a href="#{@base_url}/">root</a>}]
+
+        # Then for each directory, add a crumb
         path.descend do |crumb|
           title = crumb.basename
 


### PR DESCRIPTION
Proposal to fix issue #629 

It adds a breadcrumb, based on the one from "all pages", to every wiki document. I'm not too fan of the css styling I've made, but I'm unsure how we'd like the breadcrumbs to look like. Suggestions are welcome!

I'm not a ruby developer, so you may want to double check the implementation. Also, I could not find how to run the tests. Apparently my rake version is out of date, but it's the system rake, so I'm afraid of breaking stuff if I change it.
