### PR TITLE
Update test to avoid being dependent on git configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,3 @@ rvm:
 before_install:
  - sudo apt-get update
  - sudo apt-get install libicu-dev
- - git config --global --add diff.renames copies

--- a/test/test_latest_changes_view.rb
+++ b/test/test_latest_changes_view.rb
@@ -24,11 +24,11 @@ context "Precious::Views::LatestChanges" do
     assert !body.include?('0ed8cbe'), "/latest_changes should not include more than latest_changes_count commits"
     assert body.include?('<a href="Data-Two.csv/874f597a5659b4c3b153674ea04e406ff393975e">Data-Two.csv</a>'), "/latest_changes include links to modified files in #{body}"
     assert body.include?('<a href="Hobbit/874f597a5659b4c3b153674ea04e406ff393975e">Hobbit.md</a>'), "/latest_changes should include links to modified pages in #{body}"
-    assert body.include?('<a href="My-Precious/60f12f4254f58801b9ee7db7bca5fa8aeefaa56b">My-&lt;b&gt;Precious.md =&gt; My-Precious.md</a>'), "/latest_changes should indicate renaming action in #{body}"
   end
 
   test "extract destination file name in case of path renaming" do
     view = Precious::Views::LatestChanges.new
+    assert_equal "newname.md", view.extract_renamed_path_destination("oldname.md => newname.md")
     assert_equal "newDirectoryName/fileName.md", view.extract_renamed_path_destination("{oldDirectoryName => newDirectoryName}/fileName.md")
   end
 


### PR DESCRIPTION
The previous test implementation was dependent on the git configuration:
    renames = copies

It could then pass on a computer with that config but not passe on
a different developer computer who could have a different git configuration.

That new implementation is testing the same behaviour but at a lower
level and is not dependent on the git configuration anymore.
