### PR TITLE
Fix wiki_options errors for hosted Gollum instances

### DIFF
--- a/lib/gollum/editing_auth.rb
+++ b/lib/gollum/editing_auth.rb
@@ -7,7 +7,7 @@ module Precious
     def call(env)
       @env = env
       # Blocks all potentially editable pages. Use EditingAuth::whitelist_pages to unblock pages.
-      unless (env["REQUEST_METHOD"] == "GET") || App::settings.wiki_options[:allow_editing]
+      unless (env["REQUEST_METHOD"] == "GET") || @app.settings.wiki_options[:allow_editing]
         return block unless excluded_page?
       end
       @app.call(env)


### PR DESCRIPTION
While running a Gollum instance hosted inside another Sinatra app, whenever I went to edit a page I'd see the following in my logs:

``` text
ERROR -- : app error: undefined method `wiki_options' for Precious::App:Class (NoMethodError)
ERROR -- : /home/gollum/production/releases/20141229-172128/vendor/bundle/ruby/2.0.0/gems/gollum-3.1.1.1anchor4/lib/gollum/editing_auth.rb:10:in `call'
ERROR -- : /home/gollum/production/releases/20141229-172128/vendor/bundle/ruby/2.0.0/gems/rack-protection-1.5.3/lib/rack/protection/xss_header.rb:18:in `call'
...
```

I suspect this is the case for Sinatra applications that host instances of Gollum using its `map` feature, as this reflects the production setup we're using it in. Calling @app.settings.wiki_options uses the app instance that gets passed into Precious::EditingAuth, thereby ensuring that we're getting a Gollum instance all the time.
