### PR TITLE
Encode the page title in the URL of a diff page

### DIFF
--- a/lib/gollum/app.rb
+++ b/lib/gollum/app.rb
@@ -372,7 +372,7 @@ module Precious
     end
     
     post '/compare/*' do
-      @file     = params[:splat].first
+      @file     = encodeURIComponent(params[:splat].first)
       @versions = params[:versions] || []
       if @versions.size < 2
         redirect to("/history/#{@file}")


### PR DESCRIPTION
This fixes URI::InvalidURIError when browsing the history of a page with unicode characters in its title (possible with the rugged adapter).