### PR TITLE
Set the allow_editing wiki option to true by default.

### DIFF
--- a/lib/gollum/app.rb
+++ b/lib/gollum/app.rb
@@ -102,7 +102,8 @@ module Precious
       @css = settings.wiki_options[:css]
       @js  = settings.wiki_options[:js]
       @mathjax_config = settings.wiki_options[:mathjax_config]
-      @allow_editing = settings.wiki_options.fetch(:allow_editing, true)
+      settings.wiki_options[:allow_editing] = settings.wiki_options.fetch(:allow_editing, true)
+      @allow_editing = settings.wiki_options[:allow_editing]
     end
 
     get '/' do

--- a/lib/gollum/helpers.rb
+++ b/lib/gollum/helpers.rb
@@ -39,7 +39,7 @@ module Precious
       url.gsub('%2F', '/').gsub(/^\/+/, '').gsub('//', '/')
     end
 
-    def forbid(msg = "Forbidden.")
+    def forbid(msg = "Forbidden. This wiki is set to no-edit mode.")
       @message = msg
       status 403
       halt mustache :error


### PR DESCRIPTION
There was a bug when mounting gollum as rack app: the new `:allow_editing` option in the wiki's option hash would default to false. See https://github.com/gollum/gollum/issues/911. However, https://github.com/gollum/gollum/commit/09149592b55d4a0e87296bb8a3acc3f9015a6c79 did not fix the issue completely. More specifically, it fixed it for GET requests, but not for POST requests.

This is because my previous fix only made the `@allow_editing` instance variable, and not the corresponding key in the options hash, default to true. So [this line](https://github.com/gollum/gollum/blob/master/lib/gollum/editing_auth.rb#L10) would stop any POST request.

My apologies. ;)