### PR TITLE
pixel tweaks so the left scrollbar is selectable and the viewport takes the whole page

### DIFF
--- a/lib/gollum/public/gollum/livepreview/js/livepreview.js
+++ b/lib/gollum/public/gollum/livepreview/js/livepreview.js
@@ -453,18 +453,16 @@ var applyTimeout = function () {
     var height = $( win ).height();
     var heightHalf = height / 2;
 
-    // height minus 50 so the end of document text doesn't flow off the page.
-    // + 15 for scroll bar
-    var editorContainerStyle = 'width:' + (widthHalf + 15) + 'px;' +
-      'height:' + (height - 50) + 'px;' +
+    // height minus 40 so the end of document text doesn't flow off the page.
+    var editorContainerStyle = 'width:' + widthHalf + 'px;' +
+      'height:' + (height - 40) + 'px;' +
       'left:' + (leftRight === false ? widthHalf + 'px;' : '0px;') +
       'top:' + '40px;'; // use 40px for tool menu
     cssSet( editorContainer, editorContainerStyle );
     editor.resize();
 
-    // width -2 for scroll bar & -10 for left offset
-    var previewStyle = 'width:' + (widthHalf - 2 - 10) + 'px;' +
-      'height:' + (height -50) + 'px;' +
+    var previewStyle = 'width:' + widthHalf + 'px;' +
+      'height:' + (height - 40) + 'px;' +
       'left:' + (leftRight === false ? '10px;' : widthHalf + 'px;') +
        // preview panel top is equal to height of comment tool panel (40px) + 1
       'top:41px;';


### PR DESCRIPTION
Happens on firefox for both windows & linux. See #952.

Before
![before](https://cloud.githubusercontent.com/assets/628500/5892023/d1122db8-a505-11e4-9993-71055fe148b8.png)

After
![after](https://cloud.githubusercontent.com/assets/628500/5892024/d50bb22c-a505-11e4-94b8-e776bd40b0bf.png)
