### PR TITLE
enable mathjax in live preview

### DIFF
--- a/lib/gollum/app.rb
+++ b/lib/gollum/app.rb
@@ -28,7 +28,7 @@ class String
       self # Do not transliterate utf-8 url's unless using Grit
     end
   end
-  
+
   # _Header => header which causes errors
   def to_url
     return nil if self.nil?
@@ -148,7 +148,7 @@ module Precious
       @allow_uploads = wiki.allow_uploads
       if page = wikip.page
         if wiki.live_preview && page.format.to_s.include?('markdown') && supported_useragent?(request.user_agent)
-          live_preview_url = '/livepreview/index.html?page=' + encodeURIComponent(@name)
+          live_preview_url = '/livepreview/?page=' + encodeURIComponent(@name)
           if @path
             live_preview_url << '&path=' + encodeURIComponent(@path)
           end
@@ -362,6 +362,12 @@ module Precious
       mustache :page
     end
 
+    get '/livepreview/' do
+      wiki = wiki_new
+      @mathjax = wiki.mathjax
+      mustache :livepreview, { :layout => false }
+    end
+
     get '/history/*' do
       @page     = wiki_page(params[:splat].first).page
       @page_num = [params[:page].to_i, 1].max
@@ -379,7 +385,7 @@ module Precious
       @versions = @wiki.latest_changes({:max_count => max_count})
       mustache :latest_changes
     end
-    
+
     post '/compare/*' do
       @file     = encodeURIComponent(params[:splat].first)
       @versions = params[:versions] || []

--- a/lib/gollum/public/gollum/livepreview/js/livepreview.js
+++ b/lib/gollum/public/gollum/livepreview/js/livepreview.js
@@ -311,6 +311,10 @@ var makePreviewHtml = function () {
   // preview.innerHTML = text; // this doesn't work on IE.
   previewSet( text );
 
+  if (win.MathJax) {
+    win.MathJax.Hub.Queue(['Typeset', win.MathJax.Hub, 'contentframe']);
+  }
+
   // highlight code blocks.
   var codeElements = preview.getElementsByTagName( 'pre' );
   var codeElementsLength = codeElements.length;
@@ -370,19 +374,19 @@ var applyTimeout = function () {
      ~-1 == false; !~-1 == true;
    */
   if ( !~ location.host.indexOf( 'github.com' ) ) {
-    
+
     // returns unescaped key with leading slashes removed
     function key_no_leading_slash( key ) {
       return unescape( $.key( key ) || '' ).replace( /^\/+/, '' );
     }
-    
+
     // ensure leading / is removed from path and that it ends with /
     var path = key_no_leading_slash( 'path' );
     // don't append '/' if path is empty from removing leading slash
     if ( path !== '' && path.charAt( path.length - 1 ) !== '/' ) {
-      path += '/';  
+      path += '/';
     }
-    
+
     jQuery.ajax( {
       type: 'GET',
       url: baseUrl + '/data/' + path + key_no_leading_slash( 'page' ),

--- a/lib/gollum/templates/layout.mustache
+++ b/lib/gollum/templates/layout.mustache
@@ -38,7 +38,7 @@
   <script type="text/javascript">
   window.MathJax = {
     tex2jax: {
-      inlineMath:  [ ['\\(','\\)'] ],
+      inlineMath:  [ ['$','$'], ['\\(','\\)'] ],
       displayMath: [ ['$$','$$'], ['\\[','\\]'] ],
       processEscapes: true
     },

--- a/lib/gollum/templates/livepreview.mustache
+++ b/lib/gollum/templates/livepreview.mustache
@@ -45,7 +45,7 @@ var require = {
 <script type="text/javascript">
 window.MathJax = {
 tex2jax: {
-  inlineMath:  [ ['\\(','\\)'] ],
+  inlineMath:  [ ['$','$'], ['\\(','\\)'] ],
   displayMath: [ ['$$','$$'], ['\\[','\\]'] ],
   processEscapes: true
 },

--- a/lib/gollum/templates/livepreview.mustache
+++ b/lib/gollum/templates/livepreview.mustache
@@ -9,7 +9,7 @@
 <body>
 <div id='editor'></div>
 <div id='previewframe'><div id='contentframe' class='markdown-body'></div></div>
-<!-- tool panel from notepage.es. save & savecomment icons from Retina Display Icon Set. -->  
+<!-- tool panel from notepage.es. save & savecomment icons from Retina Display Icon Set. -->
 <div id='toolpanel' class='toolpanel edit' style='width: 500px; right: 0px; visibility: hidden;'>
   <a id='preview' class='edit'><img src='images/globe_24.png' alt='Preview' title='Preview'></a>
   <a id='save' class='edit'><img src='images/save_24.png' alt='Save' title='Save'></a>
@@ -40,5 +40,27 @@ var require = {
 <script src='js/sundown.js'></script>
 <script src='js/md_sundown.js'></script>
 <script src='js/livepreview.js'></script>
+{{#mathjax}}
+{{^mathjax_config}}
+<script type="text/javascript">
+window.MathJax = {
+tex2jax: {
+  inlineMath:  [ ['\\(','\\)'] ],
+  displayMath: [ ['$$','$$'], ['\\[','\\]'] ],
+  processEscapes: true
+},
+TeX: { extensions: ["autoload-all.js"] }
+};
+</script>
+{{/mathjax_config}}
+{{#mathjax_config}}
+<script type="text/javascript" src="{{base_url}}/{{mathjax_config}}"></script>
+{{/mathjax_config}}
+<script>(function(d,j){
+j = d.createElement('script');
+j.src = '//cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML';
+(d.head || d.getElementsByTagName('head')[0]).appendChild(j);
+}(document));
+</script>{{/mathjax}}
 </body>
 </html>

--- a/lib/gollum/views/livepreview.rb
+++ b/lib/gollum/views/livepreview.rb
@@ -1,0 +1,13 @@
+module Precious
+  module Views
+    class Livepreview < Layout
+      def mathjax
+        @mathjax
+      end
+
+      def mathjax_config
+        @mathjax_config
+      end
+    end
+  end
+end


### PR DESCRIPTION
I moved live preview to the templates directory so the mathjax script is only included when mathjax is enabled.

![screenshot](https://cloud.githubusercontent.com/assets/628500/5933684/0a2e8ed4-a718-11e4-8ffc-83a3ac3f515f.png)
