### PR TITLE
adding template dir logic to app.rb vs. just the bin

### DIFF
--- a/lib/gollum/app.rb
+++ b/lib/gollum/app.rb
@@ -96,6 +96,7 @@ module Precious
     end
 
     before do
+      Precious::App.set(:mustache, {:templates => settings.wiki_options[:template_dir]}) if settings.wiki_options[:template_dir]
       @base_url = url('/', false).chomp('/')
       # above will detect base_path when it's used with map in a config.ru
       settings.wiki_options.merge!({ :base_path => @base_url })


### PR DESCRIPTION
I'm running gollum from a `config.ru` file:

    Precious::App.set(:wiki_options, {:universal_toc => false, :template_dir => 'templates'})
    run Precious::App

and without this fix, it never reads my custom templates directory.