### PR TITLE
prepend baseUrl to /uploadFile

### DIFF
--- a/lib/gollum/public/gollum/javascript/editor/gollum.editor.js
+++ b/lib/gollum/public/gollum/javascript/editor/gollum.editor.js
@@ -121,7 +121,7 @@
           formData.append('file', file);
 
           $.ajax({
-            url: '/uploadFile',
+            url: baseUrl + '/uploadFile',
             data: formData,
             cache: false,
             contentType: false,


### PR DESCRIPTION
Hi folks,

Uploading a file into the editor fails when the gollum wiki is running with base_path != '/'.   The fix is pretty simple.  By the way, I noticed that there is a post to /wiki/help in this same js file.  I'm not sure what that's for, but I imagine it needs a similar treatment.

best,
-Kirat