### PR TITLE
Remove extraneous li tags

### DIFF
--- a/lib/gollum/templates/page.mustache
+++ b/lib/gollum/templates/page.mustache
@@ -41,10 +41,8 @@ Mousetrap.bind(['e'], function( e ) {
       {{/editable}}
     {{/allow_editing}}
     {{#page_exists}}
-    <li class="minibutton jaws">
     <li class="minibutton"><a href="{{base_url}}/history/{{escaped_url_path}}"
        class="action-page-history">History</a></li>
-	<li class="minibutton jaws">
     <li class="minibutton"><a href="{{base_url}}/latest_changes"
        class="action-page-history">Latest Changes</a></li>
     {{/page_exists}}


### PR DESCRIPTION
I found a couple of unclosed `li` tags that appear to do nothing (correct me if I'm wrong). 