### PR TITLE
Fix #1012: /Pages View should list folders first, then files, all alphabetically

### DIFF
--- a/lib/gollum/views/pages.rb
+++ b/lib/gollum/views/pages.rb
@@ -31,9 +31,11 @@ module Precious
 
       def files_folders
         if has_results
-          folder_links = []
+          folders = {}
+          page_files = {}
 
-          @results.map { |page|
+          # 1012: Folders and Pages need to be separated
+          @results.each do |page|
             page_path = page.path.sub(/^#{@path}\//, '')
 
             if page_path.include?('/')
@@ -41,19 +43,23 @@ module Precious
               folder_path = @path ? "#{@path}/#{folder}" : folder
               folder_link = %{<li><a href="#{@base_url}/pages/#{folder_path}/" class="folder">#{folder}</a></li>}
 
-              unless folder_links.include?(folder_link)
-                folder_links << folder_link
-
-                folder_link
-              end
+              folders[folder] = folder_link unless folders.key?(folder)
             elsif page_path != ".gitkeep"
               if defined? page.format
-                %{<li><a href="#{@base_url}/#{page.escaped_url_path}" class="file">#{page.name}</a></li>}
+                page_link = %{<li><a href="#{@base_url}/#{page.escaped_url_path}" class="file">#{page.name}</a></li>}
+                page_files[page.name] = page_link
               else
-                %{<li><a href="#{@base_url}/#{page.escaped_url_path}#{page.name}" class="file">#{page.name}</a></li>}
+                page_link = %{<li><a href="#{@base_url}/#{page.escaped_url_path}#{page.name}" class="file">#{page.name}</a></li>}
+                page_files[page.name] = page_link
               end
             end
-          }.compact.join("\n")
+          end
+
+          # 1012: All Pages should be rendered as Folders first, then Pages, each sorted alphabetically
+          result = Hash[folders.sort_by{| key, value | key.downcase} ].values.join("\n") + "\n"
+          result += Hash[page_files.sort_by{ | key, value | key.downcase } ].values.join("\n")
+
+          result
         else
           ""
         end

--- a/test/test_pages_view.rb
+++ b/test/test_pages_view.rb
@@ -39,12 +39,19 @@ context "Precious::Views::Pages" do
     assert_equal 'Home', @page.breadcrumb
   end
 
-  test "files_folders" do
+  test "folders first" do
+    @page.instance_variable_set("@base_url", "")
+	results = [FakePageResult.new("Gondor/Bromir.md"), FakePageResult.new("Hobbit.md"), FakePageResult.new("Home.md"), FakePageResult.new("Mordor/Eye-Of-Sauron.md"), FakePageResult.new("Mordor/todo.md"), FakePageResult.new("Rivendell/Elrond.md"), FakePageResult.new("My-Precious.md"), FakePageResult.new("Zamin.md"), FakePageResult.new("Samwise-Gamgee.md"), FakePageResult.new("roast-mutton.md"), FakePageResult.new("Bilbo-Baggins.md")]
+    @page.instance_variable_set("@results", results)
+    assert_equal %{<li><a href="/pages/Gondor/" class="folder">Gondor</a></li>\n<li><a href="/pages/Mordor/" class="folder">Mordor</a></li>\n<li><a href="/pages/Rivendell/" class="folder">Rivendell</a></li>\n<li><a href="/Bilbo-Baggins" class="file">Bilbo Baggins</a></li>\n<li><a href="/Hobbit" class="file">Hobbit</a></li>\n<li><a href="/Home" class="file">Home</a></li>\n<li><a href="/My-Precious" class="file">My Precious</a></li>\n<li><a href="/roast-mutton" class="file">roast mutton</a></li>\n<li><a href="/Samwise-Gamgee" class="file">Samwise Gamgee</a></li>\n<li><a href="/Zamin" class="file">Zamin</a></li>}, @page.files_folders
+  end
+
+  test "files_folders from subdir" do
     @page.instance_variable_set("@path", "Mordor")
     @page.instance_variable_set("@base_url", "")
     results = [FakePageResult.new("Mordor/Eye-Of-Sauron.md"), FakeFileResult.new("Mordor/Aragorn.pdf"), FakePageResult.new("Mordor/Orc/Saruman.md"), FakeFileResult.new("Mordor/.gitkeep")]
     @page.instance_variable_set("@results", results)
-    assert_equal %{<li><a href="/Mordor/Eye-Of-Sauron" class="file">Eye Of Sauron</a></li>\n<li><a href="/Mordor/Aragorn.pdf" class="file">Aragorn.pdf</a></li>\n<li><a href="/pages/Mordor/Orc/" class="folder">Orc</a></li>}, @page.files_folders
+    assert_equal %{<li><a href="/pages/Mordor/Orc/" class="folder">Orc</a></li>\n<li><a href="/Mordor/Aragorn.pdf" class="file">Aragorn.pdf</a></li>\n<li><a href="/Mordor/Eye-Of-Sauron" class="file">Eye Of Sauron</a></li>}, @page.files_folders
   end
 
   test "base url" do
@@ -53,6 +60,6 @@ context "Precious::Views::Pages" do
     @page.instance_variable_set("@base_url", "/wiki")
     results = [FakePageResult.new("Mordor/Eye-Of-Sauron.md"), FakeFileResult.new("Mordor/Aragorn.pdf"), FakePageResult.new("Mordor/Orc/Saruman.md"), FakePageResult.new("Mordor/.gitkeep")]
     @page.instance_variable_set("@results", results)
-    assert_equal %{<li><a href="/wiki/Mordor/Eye-Of-Sauron" class="file">Eye Of Sauron</a></li>\n<li><a href=\"/wiki/Mordor/Aragorn.pdf\" class=\"file\">Aragorn.pdf</a></li>\n<li><a href="/wiki/pages/Mordor/Orc/" class="folder">Orc</a></li>}, @page.files_folders
+    assert_equal %{<li><a href="/wiki/pages/Mordor/Orc/" class="folder">Orc</a></li>\n<li><a href="/wiki/Mordor/Aragorn.pdf" class="file">Aragorn.pdf</a></li>\n<li><a href="/wiki/Mordor/Eye-Of-Sauron" class="file">Eye Of Sauron</a></li>}, @page.files_folders
   end
 end


### PR DESCRIPTION
This pull request fixes #1012 that I opened earlier this week. The `/pages` view will now list all folders in the given base path alphabetically first, and then pages. I have also updated the tests for `/pages` to account for the changes.

While this should technically cover the changes in 1200afe, I think we may want to consider re-writing these tests or re-naming them, as they seem to only provide coverage for the `/Mordor` sub-folder. A better test would cover the root of the test repository because it contains more folders and a mix of upper- and lower-case pages.

I can write up a separate test for that situation if requested.

Sorry for the delay, Sinatra has been behaving funny on my arch install.