### PR TITLE
Fix #1030: Disable AJAX Cach in Live Editor

### DIFF
--- a/lib/gollum/public/gollum/livepreview/js/livepreview.js
+++ b/lib/gollum/public/gollum/livepreview/js/livepreview.js
@@ -394,6 +394,7 @@ var applyTimeout = function () {
     jQuery.ajax( {
       type: 'GET',
       url: baseUrl + '/data/' + path + key_no_leading_slash( 'page' ),
+      cache: false,
       success: function( data ) {
          editorSession.setValue( data );
       }


### PR DESCRIPTION
Internet Explorer caches all AJAX get requests and decides when to expire
them in the cache. This commit disables caching on the GET request to
/data/<PAGE NAME>, which fixes IE displaying old page data when using the
live editor.

See http://www.dashbay.com/2011/05/internet-explorer-caches-ajax/ and
https://stackoverflow.com/questions/4303829/how-to-prevent-a-jquery-ajax-request-from-caching-in-internet-explorer