### PR TITLE
upgrade/update some component

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ rvm:
   - 2.0.0
   - 2.1.0
   - 2.1.1
+  - 2.2.2
   - jruby-19mode
 before_install:
  - sudo apt-get update

--- a/gollum.gemspec
+++ b/gollum.gemspec
@@ -35,6 +35,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'minitest-reporters', '~> 0.14.16'
   s.add_development_dependency 'twitter_cldr', '~> 3.2.0'
   s.add_development_dependency 'mocha', '~> 1.1.0'
+  s.add_development_dependency 'test-unit', '~> 3.1.0' if RUBY_VERSION =~ /^2.2/
 
   # = MANIFEST =
   s.files = %w[

--- a/gollum.gemspec
+++ b/gollum.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'shoulda', '~> 3.5.0'
   s.add_development_dependency 'minitest-reporters', '~> 0.14.16'
   s.add_development_dependency 'twitter_cldr', '~> 2.4.2'
-  s.add_development_dependency 'mocha', '~> 1.0.0'
+  s.add_development_dependency 'mocha', '~> 1.1.0'
 
   # = MANIFEST =
   s.files = %w[

--- a/gollum.gemspec
+++ b/gollum.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rack-test', '~> 0.6.2'
   s.add_development_dependency 'shoulda', '~> 3.5.0'
   s.add_development_dependency 'minitest-reporters', '~> 0.14.16'
-  s.add_development_dependency 'twitter_cldr', '~> 2.4.2'
+  s.add_development_dependency 'twitter_cldr', '~> 3.2.0'
   s.add_development_dependency 'mocha', '~> 1.1.0'
 
   # = MANIFEST =

--- a/gollum.gemspec
+++ b/gollum.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'kramdown', '~> 1.8.0'
   s.add_dependency 'sinatra', '~> 1.4', '>= 1.4.4'
   s.add_dependency 'mustache', ['>= 0.99.5', '< 1.0.0']
-  s.add_dependency 'useragent', '~> 0.10.0'
+  s.add_dependency 'useragent', '~> 0.14.0'
 
   s.add_development_dependency 'rack-test', '~> 0.6.2'
   s.add_development_dependency 'shoulda', '~> 3.5.0'

--- a/gollum.gemspec
+++ b/gollum.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = %w[README.md LICENSE]
 
   s.add_dependency 'gollum-lib', '~> 4.0', '>= 4.0.1'
-  s.add_dependency 'kramdown', '~> 1.6.0'
+  s.add_dependency 'kramdown', '~> 1.8.0'
   s.add_dependency 'sinatra', '~> 1.4', '>= 1.4.4'
   s.add_dependency 'mustache', ['>= 0.99.5', '< 1.0.0']
   s.add_dependency 'useragent', '~> 0.10.0'

--- a/test/test_app.rb
+++ b/test/test_app.rb
@@ -64,7 +64,7 @@ context "Frontend" do
   end
 
   def nfd utf8
-    TwitterCldr::Normalization::NFD.normalize utf8
+    TwitterCldr::Normalization.normalize(utf8, using: :nfd)
   end
 
   test "UTF-8 headers href preserved" do


### PR DESCRIPTION
The Dependency Status is [![Dependency Status](https://gemnasium.com/gollum/gollum.svg)](https://gemnasium.com/gollum/gollum), it can be good to upgrade few of them.

I try to upgrade some dependencies:
  - kramdown -> 1.8
  - useragent  -> 0.14
  - mocha -> 1.1
  - twitter_cldr -> 3.2

and add `ruby2.2`  into travis.yml and add `test-unit` gem as new requirement (not present in ruby >2.2)

I hope this PR is good and interesting.

Thanks
/Richard