### PR TITLE
Changed layout template, to handle custom.x with page-file-dir

### DIFF
--- a/lib/gollum/app.rb
+++ b/lib/gollum/app.rb
@@ -98,6 +98,7 @@ module Precious
       forbid unless @allow_editing || request.request_method == "GET"
       Precious::App.set(:mustache, {:templates => settings.wiki_options[:template_dir]}) if settings.wiki_options[:template_dir]
       @base_url = url('/', false).chomp('/')
+      @page_dir = settings.wiki_options[:page_file_dir].to_s
       # above will detect base_path when it's used with map in a config.ru
       settings.wiki_options.merge!({ :base_path => @base_url })
       @css = settings.wiki_options[:css]
@@ -106,8 +107,7 @@ module Precious
     end
 
     get '/' do
-      page_dir = settings.wiki_options[:page_file_dir].to_s
-      redirect clean_url(::File.join(@base_url, page_dir, wiki_new.index_page))
+      redirect clean_url(::File.join(@base_url, @page_dir, wiki_new.index_page))
     end
 
     # path is set to name if path is nil.

--- a/lib/gollum/templates/layout.mustache
+++ b/lib/gollum/templates/layout.mustache
@@ -10,7 +10,7 @@
   <link rel="stylesheet" type="text/css" href="{{base_url}}/css/dialog.css" media="all">
   <link rel="stylesheet" type="text/css" href="{{base_url}}/css/template.css" media="all">
   <link rel="stylesheet" type="text/css" href="{{base_url}}/css/print.css" media="print">
-  {{#css}}<link rel="stylesheet" type="text/css" href="{{base_url}}/custom.css" media="all">{{/css}}
+  {{#css}}<link rel="stylesheet" type="text/css" href="{{custom_path}}/custom.css" media="all">{{/css}}
   {{#noindex}}<meta name="robots" content="noindex, nofollow" />{{/noindex}}
 
   <!--[if IE 7]>
@@ -55,7 +55,7 @@
   (d.head || d.getElementsByTagName('head')[0]).appendChild(j);
   }(document));
   </script>{{/mathjax}}
-  {{#js}}<script type="text/javascript" src="{{base_url}}/custom.js"></script>{{/js}}
+  {{#js}}<script type="text/javascript" src="{{custom_path}}/custom.js"></script>{{/js}}
 
   <title>{{title}}</title>
 </head>

--- a/lib/gollum/views/layout.rb
+++ b/lib/gollum/views/layout.rb
@@ -20,8 +20,16 @@ module Precious
         !@path.nil?
       end
 
+      def page_dir
+        @page_dir
+      end
+
       def base_url
         @base_url
+      end
+
+      def custom_path
+        "#{@base_url}#{@page_dir.nil? ? '' : '/'}#{@page_dir}"
       end
 
       def css # custom css


### PR DESCRIPTION
Because currently, gollum is only able to read custom files from the root directory - but when page-file-dir is set, the root directory is not accessible, making it impossible to load a custom.js or custom.css file.