### PR TITLE
Fix custom.x path when page-file-dir is not set

### DIFF
--- a/lib/gollum/views/layout.rb
+++ b/lib/gollum/views/layout.rb
@@ -29,7 +29,7 @@ module Precious
       end
 
       def custom_path
-        "#{@base_url}#{@page_dir.nil? ? '' : '/'}#{@page_dir}"
+        "#{@base_url}#{@page_dir.empty? ? '' : '/'}#{@page_dir}"
       end
 
       def css # custom css

--- a/test/test_app.rb
+++ b/test/test_app.rb
@@ -513,8 +513,21 @@ context "Frontend" do
                      { :name => 'user1', :email => 'user1' });
 
     get page
-    assert_match /custom.js/, last_response.body
+    assert_match /"\/custom.js"/, last_response.body
     Precious::App.set(:wiki_options, { :js => nil })
+  end
+
+  test "change custom.css path if page-file-dir is set" do
+    Precious::App.set(:wiki_options, { :css => true, :page_file_dir => 'docs'})
+    page = 'docs/yaycustom'
+    text = 'customized!'
+
+    @wiki.write_page(page, :markdown, text,
+                     { :name => 'user1', :email => 'user1' });
+
+    get page
+    assert_match /"\/docs\/custom.css"/, last_response.body
+    Precious::App.set(:wiki_options, { :css => nil, :page_file_dir => nil })
   end
 
   test "show edit page with header and footer and sidebar of multibyte" do


### PR DESCRIPTION
Addresses problem introduced by https://github.com/gollum/gollum/pull/1047. Edit an existing test and add a new test to ensure that the path to custom.css/custom.js correctly reflects page-file-dir.