### PR TITLE
Use `last_version` instead of `versions` when possible. Fixes #1087.

### DIFF
--- a/lib/gollum/app.rb
+++ b/lib/gollum/app.rb
@@ -496,7 +496,7 @@ module Precious
 
         # Extensions and layout data
         @editable      = true
-        @page_exists   = !page.versions.empty?
+        @page_exists   = !page.last_version.nil?
         @toc_content   = wiki.universal_toc ? @page.toc_data : nil
         @mathjax       = wiki.mathjax
         @h1_title      = wiki.h1_title

--- a/lib/gollum/views/page.rb
+++ b/lib/gollum/views/page.rb
@@ -22,15 +22,13 @@ module Precious
       end
 
       def author
-        page_versions = @page.versions
-        first         = page_versions ? page_versions.first : false
+        first = page.last_version
         return DEFAULT_AUTHOR unless first
         first.author.name.respond_to?(:force_encoding) ? first.author.name.force_encoding('UTF-8') : first.author.name
       end
 
       def date
-        page_versions = @page.versions
-        first         = page_versions ? page_versions.first : false
+        first = page.last_version
         return Time.now.strftime(DATE_FORMAT) unless first
         first.authored_date.strftime(DATE_FORMAT)
       end


### PR DESCRIPTION
Use Gollum::Page#last_version instead of Gollum::Page#versions in the
cases identified in #1087:
 * In Precious::App#show_page_or_file
 * In Precious::Views::Page#author
 * In Precious::Views::Page#date