### PR TITLE
Work in progress on Javascript editor

### DIFF
--- a/lib/gollum/app.rb
+++ b/lib/gollum/app.rb
@@ -281,6 +281,16 @@ module Precious
       redirect to('/')
     end
 
+    get '/jstest/*' do
+      name = params[:splat].first
+      halt 404 if !Gollum::Markup.formats().keys.include?(name.to_sym)
+      wikip = wiki_page(name)
+      @name = wikip.name.to_url
+      
+      mustache :jstest
+    end
+
+
     get '/create/*' do
       forbid unless @allow_editing
       wikip = wiki_page(params[:splat].first.gsub('+', '-'))

--- a/lib/gollum/public/gollum/javascript/editor/gollum.editor.js
+++ b/lib/gollum/public/gollum/javascript/editor/gollum.editor.js
@@ -13,7 +13,7 @@
     EditorMode: 'code',
     NewFile: false,
     HasFunctionBar: true,
-    Debug: false,
+    Debug: true,
     NoDefinitionsFor: []
   };
   var ActiveOptions = {};
@@ -600,15 +600,14 @@
         debug('repText is ' + '"' + repText + '"');
         // replace text
         if ( definitionObject.replace &&
-             typeof definitionObject.replace == 'string' ) {
+             (typeof definitionObject.replace == 'string' ||
+              typeof definitionObject.replace == 'function') ) {
           debug('Running replacement - using ' + definitionObject.replace);
           var rt = definitionObject.replace;
 
-          repText = escape( repText );
           repText = repText.replace( searchExp, rt );
-          // remove backreferences
-          repText = repText.replace( /\$[\d]/g, '' );
-          repText = unescape( repText );
+
+          debug('New repText is ' + '"' + repText + '"');
 
           if ( repText === '' ) {
             debug('Search string is empty');
@@ -630,10 +629,23 @@
         // append if necessary
         if ( definitionObject.append &&
              typeof definitionObject.append == 'string' ) {
+
+          // This causes the cursor to jump to the end of the content
+          // if all we did was an append, which it shouldn't do. But need
+          // further testing to see if removing this breaks anything else.
+          /*
           if ( repText == selText ) {
             reselect = false;
           }
+          */
+
           repText += definitionObject.append;
+
+          // If a cursor position hasn't already been determined
+          // put the cursor at the end of the appended text.
+	  if (cursor === null) {
+            cursor = repText.length;
+	  } 
         }
 
         if ( repText ) {

--- a/lib/gollum/public/gollum/javascript/editor/langs/rest.js
+++ b/lib/gollum/public/gollum/javascript/editor/langs/rest.js
@@ -1,0 +1,252 @@
+/**
+ *  reStructuredText Language Definition
+ *
+ *  A language definition for string manipulation operations, in this case
+ *  for the reStructuredText markup language. Uses regexes for various 
+ *  functions by default. If regexes won't do and you need to do some serious
+ *  manipulation, you can declare a function in the object instead.
+ *
+ *  Code example:
+ *  'functionbar-id'  :   {
+ *                          exec: function(text, selectedText) {
+ *                                   functionStuffHere();
+ *                                },
+ *                          search: /somesearchregex/gi,
+ *                          replace: 'replace text for RegExp.replace',
+ *                          append: "just add this where the cursor is"
+ *                         }
+ *
+**/
+(function($) {
+
+var reStructuredText = {
+
+  'function-bold' :         {
+                              search: /([^\n]+)([\n\s]*)/g,
+                              replace: "**$1**$2"
+                            },
+
+  'function-italic' :       {
+                              search: /([^\n]+)([\n\s]*)/g,
+                              replace: "*$1*$2"
+                            },
+
+  'function-code'   :       {
+                              search: /([^\n]+)([\n\s]*)/g,
+                              replace: "``$1``$2"
+                            },
+
+  'function-hr'     :       {
+                              append: "\n\n----\n\n"
+                            },
+
+  'function-ul'     :       {
+			        exec: function(txt, selText, $field) {
+	                          var pfx = "* ";
+                                  var lines = selText.split("\n");
+                                  for ( var i = 0; i < lines.length; i++ ) {
+                                      lines[i] = pfx + lines[i];
+				  }
+                                  var repText = lines.join("\n");
+                                  $.GollumEditor.replaceSelection(repText);
+                                }
+                            },
+
+  'function-ol'   :         {
+                                exec: function( txt, selText, $field) {
+                                  var lines = selText.split("\n");
+                                  for ( var i = 0; i < lines.length; i++ ) {
+                                      pfx = (i + 1).toString() + ". ";
+                                      lines[i] = pfx + lines[i];
+                                  }
+                                  var repText = lines.join("\n");
+                                  $.GollumEditor.replaceSelection(repText);
+                                }
+                            },
+
+  'function-blockquote' :   {
+                                exec: function( txt, selText, $field) {
+	                          var pfx = "    ";
+                                  var lines = selText.split("\n");
+                                  for ( var i = 0; i < lines.length; i++ ) {
+                                      lines[i] = pfx + lines[i];
+                                  }
+                                  var repText = lines.join("\n");
+                                  $.GollumEditor.replaceSelection(repText);
+                                }
+                            },
+
+  'function-h1'         :   {
+                              search: /(.+)([\n]?)/g,
+                              /* replace: "# $1$2" */
+			      replace: function(m, p1, p2, offset, string) {  
+                                var sym = "=";
+                                var p1u = unescape(p1);
+	                        var under = Array(p1u.length + 1).join(sym);
+	                        return p1 + "\n" + under + "\n" + p2;
+	                      }
+                            },              
+  
+  'function-h2'         :   {
+                              search: /(.+)([\n]?)/g,
+                              /* replace: "## $1$2" */
+			      replace: function(m, p1, p2, offset, string) {  
+                                var sym = "-";
+                                var p1u = unescape(p1);
+	                        var under = Array(p1u.length + 1).join(sym);
+	                        return p1 + "\n" + under + "\n" + p2;
+	                      }
+                            },
+
+  'function-h3'         :   {
+                              search: /(.+)([\n]?)/g,
+                              /* replace: "### $1$2" */
+			      replace: function(m, p1, p2, offset, string) {  
+                                var sym = "~";
+                                var p1u = unescape(p1);
+	                        var under = Array(p1u.length + 1).join(sym);
+	                        return p1 + "\n" + under + "\n" + p2;
+	                      }
+			      
+                            }
+  /*
+                             ,
+  'function-link'       :   {
+                              exec: function( txt, selText, $field ) {
+                                var results = null;
+                                $.GollumEditor.Dialog.init({
+                                  title: 'Insert Link',
+                                  fields: [
+                                    {
+                                      id:   'text',
+                                      name: 'Link Text',
+                                      type: 'text',
+                                      defaultValue: selText
+                                    },
+                                    {
+                                      id:   'href',
+                                      name: 'URL',
+                                      type: 'text'
+                                    }
+                                  ],
+                                  OK: function( res ) {
+                                   var rep = '';
+                                   if ( res['text'] && res['href'] ) {
+                                      rep = '[' + res['text'] + '](' +
+                                             res['href'] + ')';
+                                    }
+                                    $.GollumEditor.replaceSelection( rep );
+                                  }
+                                });
+                              }
+                            },
+
+  'function-image'      :   {
+                              exec: function( txt, selText, $field ) {
+                                var results = null;
+                                $.GollumEditor.Dialog.init({
+                                  title: 'Insert Image',
+                                  fields: [
+                                    {
+                                      id: 'url',
+                                      name: 'Image URL',
+                                      type: 'text'
+                                    },
+                                    {
+                                      id: 'alt',
+                                      name: 'Alt Text',
+                                      type: 'text'
+                                    }
+                                  ],
+                                  OK: function( res ) {
+                                    var rep = '';
+                                    if ( res['url'] && res['alt'] ) {
+                                      rep = '![' + res['alt'] + ']' +
+                                            '(' + res['url'] + ')';
+                                    }
+                                    $.GollumEditor.replaceSelection( rep );
+                                  }
+                                });
+                              }
+                            }
+  */
+};
+
+var reStructuredTextHelp = [
+
+  {
+    menuName: 'Block Elements',
+    content: [
+                {
+                  menuName: 'Paragraphs &amp; Breaks',
+                  data: '<p>To create a paragraph, simply create a block of text that is not separated by one or more blank lines. Blocks of text separated by one or more blank lines will be parsed as paragraphs.</p><p>If you want to create a line break, end a line with two or more spaces, then hit Return/Enter.</p>'
+                },
+                {
+                  menuName: 'Headers',
+                  data: '<p>Markdown supports two header formats. The wiki editor uses the &ldquo;atx&rsquo;-style headers. Simply prefix your header text with the number of <code>#</code> characters to specify heading depth. For example: <code># Header 1</code>, <code>## Header 2</code> and <code>### Header 3</code> will be progressively smaller headers. You may end your headers with any number of hashes.</p>'
+                },
+                {
+                  menuName: 'Blockquotes',
+                  data: '<p>Markdown creates blockquotes email-style by prefixing each line with the <code>&gt;</code>. This looks best if you decide to hard-wrap text and prefix each line with a <code>&gt;</code> character, but Markdown supports just putting <code>&gt;</code> before your paragraph.</p>'
+                },
+                {
+                  menuName: 'Lists',
+                  data: '<p>Markdown supports both ordered and unordered lists. To create an ordered list, simply prefix each line with a number (any number will do &mdash; this is why the editor only uses one number.) To create an unordered list, you can prefix each line with <code>*</code>, <code>+</code> or <code>-</code>.</p> List items can contain multiple paragraphs, however each paragraph must be indented by at least 4 spaces or a tab.'
+                },
+                {
+                  menuName: 'Code Blocks',
+                  data: '<p>Markdown wraps code blocks in pre-formatted tags to preserve indentation in your code blocks. To create a code block, indent the entire block by at least 4 spaces or one tab. Markdown will strip the extra indentation you&rsquo;ve added to the code block.</p>'
+                },
+                {
+                  menuName: 'Horizontal Rules',
+                  data: 'Horizontal rules are created by placing three or more hyphens, asterisks or underscores on a line by themselves. Spaces are allowed between the hyphens, asterisks or underscores.'
+                }
+              ]
+  },
+
+  {
+    menuName: 'Span Elements',
+    content: [
+                {
+                  menuName: 'Links',
+                  data: '<p>Markdown has two types of links: <strong>inline</strong> and <strong>reference</strong>. For both types of links, the text you want to display to the user is placed in square brackets. For example, if you want your link to display the text &ldquo;GitHub&rdquo;, you write <code>[GitHub]</code>.</p><p>To create an inline link, create a set of parentheses immediately after the brackets and write your URL within the parentheses. (e.g., <code>[GitHub](http://github.com/)</code>). Relative paths are allowed in inline links.</p><p>To create a reference link, use two sets of square brackets. <code>[my internal link][internal-ref]</code> will link to the internal reference <code>internal-ref</code>.</p>'
+                },
+
+                {
+                  menuName: 'Emphasis',
+                  data: '<p>Asterisks (<code>*</code>) and underscores (<code>_</code>) are treated as emphasis and are wrapped with an <code>&lt;em&gt;</code> tag, which usually displays as italics in most browsers. Double asterisks (<code>**</code>) or double underscores (<code>__</code>) are treated as bold using the <code>&lt;strong&gt;</code> tag. To create italic or bold text, simply wrap your words in single/double asterisks/underscores. For example, <code>**My double emphasis text**</code> becomes <strong>My double emphasis text</strong>, and <code>*My single emphasis text*</code> becomes <em>My single emphasis text</em>.</p>'
+                },
+
+                {
+                  menuName: 'Code',
+                  data: '<p>To create inline spans of code, simply wrap the code in backticks (<code>`</code>). Markdown will turn <code>`myFunction`</code> into <code>myFunction</code>.</p>'
+                },
+
+                {
+                  menuName: 'Images',
+                  data: '<p>Markdown image syntax looks a lot like the syntax for links; it is essentially the same syntax preceded by an exclamation point (<code>!</code>). For example, if you want to link to an image at <code>http://github.com/unicorn.png</code> with the alternate text <code>My Unicorn</code>, you would write <code>![My Unicorn](http://github.com/unicorn.png)</code>.</p>'
+                }
+              ]
+  },
+
+  {
+    menuName: 'Miscellaneous',
+    content: [
+                {
+                  menuName: 'Automatic Links',
+                  data: '<p>If you want to create a link that displays the actual URL, markdown allows you to quickly wrap the URL in <code>&lt;</code> and <code>&gt;</code> to do so. For example, the link <a href="javascript:void(0);">http://github.com/</a> is easily produced by writing <code>&lt;http://github.com/&gt;</code>.</p>'
+                },
+
+                {
+                  menuName: 'Escaping',
+                  data: '<p>If you want to use a special Markdown character in your document (such as displaying literal asterisks), you can escape the character with the backslash (<code>\\</code>). Markdown will ignore the character directly after a backslash.'
+                }
+              ]
+  }
+];
+
+
+$.GollumEditor.defineLanguage('rest', reStructuredText);
+$.GollumEditor.defineHelp('rest', reStructuredTextHelp);
+
+})(jQuery);

--- a/lib/gollum/public/gollum/javascript/editor/tests/harness.js
+++ b/lib/gollum/public/gollum/javascript/editor/tests/harness.js
@@ -1,0 +1,51 @@
+var gollumEditorTests = {
+    Text: function(text, sel_start, sel_end) {
+        this.text = text;
+
+        if ( typeof sel_start == "number" )
+            this.selStart = sel_start;
+        else
+            this.selStart = this.text.indexOf(sel_start);
+
+        if ( typeof sel_end == "number" )
+            this.selEnd = sel_end;
+        else
+            this.selEnd = this.text.indexOf(sel_end);
+    },    
+
+    editorFunctionTest: function(assert, func, 
+				 text, sel_start, sel_end,
+				 expected, exp_start, exp_end) {
+
+        // Append some text to the buffer.
+        // Select a portion (possibly empty) of the text appended.
+        // Apply an editor function to the selected text, or at point.
+        // Check that the applied function had the expected effect,
+        // i.e., that the resulting text is the same as `expected`,
+        // and that the resulting selection has the expected start
+        // and end indexes (`exp_start` and `exp_end`).
+
+
+	var $editorBody = $("#gollum-editor-body"); // JQuery object
+        var editorBody = $editorBody[0];            // DOM object
+        var content = $editorBody.val();
+        var start = content.length;
+        $editorBody.val(content + text + "\n\n");
+
+        var t0 = new gollumEditorTests.Text(text, sel_start, sel_end);
+        var t1 = new gollumEditorTests.Text(expected, exp_start, exp_end);
+
+	editorBody.focus();
+	editorBody.select();
+	editorBody.setSelectionRange(start + t0.selStart, 
+                                     start + t0.selEnd);
+        $("#function-"+func).click();
+
+        assert.equal( $editorBody.val().slice(start, -2), t1.text, 
+                      "expected markup" );
+        assert.equal( editorBody.selectionStart, start + t1.selStart, 
+                      "selection start should be " + (start + t1.selStart) );
+	assert.equal( editorBody.selectionEnd, start + t1.selEnd, 
+                      "selection end should be " + (start + t1.selEnd) );
+    }
+};

--- a/lib/gollum/public/gollum/javascript/editor/tests/markdown.js
+++ b/lib/gollum/public/gollum/javascript/editor/tests/markdown.js
@@ -1,0 +1,104 @@
+var expected_markup = "markdown";
+
+QUnit.test( "Editor environment", function( assert ) {
+        assert.equal( typeof $.GollumEditor, "function",
+                      "GollumEditor should be a function");
+        assert.equal( default_markup, expected_markup, 
+                      "default_markup should be " + expected_markup);
+});
+
+var funcTest = gollumEditorTests.editorFunctionTest;
+
+QUnit.test( "Bold function", function( assert ) {
+    var func = "bold";
+
+    funcTest(assert, func, 
+	     "Some test text", 5, 9,
+             "Some **test** text", 5, 13);
+
+    funcTest(assert, func,
+	     "Make these four\nwords bold, and \nthe rest not.",
+	     "these", ",",
+	     "Make **these four**\n**words bold**, and \nthe rest not.",
+	     "**", ",");
+
+    var t = "Bold the following text: ";
+    funcTest(assert, func, 
+	     t, t.length, t.length,
+             t + "****", t.length + 2, t.length + 2);
+
+});
+
+QUnit.test( "Italic function", function( assert ) {
+    var func = "italic";
+
+    funcTest(assert, func, 
+	     "Some test text", 5, 9,
+             "Some _test_ text", 5, 11);
+
+    funcTest(assert, func,
+	     "Make these four\nwords italic, and \nthe rest not.",
+	     "these", ",",
+	     "Make _these four_\n_words italic_, and \nthe rest not.",
+	     "_", ",");
+
+    var t = "Italicize the following text: ";
+    funcTest(assert, func, 
+	     t, t.length, t.length,
+             t + "__", t.length + 1, t.length + 1);
+});
+
+QUnit.test( "Code function", function( assert ) {
+    var func = "code";
+
+    funcTest(assert, func, 
+	     "Set the word function in code font.", "function", " in",
+	     "Set the word `function` in code font.", "`", " in");
+});
+
+QUnit.test( "HR function", function( assert ) {
+    var func = "hr";
+    expect(0);
+});
+
+QUnit.test( "UL function", function( assert ) {
+    var func = "ul";
+    expect(0);
+});
+
+QUnit.test( "OL function", function( assert ) {
+    var func = "ol";
+    expect(0);
+});
+
+QUnit.test( "Blockquote function", function( assert ) {
+    var func = "blockquote";
+    expect(0);
+});
+
+QUnit.test( "H1 function", function( assert ) {
+    var func = "h1";
+    expect(0);
+});
+
+QUnit.test( "H2 function", function( assert ) {
+    var func = "h2";
+    expect(0);
+});
+
+QUnit.test( "H3 function", function( assert ) {
+    var func = "h3";
+    expect(0);
+});
+
+QUnit.test( "Link function", function( assert ) {
+    var func = "link";
+    expect(0);
+});
+
+QUnit.test( "Image function", function( assert ) {
+    var func = "image";
+    expect(0);
+});
+
+

--- a/lib/gollum/public/gollum/javascript/editor/tests/rest.js
+++ b/lib/gollum/public/gollum/javascript/editor/tests/rest.js
@@ -1,0 +1,139 @@
+var expected_markup = "rest";
+
+QUnit.test( "Editor environment", function( assert ) {
+        assert.equal( typeof $.GollumEditor, "function",
+                      "GollumEditor should be a function");
+        assert.equal( default_markup, expected_markup, 
+                      "default_markup should be " + expected_markup);
+});
+
+var funcTest = gollumEditorTests.editorFunctionTest;
+
+QUnit.test( "Bold function", function( assert ) {
+    var func = "bold";
+
+    funcTest(assert, func, 
+	     "Some test text", 5, 9,
+             "Some **test** text", 5, 13);
+
+    funcTest(assert, func,
+	     "Make these four\nwords bold, and \nthe rest not.",
+	     "these", ",",
+	     "Make **these four**\n**words bold**, and \nthe rest not.",
+	     "**", ",");
+
+    var t = "Bold the following text: ";
+    funcTest(assert, func, 
+	     t, t.length, t.length,
+             t + "****", t.length + 2, t.length + 2);
+});
+
+QUnit.test( "Italic function", function( assert ) {
+    var func = "italic";
+
+    funcTest(assert, func, 
+	     "Some test text", 5, 9,
+             "Some *test* text", 5, 11);
+
+    funcTest(assert, func,
+	     "Make these four\nwords italic, and \nthe rest not.",
+	     "these", ",",
+	     "Make *these four*\n*words italic*, and \nthe rest not.",
+	     "*", ",");
+
+    var t = "Italicize the following text: ";
+    funcTest(assert, func, 
+	     t, t.length, t.length,
+             t + "**", t.length + 1, t.length + 1);
+});
+
+QUnit.test( "Code function", function( assert ) {
+    var func = "code";
+
+    funcTest(assert, func, 
+	     "Set the word function in code font.", "function", " in",
+	     "Set the word ``function`` in code font.", "`", " in");
+});
+
+QUnit.test( "HR function", function( assert ) {
+    var func = "hr";
+
+    var t = "Horizontal rule should follow this line.";
+    var th = t + "\n\n----\n\n";
+    funcTest(assert, func, 
+	     t, t.length, t.length,
+	     th, th.length, th.length);
+
+});
+
+QUnit.test( "UL function", function( assert ) {
+    var func = "ul";
+
+    var t0 = "Some list items:\nFoo\nBar\nBaz\nNot part of the list.";
+    var t1 = "Some list items:\n* Foo\n* Bar\n* Baz\nNot part of the list.";
+    funcTest( assert, func,
+              t0, "Foo", "\nNot",
+              t1, "*", "\nNot" );
+});
+
+QUnit.test( "OL function", function( assert ) {
+    var func = "ol";
+
+    var t0 = "Some list items:\nUno\nDue\nTre\nNot part of the list.";
+    var t1 = "Some list items:\n1. Uno\n2. Due\n3. Tre\nNot part of the list.";
+
+    funcTest( assert, func,
+              t0, "Uno", "\nNot",
+              t1, "1.", "\nNot" );
+});
+
+QUnit.test( "Blockquote function", function( assert ) {
+    var func = "blockquote";
+
+    t0 = "All this text should be blockquoted.";
+    indent = "    ";
+    funcTest( assert, func,
+              t0, 0, 0,
+              indent + t0, 0, indent.length);
+});
+
+QUnit.test( "H1 function", function( assert ) {
+    var func = "h1";
+
+    t = "Heading 1";
+    funcTest(assert, func,
+             t, 0, t.length,
+	     t + "\n" + "=".repeat(t.length) + "\n", 0, 2 * (t.length + 1))
+});
+
+QUnit.test( "H2 function", function( assert ) {
+    var func = "h2";
+
+    t = "Heading 2";
+    funcTest(assert, func,
+             t, 0, t.length,
+	     t + "\n" + "-".repeat(t.length) + "\n", 0, 2 * (t.length + 1))
+});
+
+QUnit.test( "H3 function", function( assert ) {
+    var func = "h3";
+
+    t = "Heading 3";
+    funcTest(assert, func,
+             t, 0, t.length,
+	     t + "\n" + "~".repeat(t.length) + "\n", 0, 2 * (t.length + 1))
+});
+
+QUnit.test( "Link function", function( assert ) {
+    var func = "link";
+
+    expect(0);
+});
+
+QUnit.test( "Image function", function( assert ) {
+    var func = "image";
+
+    expect(0);
+});
+
+

--- a/lib/gollum/public/gollum/javascript/editor/tests/your_favorite_markup.js
+++ b/lib/gollum/public/gollum/javascript/editor/tests/your_favorite_markup.js
@@ -1,0 +1,106 @@
+/*
+ * Template for writing editor-function tests for your favorite
+ * markup language. 
+ *
+ * Replace "YOUR_FAVORITE_MARKUP" below with the name Gollum uses
+ * to identify your markup (e.g., "rest" for "reStructuredText", etc.).
+ *
+ * Then implement tests for whichever editor functions Gollum supports
+ * for your markup language.
+ */
+var expected_markup = "YOUR_FAVORITE_MARKUP";
+
+QUnit.test( "Editor environment", function( assert ) {
+        assert.equal( typeof $.GollumEditor, "function",
+                      "GollumEditor should be a function");
+        assert.equal( default_markup, expected_markup, 
+                      "default_markup should be " + expected_markup);
+});
+
+var funcTest = gollumEditorTests.editorFunctionTest;
+
+QUnit.test( "Bold function", function( assert ) {
+    var func = "bold";
+
+    // Leave the `expect(0);` line, and go on to the next
+    // `Qunit.test()` call if your markup language doesn't 
+    // have syntax for the kind of markup that's the subject
+    // of the test, or the Gollum editor doesn't yet have an
+    // editor function for that syntax. 
+
+    expect(0);
+
+    // Otherwise, delete the `expect(0);` line and write your 
+    // tests.
+
+    // See harness.js for a useful helper function,
+    // `gollumEditorTests.editorFunctionTest()`.
+});
+
+QUnit.test( "Italic function", function( assert ) {
+    var func = "italic";
+
+    expect(0);    
+});
+
+QUnit.test( "Code function", function( assert ) {
+    var func = "code";
+
+    expect(0);
+});
+
+QUnit.test( "HR function", function( assert ) {
+    var func = "hr";
+
+    expect(0);
+});
+
+QUnit.test( "UL function", function( assert ) {
+    var func = "ul";
+
+    expect(0);
+});
+
+QUnit.test( "OL function", function( assert ) {
+    var func = "ol";
+
+    expect(0);
+});
+
+QUnit.test( "Blockquote function", function( assert ) {
+    var func = "blockquote";
+
+    expect(0);
+});
+
+QUnit.test( "H1 function", function( assert ) {
+    var func = "h1";
+
+    expect(0);
+});
+
+QUnit.test( "H2 function", function( assert ) {
+    var func = "h2";
+
+    expect(0);
+});
+
+QUnit.test( "H3 function", function( assert ) {
+    var func = "h3";
+
+    expect(0);
+});
+
+QUnit.test( "Link function", function( assert ) {
+    var func = "link";
+
+    expect(0);
+});
+
+QUnit.test( "Image function", function( assert ) {
+    var func = "image";
+
+    expect(0);
+});
+
+

--- a/lib/gollum/templates/jstest.mustache
+++ b/lib/gollum/templates/jstest.mustache
@@ -1,0 +1,23 @@
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+<script type="text/javascript" src="//code.jquery.com/qunit/qunit-1.20.0.js"></script>
+<script type="text/javascript" src="{{base_url}}/javascript/editor/tests/harness.js"></script>
+<script type="text/javascript" src="{{base_url}}/javascript/editor/tests/{{default_markup}}.js"></script>
+<div id="wiki-wrapper" class="create">
+<div id="head">
+  <h1>Testing JavaScript editor functions; saving disabled</h1>
+</div>
+<div id="wiki-content" class="create edit">
+  <div class="has-sidebar">
+    {{>editor}}
+  </div>
+</div>
+</div>
+name = {{name}}
+<script type="text/javascript">
+var default_markup = '{{default_markup}}';
+$(document).ready(function() {
+    $("#gollum-editor-submit").prop("disabled", true);
+});
+</script>
+{{something}}

--- a/lib/gollum/templates/layout.mustache
+++ b/lib/gollum/templates/layout.mustache
@@ -11,6 +11,7 @@
   <link rel="stylesheet" type="text/css" href="{{base_url}}/css/template.css" media="all">
   <link rel="stylesheet" type="text/css" href="{{base_url}}/css/print.css" media="print">
   {{#css}}<link rel="stylesheet" type="text/css" href="{{custom_path}}/custom.css" media="all">{{/css}}
+  <link rel="stylesheet" href="//code.jquery.com/qunit/qunit-1.20.0.css">
   {{#noindex}}<meta name="robots" content="noindex, nofollow" />{{/noindex}}
 
   <!--[if IE 7]>

--- a/lib/gollum/views/jstest.rb
+++ b/lib/gollum/views/jstest.rb
@@ -1,0 +1,61 @@
+module Precious
+  module Views
+    class Jstest < Layout
+      include Editable
+
+      attr_reader :page, :name
+
+      def title
+        "Run Javascript editor tests"
+      end
+
+      def is_create_page
+        true
+      end
+
+      def is_edit_page
+        false
+      end
+
+      def allow_uploads
+        @allow_uploads
+      end
+
+      def upload_dest
+        @upload_dest
+      end
+
+      def format
+        @format = (@page.format || false) if @format.nil? && @page
+        @format.to_s.downcase
+      end
+
+      def has_footer
+        @footer = (@page.footer || false) if @footer.nil? && @page
+        !!@footer
+      end
+
+      def has_header
+        @header = (@page.header || false) if @header.nil? && @page
+        !!@header
+      end
+
+      def has_sidebar
+        @sidebar = (@page.sidebar || false) if @sidebar.nil? && @page
+        !!@sidebar
+      end
+
+      def page_name
+        @name.gsub('-', ' ')
+      end
+
+      def formats
+        super(:markdown)
+      end
+
+      def default_markup
+        @name.to_sym # pathname element following "jstest" in url
+      end
+    end
+  end
+end


### PR DESCRIPTION
In-progress changes in this branch ("editor-functions-fix"), not yet ready for merging:
- Fix editor misfeatures related to "backreferences," and loss of cursor position when applying functions that append text;
- New editor functions for reStructuredText;
- Introduction of QUnit testing framework, and a handful of tests (incomplete) for markdown and reStructuredText editor functions;
- Sinatra endpoint for invoking tests.

If possible, I would like someone to review my approach and suggest improvements if anything I've done so far clashes with established design philosophy.

The small fixes to `gollum.editor.js`, and the editor functions in `langs/rest.js` are straightforward and should be unremarkable. (Note, though, that in the current commit I have left JS console debugging turned on in the editor, and have not updated the help text in `rest.js` -- it's still the help text for markdown, since I cloned `rest.js` from `markdown.js`, but haven't updated the text yet).

Of greater possible concern is the way I've implemented the invocation of JS tests. In `app.rb` I've created a new endpoint called `jstest`, which takes an additional pathname element identifying the markup language whose test suite is to be run. For example:

```
http://localhost:4567/wiki/jstest/rest
```

runs the test suite for reStructuredText. Note that saving is disabled in the jstest editor view, although I haven't added the CSS necessary to "grey out" the "Save" button.

Running a test suite for a supported markup language that has no test suite defined results in "0 of 0 tests passed." Running a test suite for an unsupported or unknown markup language results in a 404 Not Found. 

This all seems to work quite nicely, but the question is whether this is really the _right_ way to invoke the tests, or if there's a better way that (a) doesn't use up a perfectly good endpoint name, and (b) could possibly run all defined test suites for supported languages at a single go.

---

A second question, completely orthogonal to the first, is: 

Do the editor functions (across all the supported markup languages) work the way that a user would really want them to in terms of (a) whether they produce markup that will render correctly without further input from the user, and (b) where they leave the cursor or highlighted region?

Consider the following cases:
1. The "HR" function for markdown splits the current line at the cursor (or end of the current selection), and puts a sequence of three asterisks on a line by themselves at the split. However, it only puts a single newline before and after the asterisks, meaning that if the user goes immediately to the preview, the asterisks don't get rendered as a horizontal rule if there wasn't a newline immediately before the cursor position (or end of the selection) when the function was invoked. In this case the user needs to manually add the newline before the horizontal rule will render correctly. Should the HR function instead ensure that there is always a blank line before the asterisks? And if so, how sophisticated should it be? Is it okay to blindly add the extra newline even if there had already been a newline before the cursor? (See my implementation of "HR" for reStructuredText for an example of such a "blind" approach.)
2. The "HR" function also has the annoying property that it moves the cursor all the way to the end of the editor buffer. I've tentatively fixed this by changing any "append-only" editor function to put the cursor at the _end_ of the appended fragment of text. But is this the right behavior? Might it make more sense to set the current selection to the entirety of the appended (so, for example, if the user is not happy with it, it's a simple matter of backspacing to get rid of it).
3. See also the behavior of the UL and OL functions for both markdown and reStructuredText, which can also produce results that need the same kind of additional user input as in case 1 above in order to yield correct rendering.

Would be curious to know if there's a "desired behavior" for these aspects of the editor functions, perhaps already implemented by some existing editor, that I should be trying to emulate.
