### PR TITLE
Fix compare page not accessible in no-edit mode. Resolves #1140.

### DIFF
--- a/lib/gollum/app.rb
+++ b/lib/gollum/app.rb
@@ -96,7 +96,6 @@ module Precious
     before do
       settings.wiki_options[:allow_editing] = settings.wiki_options.fetch(:allow_editing, true)
       @allow_editing = settings.wiki_options[:allow_editing]
-      forbid unless @allow_editing || request.request_method == "GET"
       Precious::App.set(:mustache, {:templates => settings.wiki_options[:template_dir]}) if settings.wiki_options[:template_dir]
       @base_url = url('/', false).chomp('/')
       @page_dir = settings.wiki_options[:page_file_dir].to_s
@@ -173,6 +172,8 @@ module Precious
     end
 
     post '/uploadFile' do
+      forbid unless @allow_editing
+
       wiki = wiki_new
 
       unless wiki.allow_uploads
@@ -222,6 +223,8 @@ module Precious
     end
 
     post '/rename/*' do
+      forbid unless @allow_editing
+
       wikip = wiki_page(params[:splat].first)
       halt 500 if wikip.nil?
       wiki   = wikip.wiki
@@ -258,6 +261,8 @@ module Precious
     end
 
     post '/edit/*' do
+      forbid unless @allow_editing
+
       path      = '/' + clean_url(sanitize_empty_params(params[:path])).to_s
       page_name = CGI.unescape(params[:page])
       wiki      = wiki_new
@@ -317,6 +322,8 @@ module Precious
     end
 
     post '/create' do
+      forbid unless @allow_editing
+
       name   = params[:page].to_url
       path   = sanitize_empty_params(params[:path]) || ''
       format = params[:format].intern
@@ -336,6 +343,8 @@ module Precious
     end
 
     post '/revert/*/:sha1/:sha2' do
+      forbid unless @allow_editing
+
       wikip = wiki_page(params[:splat].first)
       @path = wikip.path
       @name = wikip.name
@@ -359,6 +368,8 @@ module Precious
     end
 
     post '/preview' do
+      forbid unless @allow_editing
+
       wiki           = wiki_new
       @name          = params[:page] || "Preview"
       @page          = wiki.preview_page(@name, params[:content], params[:format])


### PR DESCRIPTION
Permission checking was spread across `post` action handlers instead of inside the `before` to normalize between `get` and `post` action handlers and be more explicit.

This resolves #1140.

#### Result

<img width="972" alt="screen shot 2016-06-27 at 13 52 24" src="https://cloud.githubusercontent.com/assets/113730/16389998/90980008-3c6e-11e6-96ba-34a5cf3a5ed6.png">
