### PR TITLE
Remove calls to Page#last_version. Closes #1078.

### DIFF
--- a/lib/gollum/app.rb
+++ b/lib/gollum/app.rb
@@ -5,6 +5,7 @@ require 'gollum-lib'
 require 'mustache/sinatra'
 require 'useragent'
 require 'stringex'
+require 'json'
 
 require 'gollum'
 require 'gollum/views/layout'
@@ -129,6 +130,14 @@ module Precious
 
     def wiki_new
       Gollum::Wiki.new(settings.gollum_path, settings.wiki_options)
+    end
+
+    get '/last-commit-info' do
+      content_type :json
+      if page = wiki_page(params[:path]).page
+        version = page.last_version
+        {:author => version.author.name, :date => version.authored_date}.to_json
+      end
     end
 
     get '/emoji/:name' do
@@ -496,7 +505,6 @@ module Precious
 
       name = extract_name(fullpath) || wiki.index_page
       path = extract_path(fullpath) || '/'
-
       if page = wiki.paged(name, path, exact = true)
         @page          = page
         @name          = name
@@ -505,7 +513,6 @@ module Precious
 
         # Extensions and layout data
         @editable      = true
-        @page_exists   = !page.last_version.nil?
         @toc_content   = wiki.universal_toc ? @page.toc_data : nil
         @mathjax       = wiki.mathjax
         @h1_title      = wiki.h1_title

--- a/lib/gollum/public/gollum/javascript/gollum.js
+++ b/lib/gollum/public/gollum/javascript/gollum.js
@@ -306,6 +306,19 @@ $(document).ready(function() {
     $.GollumEditor();
   }
 
+  if( $("#last-edit").length ) {
+    $("#page-info-toggle").click ( function () {
+      $.ajax({
+        url: '/last-commit-info',
+        data: {path: $("#page-info-toggle").data('pagepath')},
+        success: function ( data ) {
+          $("#last-edit").html('Last edited by <b>' + data.author + '</b>, ' + data.date);
+        }
+      });
+      $("#last-edit").html('<i class="fa fa-spinner fa-spin"></i> Getting commit info...');
+    })
+  }
+
   if( $('#wiki-wrapper.create').length ){
     $("#gollum-editor-submit").click( function() { window.onbeforeunload = null; } );
     $("#gollum-editor-body").one('change', function(){

--- a/lib/gollum/templates/page.mustache
+++ b/lib/gollum/templates/page.mustache
@@ -40,12 +40,10 @@ Mousetrap.bind(['e'], function( e ) {
            class="action-edit-page">Edit</a></li>
       {{/editable}}
     {{/allow_editing}}
-    {{#page_exists}}
     <li class="minibutton"><a href="{{base_url}}/history/{{escaped_url_path}}"
        class="action-page-history">History</a></li>
     <li class="minibutton"><a href="{{base_url}}/latest_changes"
        class="action-page-history">Latest Changes</a></li>
-    {{/page_exists}}
   </ul>
 </div>
 <div id="wiki-content">
@@ -85,10 +83,10 @@ Mousetrap.bind(['e'], function( e ) {
 
 </div>
 <div id="footer">
-  <p id="last-edit">Last edited by <b>{{author}}</b>, {{date}}</p>
+  <p id="last-edit"><a id="page-info-toggle" data-pagepath="{{escaped_url_path}}">When was this page last modified?</a></p>
   {{#allow_editing}}
     <p>
-      <a id="delete-link" href="{{base_url}}/{{escaped_url_path}}" data-confirm="Are you sure you want to delete this page?"><span>Delete this Page</span></a>
+      <a id="delete-link" href="{{escaped_url_path}}" data-confirm="Are you sure you want to delete this page?"><span>Delete this Page</span></a>
     </p>
   {{/allow_editing}}
 </div>

--- a/lib/gollum/views/page.rb
+++ b/lib/gollum/views/page.rb
@@ -41,10 +41,6 @@ module Precious
         @editable
       end
 
-      def page_exists
-        @page_exists
-      end
-
       def allow_editing
         @allow_editing
       end

--- a/test/test_app.rb
+++ b/test/test_app.rb
@@ -90,25 +90,14 @@ context "Frontend" do
     divs.each {|div| assert_match div, last_response.body}
   end
 
-  test "retain edit information" do
+  test "provide last edit information" do
     page1 = 'page1'
     user1 = 'user1'
     @wiki.write_page(page1, :markdown, '',
                      { :name => user1, :email => user1 });
 
-    get page1
-    assert_match /Last edited by <b>user1/, last_response.body
-
-    page2 = 'page2'
-    user2 = 'user2'
-    @wiki.write_page(page2, :markdown, '',
-                     { :name => user2, :email => user2 });
-
-    get page2
-    assert_match /Last edited by <b>user2/, last_response.body
-
-    get page1
-    assert_match /Last edited by <b>user1/, last_response.body
+    get "/last-commit-info", :path => page1
+    assert_match /\"author\":\"user1\"/, last_response.body
   end
 
   test "edits page" do


### PR DESCRIPTION
As described in #1078:

Page loads in large repos (4000 files, 4000 commits) are slow (7 seconds and more)
* Almost all of this time is spent in `page.last_version`.
* This is  extra slow when using the `rugged_adapter`, as I think @joaquinvanschoren reported. That is because the `rugged_adapter` implements the relevant logic (in `Gollum::Git#versions_for_path`) in ruby, whereas `grit` ends up calling C-git, which is significantly faster.

Therefore:
* We've decided to eliminate the calls to `last_version` by default.

Impact:
* A call to `last_version` was used to determine whether the page had a history, so that in new pages, the 'History' minibutton would not be displayed. This check has been removed, so new pages will show the 'History' button (which will just come up empty).
* In the footer, 'Last modified on xxxx by yyyy' will no longer be shown by default.
* Instead, pages will now have a link in the footer reading 'When was this page last modified?'. When clicking that link, an `AJAX` call will be done which looks up the last commit and displays the information.