### PR TITLE
Handle GET /favicon.ico

### DIFF
--- a/lib/gollum/app.rb
+++ b/lib/gollum/app.rb
@@ -110,6 +110,15 @@ module Precious
       redirect clean_url(::File.join(@base_url, @page_dir, wiki_new.index_page))
     end
 
+    get '/favicon.ico' do
+      if File.file?('favicon.ico')
+        content_type 'image/x-icon'
+        File.read('favicon.ico')
+      else
+        halt 404
+      end
+    end
+
     # path is set to name if path is nil.
     #   if path is 'a/b' and a and b are dirs, then
     #   path must have a trailing slash 'a/b/' or


### PR DESCRIPTION
Serve up favicon.ico if it exists in the wiki root, otherwise return a 404.

Closes #1157 

I've never written ruby, but I moved this code from my `config.rb` file, where it worked fine. Could someone with a proper dev setup please do a `curl -vo /dev/null http://localhost:4567/favicon.ico` with and without a `favicon.ico` in the wiki root to ensure it works in this context?