### PR TITLE
Replace editor's content editor with Ace Editor

### DIFF
--- a/lib/gollum/templates/layout.mustache
+++ b/lib/gollum/templates/layout.mustache
@@ -30,6 +30,32 @@
   <script type="text/javascript" src="{{base_url}}/javascript/gollum.dialog.js"></script>
   <script type="text/javascript" src="{{base_url}}/javascript/gollum.placeholder.js"></script>
   <script type="text/javascript" src="{{base_url}}/javascript/editor/gollum.editor.js"></script>
+  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.2.5/ace.js"></script>
+  <script type="text/javascript">
+$(function () {
+  $('textarea[id="gollum-editor-body"]').each(function () {
+    var textarea = $(this);
+    var mode = textarea.attr("data-markup-lang");
+    var editDiv = $('<div>', {
+      position: 'absolute',
+      height: textarea.height(),
+      'class': textarea.attr('class')
+    }).insertBefore(textarea);
+    textarea.css('display', 'none');
+
+    var editor = ace.edit(editDiv[0]);
+    editor.setTheme("ace/theme/tomorrow");
+    editor.setKeyboardHandler("ace/keyboard/vim");
+    editor.getSession().setUseWrapMode(true);
+    editor.getSession().setValue(textarea.val());
+    editor.getSession().setMode("ace/mode/" + mode);
+
+    editor.getSession().on('change', function(){
+      textarea.val(editor.getSession().getValue());
+    });
+  });
+});
+  </script>
   {{#use_identicon}}
   <script type="text/javascript" src="{{base_url}}/javascript/identicon_canvas.js"></script>
   {{/use_identicon}}


### PR DESCRIPTION
Hi, I tried to replace the content editor with the famous Ace editor for better wiki editing experiences. The following are the results:

Before:
![before](https://cloud.githubusercontent.com/assets/32396/20143746/1ad380c8-a6d5-11e6-90a3-f0a18bf9eb80.png)

After:
![after](https://cloud.githubusercontent.com/assets/32396/20143755/23856664-a6d5-11e6-809e-3f29cdc8349a.png)

Here are some caveats currently, for example, dragging a file to the original textarea for uploading, snippets inserting, do not work currently.

Could someone give me some pointers whether it can be accepted in revised form to the upstream? And what should I do? I am new to the javascript world but I use gollum wiki a lot and really want to help improving it.