### PR TITLE
feature #1031

### DIFF
--- a/lib/gollum/app.rb
+++ b/lib/gollum/app.rb
@@ -511,6 +511,34 @@ module Precious
       mustache :file_view, { :layout => false }
     end
 
+    get '/tip/*' do
+      fpath = params[:splat].first
+      wiki = wiki_new
+      name = extract_name(fpath) || wiki.index_page
+      path = extract_path(fpath) || '/'
+      f = fpath + '.md'
+      if File.exist?(f)
+        page = wiki.preview_page(name, File.read(f), :markdown)
+        @page = page
+        @name = name
+        @content = page.formatted_data
+        @upload_dest = find_upload_dest(path)
+        # Extensions and layout data
+        @editable      = true
+        @page_exists   = !page.versions.empty?
+        @toc_content   = wiki.universal_toc ? @page.toc_data : nil
+        @mathjax       = wiki.mathjax
+        @h1_title      = wiki.h1_title
+        @bar_side      = wiki.bar_side
+        @allow_uploads = wiki.allow_uploads
+        mustache :page
+      elsif File.exist?(fpath)
+        send_file fpath, :disposition => 'inline'
+      else
+        show_page_or_file(fpath)
+		end
+
+    end
     get '/*' do
       show_page_or_file(params[:splat].first)
     end


### PR DESCRIPTION
I have added a new URL /tip/* which will serve pages and files directly from a working folder. That enables preview of not yet committed changes as requested in issue #1031.
Vitalije

PS: ruby is not my language of choice, therefore I didn't install any of dependencies and didn't run tests but the code is working for me and it solves #1031.