### PR TITLE
Fix page list for files that have regexp special chars.

### DIFF
--- a/lib/gollum/views/pages.rb
+++ b/lib/gollum/views/pages.rb
@@ -36,7 +36,8 @@ module Precious
 
           # 1012: Folders and Pages need to be separated
           @results.each do |page|
-            page_path = page.path.sub(/^#{@path}\//, '')
+            page_path = page.path
+            page_path = page_path.sub(/^#{Regexp.escape(@path)}\//, '') unless @path.nil?
 
             if page_path.include?('/')
               folder      = page_path.split('/').first


### PR DESCRIPTION
The page list collection logic was using the filename without any
scaping to create a regexp. This not only breaks for some names it might
even be a security problem by introducing bad regular expression as
filenames.