### PR TITLE
Pass non-empty commit author details in transliteration test

### DIFF
--- a/test/test_unicode.rb
+++ b/test/test_unicode.rb
@@ -91,7 +91,7 @@ context "Frontend Unicode support" do
 
   test 'transliteration' do
     # TODO: Remove to_url once write_page changes are merged.
-    @wiki.write_page('ééééé'.to_url, :markdown, '한글 text', { :name => '', :email => '' })
+    @wiki.write_page('ééééé'.to_url, :markdown, '한글 text', commit_details)
     page = @wiki.page('eeeee')
     assert_equal '한글 text', utf8(page.raw_data)
   end


### PR DESCRIPTION
Empty name or email are not allowed by libgit2 and cause a test failure when the test suite is run against rugged_adapter.

Please refer to https://github.com/gollum/gollum/issues/1187#issuecomment-275672962 for a more detailed explanation.