### PR TITLE
Solve bug when folder contains non-ascii character

### DIFF
--- a/lib/gollum/app.rb
+++ b/lib/gollum/app.rb
@@ -348,7 +348,7 @@ module Precious
         wiki.write_page(name, format, params[:content], commit_message, path)
 
         page_dir = settings.wiki_options[:page_file_dir].to_s
-        redirect to("/#{clean_url(::File.join(page_dir, path, encodeURIComponent(name)))}")
+        redirect to("/#{clean_url(::File.join(encodeURIComponent(page_dir), encodeURIComponent(path), encodeURIComponent(name)))}")
       rescue Gollum::DuplicatePageError => e
         @message = "Duplicate page: #{e.message}"
         mustache :error


### PR DESCRIPTION
When you create a file in a folder with non-ascii character, for exemple "Réseau", after creating the page, it throwed an "URI::InvalidURIError", given the fact that the url returned was "/Réseau/H%C3%A9y", only the part with the name of the file was correctly encoded.

So I propose to encode every part of the url to solve this issue.