### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,6 @@ Gollum comes with the following command line options:
 | --page-file-dir   | [PATH]    | Specify the subdirectory for all pages. If set, Gollum will only serve pages from this directory and its subdirectories. Default: repository root. |
 | --css             | none      | Tell Gollum to inject custom CSS into each page. Uses `custom.css` from repository root.<sup>3,5</sup> |
 | --js              | none      | Tell Gollum to inject custom JS into each page. Uses `custom.js` from repository root.<sup>3,5</sup> |
-| --emoji           | none      | Parse and interpret emoji tags (e.g. :heart:). |
 | --no-edit         | none      | Disable the feature of editing pages. |
 | --live-preview    | none      | Enable the live preview feature in page editor. |
 | --no-live-preview | none      | Disable the live preview feature in page editor. |


### PR DESCRIPTION
Removed emoji option from README this feature is not in released gem on rubygems. :sad: :cat: