### PR TITLE
Add selection of keybindings in preview page

### DIFF
--- a/lib/gollum/public/gollum/livepreview/js/livepreview.js
+++ b/lib/gollum/public/gollum/livepreview/js/livepreview.js
@@ -1,5 +1,5 @@
 require([ 'ace/undomanager', 'ace/ext/static_highlight', 'ace/theme/github', 'ace/editor', 'ace/virtual_renderer', 'ace/mode/markdown', 'ace/theme/twilight',
-'ace/mode/c_cpp', 'ace/mode/clojure', 'ace/mode/coffee', 'ace/mode/coldfusion', 'ace/mode/csharp', 'ace/mode/css', 'ace/mode/diff', 'ace/mode/golang', 'ace/mode/groovy', 'ace/mode/haxe', 'ace/mode/html', 'ace/mode/java', 'ace/mode/javascript', 'ace/mode/json', 'ace/mode/latex', 'ace/mode/less', 'ace/mode/liquid', 'ace/mode/lua', 'ace/mode/markdown', 'ace/mode/ocaml', 'ace/mode/perl', 'ace/mode/pgsql', 'ace/mode/php', 'ace/mode/powershell', 'ace/mode/python', 'ace/mode/ruby', 'ace/mode/scad', 'ace/mode/scala', 'ace/mode/scss', 'ace/mode/sh', 'ace/mode/sql', 'ace/mode/svg', 'ace/mode/textile', 'ace/mode/text', 'ace/mode/xml', 'ace/mode/xquery', 'ace/mode/yaml'
+'ace/mode/c_cpp', 'ace/mode/clojure', 'ace/mode/coffee', 'ace/mode/coldfusion', 'ace/mode/csharp', 'ace/mode/css', 'ace/mode/diff', 'ace/mode/golang', 'ace/mode/groovy', 'ace/mode/haxe', 'ace/mode/html', 'ace/mode/java', 'ace/mode/javascript', 'ace/mode/json', 'ace/mode/latex', 'ace/mode/less', 'ace/mode/liquid', 'ace/mode/lua', 'ace/mode/markdown', 'ace/mode/ocaml', 'ace/mode/perl', 'ace/mode/pgsql', 'ace/mode/php', 'ace/mode/powershell', 'ace/mode/python', 'ace/mode/ruby', 'ace/mode/scad', 'ace/mode/scala', 'ace/mode/scss', 'ace/mode/sh', 'ace/mode/sql', 'ace/mode/svg', 'ace/mode/textile', 'ace/mode/text', 'ace/mode/xml', 'ace/mode/xquery', 'ace/mode/yaml', 'ace/multi_select', 'ace/keyboard/vim', 'ace/keyboard/emacs'
 ], function() {
 var UndoManager = require("ace/undomanager").UndoManager;
 var Renderer = require( 'ace/virtual_renderer' ).VirtualRenderer;
@@ -411,6 +411,14 @@ var applyTimeout = function () {
   $( '#save' ).click( function() {
     $.save();
     return false;
+  });
+
+  $( '#keybinding' ).change( function() {
+    var keybinding = $( '#keybinding option:selected' ).text();
+    if ( keybinding === "default" )
+      editor.setKeyboardHandler();
+    else
+      editor.setKeyboardHandler( "ace/keyboard/" + keybinding );
   });
 
   // Hide dimmer, comment tool panel, and comment.

--- a/lib/gollum/templates/livepreview.mustache
+++ b/lib/gollum/templates/livepreview.mustache
@@ -15,6 +15,11 @@
   <a id='save' class='edit'><img src='images/save_24.png' alt='Save' title='Save'></a>
   <a id='savecomment' class='edit'><img src='images/savecomment_24.png' alt='Save with comment' title='Save with comment'></a>
   <a id='toggle' class='edit' href='javascript:void(0)' onclick='jsm.toggleLeftRight();'><img src='images/lr_24.png' alt='Toggle left to right' title='Toggle left to right'></a>
+  <select id="keybinding" alt="Keybinding">
+    <option selected="selected">default</option>
+    <option>vim</option>
+    <option>emacs</option>
+  </select>
 </div>
 
 <div id='editor_bg' class='editor_bg'></div>


### PR DESCRIPTION
Add keybinding choices in the preview page, including "vim", "emacs", and the default one.