### PR TITLE
Yaml frontmatter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 rvm:
-  - 2.0.0
   - 2.1.0
   - 2.1.1
-  - 2.2.2
+  - 2.2.1
   - 2.3.0
-  - jruby-19mode
+  - 2.4.0
+  - jruby-9.1.8.0
 before_install:
  - sudo apt-get update
  - sudo apt-get install libicu-dev

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Gollum comes with the following command line options:
 | --mathjax         | none      | Enables MathJax (renders mathematical equations). By default, uses the `TeX-AMS-MML_HTMLorMML` config with the `autoload-all` extension.<sup>5</sup> |
 | --irb             | none      | Launch Gollum in "console mode", with a [predefined API](https://github.com/gollum/gollum-lib/). |
 | --h1-title        | none      | Tell Gollum to use the first `<h1>` as page title. |
+| --no-display-metadata | none  | Do not render metadata tables in pages. |
 | --show-all        | none      | Tell Gollum to also show files in the file view. By default, only valid pages are shown. |
 | --collapse-tree   | none      | Tell Gollum to collapse the file tree, when the file view is opened. By default, the tree is expanded. |
 | --user-icons      | [MODE]    | Tell Gollum to use specific user icons for history view. Can be set to `gravatar`, `identicon` or `none`. Default: `none`. |

--- a/bin/gollum
+++ b/bin/gollum
@@ -131,6 +131,9 @@ MSG
   opts.on("--h1-title", "Use the first '<h1>' as page title.") do
     wiki_options[:h1_title] = true
   end
+  opts.on("--no-display-metadata", "Do not render metadata tables in pages.") do
+    wiki_options[:display_metadata] = false
+  end
   opts.on("--show-all", "Also show files in the file view. By default, only valid pages are shown.") do
     wiki_options[:show_all] = true
   end

--- a/gollum.gemspec
+++ b/gollum.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.rdoc_options = ['--charset=UTF-8']
   s.extra_rdoc_files = %w[README.md LICENSE]
 
-  s.add_dependency 'gollum-lib', '~> 4.0', '>= 4.0.1'
+  s.add_dependency 'gollum-lib', '~> 5.0.a'
   s.add_dependency 'kramdown', '~> 1.9.0'
   s.add_dependency 'sinatra', '~> 1.4', '>= 1.4.4'
   s.add_dependency 'mustache', ['>= 0.99.5', '< 1.0.0']

--- a/lib/gollum/public/gollum/css/template.css
+++ b/lib/gollum/public/gollum/css/template.css
@@ -385,7 +385,9 @@ a:active, a:hover {
 }
 
 .markdown-body table tr th,
-.markdown-body table tr td {
+.markdown-body table tr td,
+.markdown-body table tr td table,
+.markdown-body table tr th table {
   border: 1px solid #ccc;
   text-align: none;
   margin: 0;

--- a/lib/gollum/templates/page.mustache
+++ b/lib/gollum/templates/page.mustache
@@ -69,6 +69,7 @@ Mousetrap.bind(['e'], function( e ) {
     </div>
     {{/has_header}}
     <div class="markdown-body">
+      {{{rendered_metadata}}}
       {{{content}}}
     </div>
   </div>

--- a/lib/gollum/views/page.rb
+++ b/lib/gollum/views/page.rb
@@ -143,7 +143,7 @@ module Precious
       #
       # Returns HTML table.
       def rendered_metadata
-        return '' if !page.display_metadata? || metadata.empty?
+        return '' unless page.display_metadata? && !metadata.empty?
         @rendered_metadata ||= table(metadata)
       end
 

--- a/lib/gollum/views/page.rb
+++ b/lib/gollum/views/page.rb
@@ -196,7 +196,7 @@ module Precious
       def table(data)
         return data.to_s if data.empty?
         result = "<table>\n"
-        keys = data.respond_to?(:keys) ? data.keys : nil
+        keys = data.respond_to?(:keys) && data.respond_to?(:values) ? data.keys : nil
           if keys
             data = data.values
             result << "<tr>\n"

--- a/lib/gollum/views/page.rb
+++ b/lib/gollum/views/page.rb
@@ -130,13 +130,21 @@ module Precious
 
       # Access to embedded metadata.
       #
-      # Examples
-      #
-      #   {{#metadata}}{{name}}{{/metadata}}
-      #
       # Returns Hash.
       def metadata
         @page.metadata
+      end   
+
+      # Access to embedded metadata.
+      #
+      # Examples
+      #
+      #   {{#rendered_metadata}}{{name}}{{/rendered_metadata}}
+      #
+      # Returns HTML table.
+      def rendered_metadata
+        return '' if !page.display_metadata? || metadata.empty?
+        @rendered_metadata ||= table(metadata)
       end
 
       private
@@ -184,6 +192,42 @@ module Precious
         # .inner_html will cause href escaping on UTF-8
         doc.css("div#gollum-root").children.to_xml(@@to_xml)
       end
+
+      def table(data)
+        result = "<table>\n"
+        case data
+          when Hash
+            result << table_headings(data.keys)
+            result << table_row(data.values)
+          when Array
+            result << table_row(data)
+        end
+        result << "</table>\n"
+      end
+
+      def table_headings(headings)
+        result = "<tr>\n"
+        headings.each do |heading|
+          result << "<th>#{CGI.escapeHTML(heading)}</th>\n"
+        end
+        result << "</tr>\n"
+      end
+
+      def table_row(values)
+        result = "<tr>\n"
+        values.each do |value|
+          result << "<td>"
+          case value
+            when Hash, Array
+              result << table(value)
+            else
+              result << CGI.escapeHTML(value.to_s)
+          end
+          result << "</td>\n"
+        end
+        result << "</tr>\n"
+      end
+
     end
   end
 end

--- a/lib/gollum/views/page.rb
+++ b/lib/gollum/views/page.rb
@@ -194,38 +194,22 @@ module Precious
       end
 
       def table(data)
+        return data.to_s if data.empty?
         result = "<table>\n"
-        case data
-          when Hash
-            result << table_headings(data.keys)
-            result << table_row(data.values)
-          when Array
-            result << table_row(data)
-        end
-        result << "</table>\n"
-      end
-
-      def table_headings(headings)
-        result = "<tr>\n"
-        headings.each do |heading|
-          result << "<th>#{CGI.escapeHTML(heading)}</th>\n"
-        end
-        result << "</tr>\n"
-      end
-
-      def table_row(values)
-        result = "<tr>\n"
-        values.each do |value|
-          result << "<td>"
-          case value
-            when Hash, Array
-              result << table(value)
-            else
-              result << CGI.escapeHTML(value.to_s)
+        keys = data.respond_to?(:keys) ? data.keys : nil
+          if keys
+            data = data.values
+            result << "<tr>\n"
+            keys.each do |heading|
+              result << "<th>#{CGI.escapeHTML(heading)}</th>\n"
+            end
+            result << "</tr>\n"
           end
-          result << "</td>\n"
-        end
-        result << "</tr>\n"
+        result << "<tr>\n"
+          data.each do |value|
+            result << "<td>" << (value.respond_to?(:each) ? table(value) : CGI.escapeHTML(value.to_s)) << "</td>\n"
+          end
+        result << "</tr>\n</table>\n"
       end
 
     end

--- a/test/test_app.rb
+++ b/test/test_app.rb
@@ -636,11 +636,11 @@ context "Frontend with lotr" do
 
     body = last_response.body
 
-    assert body.include?("Bilbo Baggins"), "/pages should include the page 'Bilbo Baggins'"
+    assert body.include?("Bilbo-Baggins"), "/pages should include the page 'Bilbo Baggins'"
     assert body.include?("Gondor"), "/pages should include the folder 'Gondor'"
     assert !body.include?("Boromir"), "/pages should NOT include the page 'Boromir'"
     assert body.include?("Mordor"), "/pages should include the folder 'Mordor'"
-    assert !body.include?("Eye Of Sauron"), "/pages should NOT include the page 'Eye Of Sauron'"
+    assert !body.include?("Eye-Of-Sauron"), "/pages should NOT include the page 'Eye Of Sauron'"
     assert !body.match(/(Zamin).+(roast\-mutton)/m), "/pages should be sorted alphabetically"
   end
 
@@ -650,8 +650,8 @@ context "Frontend with lotr" do
 
     body = last_response.body
 
-    assert !body.include?("Bilbo Baggins"), "/pages/Mordor/ should NOT include the page 'Bilbo Baggins'"
-    assert body.include?("Eye Of Sauron"), "/pages/Mordor/ should include the page 'Eye Of Sauron'"
+    assert !body.include?("Bilbo-Baggins"), "/pages/Mordor/ should NOT include the page 'Bilbo Baggins'"
+    assert body.include?("Eye-Of-Sauron"), "/pages/Mordor/ should include the page 'Eye Of Sauron'"
   end
 
   test "symbolic link pages" do

--- a/test/test_page_view.rb
+++ b/test/test_page_view.rb
@@ -29,6 +29,28 @@ context "Precious::Views::Page" do
     assert_equal '1 & 2', actual
   end
 
+  test "metadata is rendered into a table" do
+    title = 'metadata test'
+    @wiki.write_page(title, :markdown, "---\nsome: metadata\nhere: for you\n---\n# Some markdown\nIn this doc")
+    page = @wiki.page(title)
+
+    @view = Precious::Views::Page.new
+    @view.instance_variable_set :@page, page
+
+    assert_equal @view.rendered_metadata, <<-EOS
+<table>
+<tr>
+<th>some</th>
+<th>here</th>
+</tr>
+<tr>
+<td>metadata</td>
+<td>for you</td>
+</tr>
+</table>
+EOS
+  end
+
   test "h1 title can be disabled" do
     title = 'H1'
     @wiki.write_page(title, :markdown, '# 1 & 2 <script>alert("js")</script>' + "\n # 3", commit_details)


### PR DESCRIPTION
* Implement command line switch `--no-display-metadata` to disable metadata rendering globally (enabled by default)
* Implement `rendered_metadata` method in the `Page` view
* Updated `page` layout and CSS to render metadata tables
* Added a test

This will fail until we release `gollum-lib 5.0.a1` and make `gollum` depend on that. However, the tests already pass locally.

Metadata tables render prettily for simple `{:key => :value}` metadata...
![screen shot 2017-04-08 at 16 45 55](https://cloud.githubusercontent.com/assets/147111/24830034/04200f4e-1c7e-11e7-80f6-eea8b8a91a05.png)
...but also for more complicated metadata with iterated hashes and arrays:
![screen shot 2017-04-08 at 16 45 30](https://cloud.githubusercontent.com/assets/147111/24830039/154e7be8-1c7e-11e7-90d5-49ce8a0ff38c.png)
The latter overflows the table and makes it scrollable (so too large tables will not run off the edge of the page).