### PR TITLE
Remove ws subs

### DIFF
--- a/lib/gollum/helpers.rb
+++ b/lib/gollum/helpers.rb
@@ -6,6 +6,10 @@ module Precious
 
     EMOJI_PATHNAME = Pathname.new(Gemojione.images_path).freeze
 
+    def join_page_name(name, ext)
+      "#{name}#{ext}"
+    end
+
     # Extract the path string that Gollum::Wiki expects
     def extract_path(file_path)
       return nil if file_path.nil?
@@ -23,7 +27,8 @@ module Precious
 
       # File.basename is too eager to please and will return the last
       # component of the path even if it ends with a directory separator.
-      ::File.basename(file_path)
+      ext = ::File.extname(file_path)
+      return ::File.basename(file_path, ext), ext
     end
 
     def sanitize_empty_params(param)

--- a/lib/gollum/templates/layout.mustache
+++ b/lib/gollum/templates/layout.mustache
@@ -21,7 +21,7 @@
       var baseUrl = '{{base_url}}';
       var uploadDest   = '{{upload_dest}}';
       {{#page}}
-      var pageFullPath = '{{url_path_display}}';
+      var pageFullPath = '{{url_path}}';
       {{/page}}
   </script>
   <script type="text/javascript" src="{{base_url}}/javascript/jquery-1.7.2.min.js"></script>

--- a/test/test_app.rb
+++ b/test/test_app.rb
@@ -15,29 +15,6 @@ context "Frontend" do
     FileUtils.rm_rf(@path)
   end
 
-  test "urls transform unicode" do
-    header  = '_Header'
-    footer  = '_Footer'
-    sidebar = '_Sidebar'
-
-    # header, footer, and sidebar must be preserved
-    # or gollum will not recognize them
-    assert_equal header, header.to_url
-    assert_equal footer, footer.to_url
-    assert_equal sidebar, sidebar.to_url
-
-    # spaces are converted to dashes in URLs
-    # and in file names saved to disk
-    # urls are not case sensitive
-    assert_equal 'Title-Space', 'Title Space'.to_url
-
-    # ascii only file names prevent UTF8 issues
-    # when using git repos across operating systems
-    # as this test demonstrates, translation is not
-    # great
-    assert_equal 'm-plus-F', 'μ†ℱ'.to_url
-  end
-
   test "utf-8 kcode" do
     assert_equal 'μ†ℱ'.scan(/./), ["μ", "†", "ℱ"]
   end
@@ -255,8 +232,8 @@ context "Frontend" do
   test "creates pages with escaped characters in title" do
     post "/create", :content => 'abc', :page => 'Title with spaces',
          :format             => 'markdown', :message => 'foo'
-    assert_equal 'http://example.org/Title-with-spaces', last_response.headers['Location']
-    get "/Title-with-spaces"
+    assert_equal 'http://example.org/Title%20with%20spaces', last_response.headers['Location']
+    get "/Title%20with%20spaces"
     assert_match /abc/, last_response.body
   end
 
@@ -699,8 +676,8 @@ context "Frontend with lotr" do
 
     post "/create", :content => 'really big smelly creatures', :page => 'Uruk Hai',
          :path               => 'Mordor', :format => 'markdown', :message => 'oooh, very scary'
-    assert_equal 'http://example.org/Mordor/Uruk-Hai', last_response.headers['Location']
-    get "/Mordor/Uruk-Hai"
+    assert_equal 'http://example.org/Mordor/Uruk%20Hai', last_response.headers['Location']
+    get "/Mordor/Uruk%20Hai"
     assert_match /really big smelly creatures/, last_response.body
   end
 

--- a/test/test_app.rb
+++ b/test/test_app.rb
@@ -232,7 +232,7 @@ context "Frontend" do
   test "creates pages with escaped characters in title" do
     post "/create", :content => 'abc', :page => 'Title with spaces',
          :format             => 'markdown', :message => 'foo'
-    assert_equal 'http://example.org/Title%20with%20spaces', last_response.headers['Location']
+    assert_equal 'http://example.org/Title%20with%20spaces.md', last_response.headers['Location']
     get "/Title%20with%20spaces"
     assert_match /abc/, last_response.body
   end
@@ -257,7 +257,7 @@ context "Frontend" do
     post "/create", :content => 'abc', :page => 'Home', :path => '/foo/',
          :format             => 'markdown', :message => 'foo'
 
-    assert_equal "http://example.org/foo/Home", last_response.headers['Location']
+    assert_equal "http://example.org/foo/Home.md", last_response.headers['Location']
 
     follow_redirect!
     assert last_response.ok?
@@ -649,7 +649,7 @@ context "Frontend with lotr" do
     post "/create", :content => '123', :page => page,
          :path               => 'Mordor', :format => 'markdown', :message => 'oooh, scary'
     # should be wiki/Mordor/path
-    assert_equal 'http://example.org/Mordor/' + page, last_response.headers['Location']
+    assert_equal 'http://example.org/Mordor/' + page + '.md', last_response.headers['Location']
     get '/Mordor/' + page
     assert_match /123/, last_response.body
 
@@ -660,7 +660,7 @@ context "Frontend with lotr" do
   test "create pages within sub-directories using page file dir" do
     post "/create", :content => 'one two', :page => 'base',
          :path               => 'wiki/Mordor', :format => 'markdown', :message => 'oooh, scary'
-    assert_equal 'http://example.org/wiki/Mordor/base', last_response.headers['Location']
+    assert_equal 'http://example.org/wiki/Mordor/base.md', last_response.headers['Location']
     get "/wiki/Mordor/base"
 
     assert_match /one two/, last_response.body
@@ -670,13 +670,13 @@ context "Frontend with lotr" do
   test "create pages within sub-directories" do
     post "/create", :content => 'big smelly creatures', :page => 'Orc',
          :path               => 'Mordor', :format => 'markdown', :message => 'oooh, scary'
-    assert_equal 'http://example.org/Mordor/Orc', last_response.headers['Location']
+    assert_equal 'http://example.org/Mordor/Orc.md', last_response.headers['Location']
     get "/Mordor/Orc"
     assert_match /big smelly creatures/, last_response.body
 
     post "/create", :content => 'really big smelly creatures', :page => 'Uruk Hai',
          :path               => 'Mordor', :format => 'markdown', :message => 'oooh, very scary'
-    assert_equal 'http://example.org/Mordor/Uruk%20Hai', last_response.headers['Location']
+    assert_equal 'http://example.org/Mordor/Uruk%20Hai.md', last_response.headers['Location']
     get "/Mordor/Uruk%20Hai"
     assert_match /really big smelly creatures/, last_response.body
   end
@@ -685,7 +685,7 @@ context "Frontend with lotr" do
     post "/create", :content => 'big smelly creatures', :page => 'Orc',
          :path               => 'Mordor', :format => 'markdown', :message => 'oooh, scary'
 
-    assert_equal 'http://example.org/Mordor/Orc', last_response.headers['Location']
+    assert_equal 'http://example.org/Mordor/Orc.md', last_response.headers['Location']
 
     post "/edit/Mordor/Orc", :content => 'not so big smelly creatures',
          :page                        => 'Orc', :path => 'Mordor', :message => 'minor edit'

--- a/test/test_unicode.rb
+++ b/test/test_unicode.rb
@@ -89,10 +89,12 @@ context "Frontend Unicode support" do
     assert_equal 'ghi', page.version.message
   end
 
-  test 'transliteration' do
-    # TODO: Remove to_url once write_page changes are merged.
-    @wiki.write_page('ééééé'.to_url, :markdown, '한글 text', { :name => '', :email => '' })
-    page = @wiki.page('eeeee')
+  test 'unicode filenames' do
+    # we transliterate only when adapter is grit
+    return if defined?(Gollum::GIT_ADAPTER) && Gollum::GIT_ADAPTER != 'grit'
+    
+    @wiki.write_page("ééééé".to_url, :markdown, '한글 text', { :name => '', :email => '' })
+    page = @wiki.page("eeeee".to_url)
     assert_equal '한글 text', utf8(page.raw_data)
   end
 


### PR DESCRIPTION
Refactor front end to deal with lack of whitespace substitution and the end of file extension suppression in `gollum-lib`.