### PR TITLE
Add keyboard shortcuts dialog. Closes #505.

### DIFF
--- a/lib/gollum/public/gollum/javascript/editor/gollum.editor.js
+++ b/lib/gollum/public/gollum/javascript/editor/gollum.editor.js
@@ -64,6 +64,29 @@
       editor.getSession().on('change', function(){
         textarea.val(editor.getSession().getValue());
       });
+
+      editor.commands.addCommand({
+        name: "showKeyboardShortcuts",
+        bindKey: {win: "Ctrl-Alt-h", mac: "Command-Alt-h"},
+        exec: function(editor) {
+            ace.config.loadModule("ace/ext/keybinding_menu", function(module) {
+                module.init(editor);
+                editor.showKeyboardShortcuts();
+            });
+        }
+      });
+
+      // Ace editor seems to capture all keyboard events so gollum's global
+      // shortcuts does not work in the editor area. So we add them back in
+      // the editor as commands. These commands are added back on-demand since
+      // not all gollum shortcuts are necessary in the presence of Ace editor.
+      editor.commands.addCommand({
+        name: "saveContents",
+        bindKey: {win: "Ctrl-s", mac: "Command-s"},
+        exec: function(editor) {
+          $('#gollum-editor form[name="gollum-editor"]').submit();
+        }
+      });
     });
 
     $("#gollum-editor-body-ace").resize(function(){


### PR DESCRIPTION
Keyboard shortcut dialog is a long-missing feature as indicated by #505. With the ace editor, we can easily add one. This PR implements that using the standard code from https://ace.c9.io/demo/keyboard_shortcuts.html.

Global shortcuts like `Ctrl-s` does not work on the editor area in 5.x since ace editor seems to grab all keyboard events. This can be addressed by the same approach. This PR add `Ctrl-s` back in the editor area.