### PR TITLE
Found more spurious whitespace substitution.

### DIFF
--- a/lib/gollum/app.rb
+++ b/lib/gollum/app.rb
@@ -305,8 +305,8 @@ module Precious
       if settings.wiki_options[:template_page] then
         temppage = wiki_page("/_Template")
         @template_page = (temppage.page != nil) ? temppage.page.raw_data : "Template page option is set, but no /_Template page is present or committed."
-      end          
-      wikip = wiki_page(params[:splat].first.gsub('+', '-'))
+      end
+      wikip = wiki_page(params[:splat].first)
       @name, ext = wikip.name.to_url
       @path = wikip.path
       @allow_uploads = wikip.wiki.allow_uploads

--- a/lib/gollum/views/create.rb
+++ b/lib/gollum/views/create.rb
@@ -46,7 +46,7 @@ module Precious
       end
 
       def page_name
-        @name.gsub('-', ' ')
+        @name
       end
 
       def formats

--- a/lib/gollum/views/edit.rb
+++ b/lib/gollum/views/edit.rb
@@ -16,7 +16,7 @@ module Precious
       end
 
       def page_name
-        @name.gsub('-', ' ')
+        @name
       end
 
       def header


### PR DESCRIPTION
The views were still substituting '-' with space, causing problems when trying to edit pages containing '-'.

I now searched the repo for instances of the string `'-'` and `"-"`, which should return any cases of attempted ws substitution in ruby or javascript (unless I'm too unimaginative). The only other hit was the instance in `app.rb`, which I also took care of in this PR.