### PR TITLE
Changed gollum script to allow unescaped forward slashes in base_path.

### DIFF
--- a/bin/gollum
+++ b/bin/gollum
@@ -76,7 +76,11 @@ opts = OptionParser.new do |opts|
     # make a backup of the option and sanitize it
     base_path_original = base_path.dup
     base_path = CGI.escape(base_path)
-    
+
+    # / characters are perfectly acceptible in paths, and should not be replaced.
+    # This line backs out that change.
+    base_path.gsub!("%2F", "/")
+
     # then let the user know if we changed the URL
     unless base_path_original == base_path
       puts <<MSG

--- a/bin/gollum
+++ b/bin/gollum
@@ -6,6 +6,7 @@ require 'optparse'
 require 'rubygems'
 require 'gollum'
 require 'cgi'
+require 'addressable/uri'
 
 exec         = {}
 options      = {
@@ -75,11 +76,10 @@ opts = OptionParser.new do |opts|
 
     # make a backup of the option and sanitize it
     base_path_original = base_path.dup
-    base_path = CGI.escape(base_path)
 
-    # / characters are perfectly acceptible in paths, and should not be replaced.
-    # This line backs out that change.
-    base_path.gsub!("%2F", "/")
+    # Addressable seems to be the best replacement for the obsolete URI::escape for
+    # encoding a URI properly.
+    base_path = Addressable::URI.escape(base_path)
 
     # then let the user know if we changed the URL
     unless base_path_original == base_path

--- a/gollum.gemspec
+++ b/gollum.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'mustache', ['>= 0.99.5', '< 1.0.0']
   s.add_dependency 'useragent', '~> 0.16.2'
   s.add_dependency 'gemojione', '~> 3.2'
+  s.add_dependency 'addressable', '~> 2.5'
 
   s.add_development_dependency 'rack-test', '~> 0.6.2'
   s.add_development_dependency 'shoulda', '~> 3.5.0'


### PR DESCRIPTION
The code previously would escape / characters (replacing them with "%2F"), which caused working with Omnigollum/Omniauth not to work correctly (since path comparisons no longer showed a matching path).  This minor change makes Gollum work nicely with Omnigollum even when setting a base_path that is multiple levels deep.