### PR TITLE
Update sinatra and other dependencies. Closes #1193

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
 gemspec
-gem 'rake', '~> 10.4'
+gem 'rake', '~> 12', :group => :development

--- a/Rakefile
+++ b/Rakefile
@@ -71,6 +71,7 @@ Rake::TestTask.new(:test) do |test|
   test.libs << 'lib' << 'test' << '.'
   test.pattern = 'test/**/test_*.rb'
   test.verbose = true
+  test.warning = false
 end
 
 desc "Generate RCov test coverage and open in your browser"

--- a/gollum.gemspec
+++ b/gollum.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = %w[README.md LICENSE]
 
   s.add_dependency 'gollum-lib', '~> 5.0.a'
-  s.add_dependency 'kramdown', '~> 1.9.0'
+  s.add_dependency 'kramdown', '~> 1.14.0'
   s.add_dependency 'sinatra', '~> 2.0'
   s.add_dependency 'mustache-sinatra', '~> 1.0.0'
   s.add_dependency 'useragent', '~> 0.16.8'

--- a/gollum.gemspec
+++ b/gollum.gemspec
@@ -26,10 +26,10 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'gollum-lib', '~> 5.0.a'
   s.add_dependency 'kramdown', '~> 1.9.0'
-  s.add_dependency 'sinatra', '~> 1.4', '>= 1.4.4'
-  s.add_dependency 'mustache', ['>= 0.99.5', '< 1.0.0']
-  s.add_dependency 'useragent', '~> 0.16.2'
-  s.add_dependency 'gemojione', '~> 3.2'
+  s.add_dependency 'sinatra', '~> 2.0'
+  s.add_dependency 'mustache-sinatra', '~> 1.0.0'
+  s.add_dependency 'useragent', '~> 0.16.8'
+  s.add_dependency 'gemojione', '~> 3.3'
 
   s.add_development_dependency 'rack-test', '~> 0.6.2'
   s.add_development_dependency 'shoulda', '~> 3.5.0'

--- a/lib/gollum/app.rb
+++ b/lib/gollum/app.rb
@@ -383,14 +383,15 @@ module Precious
       end
     end
 
-    get %r{
-      /compare/ # match any URL beginning with /compare/
-      (.+)      # extract the full path (including any directories)
-      /         # match the final slash
-      ([^.]+)   # match the first SHA1
-      \.{2,3}   # match .. or ...
-      (.+)      # match the second SHA1
-    }x do |path, start_version, end_version|
+    # %r{
+    #   /compare/ # match any URL beginning with /compare/
+    #   (.+)      # extract the full path (including any directories)
+    #   /         # match the final slash
+    #   ([^.]+)   # match the first SHA1
+    #   \.{2,3}   # match .. or ...
+    #   (.+)      # match the second SHA1
+    # }
+    get %r{/compare/(.+)/([^.]+)\.{2,3}(.+)} do |path, start_version, end_version|   
       wikip     = wiki_page(path)
       @path     = wikip.path
       @name     = join_page_name(wikip.name, wikip.ext)
@@ -430,12 +431,13 @@ module Precious
       mustache :search
     end
 
-    get %r{
-      /pages  # match any URL beginning with /pages
-      (?:     # begin an optional non-capturing group
-        /(.+) # capture any path after the "/pages" excluding the leading slash
-      )?      # end the optional non-capturing group
-    }x do |path|
+    # %r{
+    #   /pages  # match any URL beginning with /pages
+    #   (?:     # begin an optional non-capturing group
+    #     /(.+) # capture any path after the "/pages" excluding the leading slash
+    #   )?      # end the optional non-capturing group
+    # }
+    get %r{/pages(?:/(.+))?} do |path|
       @path        = extract_path(path) if path
       wiki_options = settings.wiki_options.merge({ :page_file_dir => @path })
       wiki         = Gollum::Wiki.new(settings.gollum_path, wiki_options)


### PR DESCRIPTION
Had to replace the multiline regexps in `app.rb` with single line variants to get this to work with `sinatra v.2`. Also had to explicitly disable warnings in the test suite because `rake >= 11` throws *a lot* of warnings.