### PR TITLE
Update deprecated MathJax CDN

### DIFF
--- a/lib/gollum/templates/layout.mustache
+++ b/lib/gollum/templates/layout.mustache
@@ -51,7 +51,7 @@
   {{/mathjax_config}}
   <script>(function(d,j){
   j = d.createElement('script');
-  j.src = '//cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML';
+  j.src = '//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML';
   (d.head || d.getElementsByTagName('head')[0]).appendChild(j);
   }(document));
   </script>{{/mathjax}}


### PR DESCRIPTION
The [MathJax CDN was shut down on April 30 2017](https://www.mathjax.org/cdn-shutting-down). This commit replaces the deprecated CDN with the new recommended one.