### PR TITLE
Set template_dir to prepend to search path

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,31 +47,31 @@ For more information on Gollum's capabilities and pitfalls:
 Varies depending on operating system, package manager and Ruby installation. Generally, you should first install Ruby and then Gollum.
 
 1. Ruby is best installed either via [RVM](https://rvm.io/) or a package manager of choice.
-2. Gollum is best installed via RubyGems:  
+2. Gollum is best installed via RubyGems:
 	```
 	[sudo] gem install gollum
 	```
 
 Installation examples for individual systems can be seen [here](https://github.com/gollum/gollum/wiki/Installation).
 
-**Notes:**  
+**Notes:**
 * Whichever Ruby implementation you're using, Gollum ships with the appropriate default git adapter. So the above installation procedure is common for both MRI and JRuby.
 * If you're installing from source:
-	* Optionally uninstall any previous versions of Gollum:  
+	* Optionally uninstall any previous versions of Gollum:
 		```
 		[sudo] gem uninstall -aIx gollum
 		```
 	* Install [Bundler](http://bundler.io/).
 	* Navigate to the cloned source of Gollum.
-	* Install dependencies:  
+	* Install dependencies:
 		```
 		[sudo] bundle install
 		```
-	* Build:  
+	* Build:
 		```
 		rake build
 		```
-	* And install:  
+	* And install:
 		```
 		[sudo] gem install --no-document pkg/gollum*.gem
 		```
@@ -158,7 +158,8 @@ Gollum comes with the following command line options:
 | --collapse-tree   | none      | Tell Gollum to collapse the file tree, when the file view is opened. By default, the tree is expanded. |
 | --user-icons      | [MODE]    | Tell Gollum to use specific user icons for history view. Can be set to `gravatar`, `identicon` or `none`. Default: `none`. |
 | --mathjax-config  | [FILE]    | Specify path to a custom MathJax configuration. If not specified, uses the `mathjax.config.js` file from repository root. |
-| --template-dir    | [PATH]    | Specify custom mustache template directory. |
+| --template-dir    | [PATH]    | Specify custom mustache template directory. This will be
+prepended to the Mustache search path (before the standard Gollum templates) |
 | --help            | none      | Display the list of options on the command line. |
 | --version         | none      | Display the current version of Gollum. |
 

--- a/bin/gollum
+++ b/bin/gollum
@@ -242,7 +242,9 @@ else
   require 'gollum/app'
   Precious::App.set(:gollum_path, gollum_path)
   Precious::App.set(:wiki_options, wiki_options)
-  Precious::App.settings.mustache[:templates] = wiki_options[:template_dir] if wiki_options[:template_dir]
+  if wiki_options[:template_dir]
+    Precious::App.settings.mustache[:templates].prepend(wiki_options[:template_dir] + File::PATH_SEPARATOR)
+  end
 
   if cfg = options[:config]
     # If the path begins with a '/' it will be considered an absolute path,

--- a/gollum.gemspec
+++ b/gollum.gemspec
@@ -27,7 +27,8 @@ Gem::Specification.new do |s|
   s.add_dependency 'gollum-lib', '>= 4.2.7'
   s.add_dependency 'kramdown', '~> 1.9.0'
   s.add_dependency 'sinatra', '~> 1.4', '>= 1.4.4'
-  s.add_dependency 'mustache', ['>= 0.99.5', '< 1.0.0']
+  s.add_dependency 'mustache', '> 1.0.5'
+  s.add_dependency 'mustache-sinatra', '>= 1.0.1'
   s.add_dependency 'useragent', '~> 0.16.2'
   s.add_dependency 'gemojione', '~> 3.2'
 

--- a/lib/gollum/app.rb
+++ b/lib/gollum/app.rb
@@ -96,7 +96,6 @@ module Precious
     before do
       settings.wiki_options[:allow_editing] = settings.wiki_options.fetch(:allow_editing, true)
       @allow_editing = settings.wiki_options[:allow_editing]
-      Precious::App.set(:mustache, {:templates => settings.wiki_options[:template_dir]}) if settings.wiki_options[:template_dir]
       @base_url = url('/', false).chomp('/')
       @page_dir = settings.wiki_options[:page_file_dir].to_s
       # above will detect base_path when it's used with map in a config.ru


### PR DESCRIPTION
* Instead of overriding default search path
  This allows you to create a template directory that contains only the
  mustache template you wish to customize, leaving the remainder of them
  in the default Gollum templates directory. I used this to change just
  the layout.

* Uses File::PATH_SEPARATOR to separate path components, if you want to
  specify more than one search directory

* It requires changes in Mustache for which I've submitted PR #238
  Alternatively point your Gemfile to townsen/mustache@multipath
  Note that this does require mustache-sinatra as a separate gem,
  and may limit you to Ruby > 2.0