### PR TITLE
Change gollum version to 5.0.1b to prevent confusion during development. Closes #1278.

### DIFF
--- a/gollum.gemspec
+++ b/gollum.gemspec
@@ -5,8 +5,8 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.9'
 
   s.name              = 'gollum'
-  s.version           = '4.1.1'
-  s.date              = '2017-04-17'
+  s.version           = '5.0.1b'
+  s.date              = '2017-01-17'
   s.rubyforge_project = 'gollum'
   s.license           = 'MIT'
 

--- a/lib/gollum.rb
+++ b/lib/gollum.rb
@@ -12,7 +12,7 @@ require 'sanitize'
 require File.expand_path('../gollum/uri_encode_component', __FILE__)
 
 module Gollum
-  VERSION = '4.1.1'
+  VERSION = '5.0.1b'
 
   def self.assets_path
     ::File.expand_path('gollum/public', ::File.dirname(__FILE__))


### PR DESCRIPTION
Change gollum version to 5.0.1b to prevent confusion during development. Closes #1278.