### PR TITLE
Adds upload option 'dirpage'

### DIFF
--- a/bin/gollum
+++ b/bin/gollum
@@ -124,11 +124,13 @@ MSG
   opts.on("--no-follow-renames", "Do not follow pages across renames in the History view.") do
     wiki_options[:follow_renames] = false
   end
-  opts.on("--allow-uploads [MODE]", [:dir, :page], "Enable file uploads.",
+  opts.on("--allow-uploads [MODE]", [:dir, :page, :dirpage], "Enable file uploads.",
     "If set to 'dir', Gollum will store all uploads in the '<git-repo>/uploads/' directory.",
-    "If set to 'page', Gollum will store each upload at the currently edited page.") do |mode|
+    "If set to 'page', Gollum will store each upload at the currently edited page.",
+    "If set to 'dirpage', Gollum will store uploads in '<git-repo>/uploads/' directory with subfolder structure mirroring that with 'page'") do |mode|
     wiki_options[:allow_uploads]    = true
-    wiki_options[:per_page_uploads] = true if mode == :page
+    wiki_options[:per_page_uploads] = true if mode == :page || mode == :dirpage
+    wiki_options[:per_page_uploads_cons] = true if mode == :dirpage
   end
   opts.on("--mathjax", "Enable MathJax (renders mathematical equations).",
     "By default, uses the 'TeX-AMS-MML_HTMLorMML' config with the 'autoload-all' extension.") do

--- a/lib/gollum/app.rb
+++ b/lib/gollum/app.rb
@@ -583,10 +583,16 @@ module Precious
     end
 
     def find_upload_dest(path)
-      settings.wiki_options[:allow_uploads] ?
-          (settings.wiki_options[:per_page_uploads] ?
-              "#{path}/#{@name}".sub(/^\/\//, '') : 'uploads'
-          ) : ''
+      if not settings.wiki_options[:allow_uploads]
+        return ''
+      end
+
+      dest = settings.wiki_options[:per_page_uploads] ?
+               "#{path}/#{@name}".sub(/^\/\//, '') : 'uploads'
+      dest = settings.wiki_options[:per_page_uploads_cons] ?
+               ::File.join([settings.wiki_options['page_file_dir'], 'uploads/', dest].compact) : dest
+
+      return dest
     end
   end
 end


### PR DESCRIPTION
Combines options 'dir' and 'page'.

Allows the reuse of filenames for uploaded files. Best of both worlds. Allows the consolidation of uploads in folder uploads, and also creates subfolder structure that mirrors that provided by option page.