### PR TITLE
Handle non-image uploads correctly

### DIFF
--- a/lib/gollum/public/gollum/javascript/editor/gollum.editor.js
+++ b/lib/gollum/public/gollum/javascript/editor/gollum.editor.js
@@ -217,7 +217,15 @@
             type: 'POST',
             success: function(){
               $editorBody.removeClass('uploading');
-              var text = '[[/' + uploadDest + '/' + file.name + ']]';
+              var ext = file.name.split('.').pop().toLowerCase()
+              var image_ext = ['jpg', 'jpeg', 'tif', 'tiff', 'png', 'gif', 'svg', 'bmp']
+              // Link directly to image files
+              if ((image_ext.indexOf(ext) > -1)) {
+                var text = '[[/' + uploadDest + '/' + file.name + ']]';
+              } else {
+                // Add file name to tag for non-image files, to avoid broken image thumbnail
+                var text = '[[' + file.name + '|/' + uploadDest + '/' + file.name + ']]';
+              }
               window.ace_editor.insert(text);
             },
             error: function(r, textStatus) {


### PR DESCRIPTION
### Description

When files are uploaded to the editor using drag-and-drop, they are given this tag:

```
[[/path/to/file.ext]]
```
If the file is an image it is displayed correctly, otherwise a broken image link is shown. This pull request checks creates an alternative tag showing the file name if the file is not an image:

```
[[file.ext|/path/to/file.ext]]
```
### Example

```
**current behaviour**  
[[/Home/document.pdf]]
```
```
**proposed behaviour**  
[[document.pdf|/Home/document.pdf]]
```

![image](https://user-images.githubusercontent.com/11261876/38760535-2be94382-3fbf-11e8-9a09-99da3d9e4a29.png)
