### PR TITLE
Update kramdown

### DIFF
--- a/gollum.gemspec
+++ b/gollum.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = %w[README.md LICENSE]
 
   s.add_dependency 'gollum-lib', '~> 5.0.a'
-  s.add_dependency 'kramdown', '~> 1.9.0'
+  s.add_dependency 'kramdown', '~> 1.17.0'
   s.add_dependency 'sinatra', '~> 2.0'
   s.add_dependency 'mustache', ['>= 0.99.5', '< 1.0.0']
   s.add_dependency 'useragent', '~> 0.16.2'


### PR DESCRIPTION
Update the `kramdown` dependency. Includes a fix for [this kramdown issue](https://github.com/gettalong/kramdown/issues/342), which allows us to let `kramdown` ignore `MathML` so that we can take care of it ourselves.

`kramdown`'s own attempt to handle math was inserting `<script>` tags into the rendered data which was then being sanitized, thus breaking math support altogether. Also see https://github.com/gollum/gollum-lib/pull/302