### PR TITLE
Implement header counting using YAML frontmatter. Resolves #908

### DIFF
--- a/lib/gollum/public/gollum/javascript/gollum.js.erb
+++ b/lib/gollum/public/gollum/javascript/gollum.js.erb
@@ -151,8 +151,6 @@ $(document).ready(function() {
     }
   }
 
-  $('.countheads').get(0).style.setProperty('--countheads-style', $('.countheads').data('countheads-style'));
-
   if ($('#minibutton-upload-page').length) {
     $('#minibutton-upload-page').parent().removeClass('jaws');
     $('#minibutton-upload-page').click(function(e) {

--- a/lib/gollum/public/gollum/javascript/gollum.js.erb
+++ b/lib/gollum/public/gollum/javascript/gollum.js.erb
@@ -151,6 +151,8 @@ $(document).ready(function() {
     }
   }
 
+  $('.countheads').get(0).style.setProperty('--countheads-style', $('.countheads').data('countheads-style'));
+
   if ($('#minibutton-upload-page').length) {
     $('#minibutton-upload-page').parent().removeClass('jaws');
     $('#minibutton-upload-page').click(function(e) {

--- a/lib/gollum/public/gollum/stylesheets/template.scss
+++ b/lib/gollum/public/gollum/stylesheets/template.scss
@@ -92,6 +92,7 @@ body {
   font: 13.34px $font-default;
   font-size: small;
   line-height: 1.4;
+  counter-reset: h1;
 }
 
 img {
@@ -116,6 +117,22 @@ a {
 }
 
 /* Markdown body */
+
+.countheads {
+  h2 {counter-reset: h3}
+  h3 {counter-reset: h4}
+  h4 {counter-reset: h5}
+  h5 {counter-reset: h6}
+
+  --countheads-style: decimal;
+  
+  h1:before {counter-increment: h1; content: counter(h1, var(--countheads-style)) ". ";}
+  h2:before {counter-increment: h2; content: counter(h1, var(--countheads-style)) "."  counter(h2, var(--countheads-style)) ". ";}
+  h3:before {counter-increment: h3; content: counter(h1, var(--countheads-style)) "." counter(h2, var(--countheads-style)) "." counter(h3, var(--countheads-style)) ". ";}
+  h4:before {counter-increment: h4; content: counter(h1, var(--countheads-style)) "." counter(h2, var(--countheads-style)) "." counter(h3, var(--countheads-style)) "." counter(h4, var(--countheads-style)) ". ";}
+  h5:before {counter-increment: h5; content: counter(h1, var(--countheads-style)) "." counter(h2, var(--countheads-style)) "." counter(h3, var(--countheads-style)) "." counter(h4, var(--countheads-style)) "." counter(h5, var(--countheads-style)) ". ";}
+  h6:before {counter-increment: h6; content: counter(h1, var(--countheads-style)) "." counter(h2, var(--countheads-style)) "." counter(h3, var(--countheads-style)) "." counter(h4, var(--countheads-style)) "." counter(h5, var(--countheads-style)) "." counter(h6, var(--countheads-style)) ". ";}
+}
 
 .markdown-body {
   padding: 1em;

--- a/lib/gollum/public/gollum/stylesheets/template.scss
+++ b/lib/gollum/public/gollum/stylesheets/template.scss
@@ -118,20 +118,20 @@ a {
 
 /* Markdown body */
 
-.countheads {
+.header-enum {
   h2 {counter-reset: h3}
   h3 {counter-reset: h4}
   h4 {counter-reset: h5}
   h5 {counter-reset: h6}
 
-  --countheads-style: decimal;
+  --header-enum-style: decimal;
   
-  h1:before {counter-increment: h1; content: counter(h1, var(--countheads-style)) ". ";}
-  h2:before {counter-increment: h2; content: counter(h1, var(--countheads-style)) "."  counter(h2, var(--countheads-style)) ". ";}
-  h3:before {counter-increment: h3; content: counter(h1, var(--countheads-style)) "." counter(h2, var(--countheads-style)) "." counter(h3, var(--countheads-style)) ". ";}
-  h4:before {counter-increment: h4; content: counter(h1, var(--countheads-style)) "." counter(h2, var(--countheads-style)) "." counter(h3, var(--countheads-style)) "." counter(h4, var(--countheads-style)) ". ";}
-  h5:before {counter-increment: h5; content: counter(h1, var(--countheads-style)) "." counter(h2, var(--countheads-style)) "." counter(h3, var(--countheads-style)) "." counter(h4, var(--countheads-style)) "." counter(h5, var(--countheads-style)) ". ";}
-  h6:before {counter-increment: h6; content: counter(h1, var(--countheads-style)) "." counter(h2, var(--countheads-style)) "." counter(h3, var(--countheads-style)) "." counter(h4, var(--countheads-style)) "." counter(h5, var(--countheads-style)) "." counter(h6, var(--countheads-style)) ". ";}
+  h1:before {counter-increment: h1; content: counter(h1, var(--header-enum-style)) ". ";}
+  h2:before {counter-increment: h2; content: counter(h1, var(--header-enum-style)) "."  counter(h2, var(--header-enum-style)) ". ";}
+  h3:before {counter-increment: h3; content: counter(h1, var(--header-enum-style)) "." counter(h2, var(--header-enum-style)) "." counter(h3, var(--header-enum-style)) ". ";}
+  h4:before {counter-increment: h4; content: counter(h1, var(--header-enum-style)) "." counter(h2, var(--header-enum-style)) "." counter(h3, var(--header-enum-style)) "." counter(h4, var(--header-enum-style)) ". ";}
+  h5:before {counter-increment: h5; content: counter(h1, var(--header-enum-style)) "." counter(h2, var(--header-enum-style)) "." counter(h3, var(--header-enum-style)) "." counter(h4, var(--header-enum-style)) "." counter(h5, var(--header-enum-style)) ". ";}
+  h6:before {counter-increment: h6; content: counter(h1, var(--header-enum-style)) "." counter(h2, var(--header-enum-style)) "." counter(h3, var(--header-enum-style)) "." counter(h4, var(--header-enum-style)) "." counter(h5, var(--header-enum-style)) "." counter(h6, var(--header-enum-style)) ". ";}
 }
 
 .markdown-body {

--- a/lib/gollum/templates/page.mustache
+++ b/lib/gollum/templates/page.mustache
@@ -66,7 +66,7 @@ Mousetrap.bind(['e'], function( e ) {
       </div>
     </div>
     {{/has_header}}
-    <div class="markdown-body">
+    <div class="markdown-body {{#countheads}}countheads{{/countheads}}" {{#countheads}}data-countheads-style="{{countheads_style}}"{{/countheads}}>
       {{{rendered_metadata}}}
       {{{content}}}
     </div>

--- a/lib/gollum/templates/page.mustache
+++ b/lib/gollum/templates/page.mustache
@@ -66,7 +66,7 @@ Mousetrap.bind(['e'], function( e ) {
       </div>
     </div>
     {{/has_header}}
-    <div class="markdown-body {{#countheads}}countheads{{/countheads}}" {{#countheads}}style="--countheads-style:{{countheads_style}};"{{/countheads}}>
+    <div class="markdown-body {{#header_enum?}}header-enum{{/header_enum?}}" {{#header_enum?}}style="--header-enum-style:{{header_enum_style}};"{{/header_enum?}}>
       {{{rendered_metadata}}}
       {{{content}}}
     </div>

--- a/lib/gollum/templates/page.mustache
+++ b/lib/gollum/templates/page.mustache
@@ -66,7 +66,7 @@ Mousetrap.bind(['e'], function( e ) {
       </div>
     </div>
     {{/has_header}}
-    <div class="markdown-body {{#countheads}}countheads{{/countheads}}" {{#countheads}}data-countheads-style="{{countheads_style}}"{{/countheads}}>
+    <div class="markdown-body {{#countheads}}countheads{{/countheads}}" {{#countheads}}style="--countheads-style:{{countheads_style}};"{{/countheads}}>
       {{{rendered_metadata}}}
       {{{content}}}
     </div>

--- a/lib/gollum/views/page.rb
+++ b/lib/gollum/views/page.rb
@@ -4,6 +4,14 @@ module Precious
       include HasPage
 
       attr_reader :content, :page, :header, :footer
+      
+      VALID_COUNTER_STYLES = ['decimal', 'decimal-leading-zero', 'arabic-indic', 'armenian', 'upper-armenian',
+        'lower-armenian', 'bengali', 'cambodian', 'khmer', 'cjk-decimal', 'devanagari', 'georgian', 'gujarati', 'gurmukhi',
+        'hebrew', 'kannada', 'lao', 'malayalam', 'mongolian', 'myanmar', 'oriya', 'persian', 'lower-roman', 'upper-roman',
+        'tamil', 'telugu', 'thai', 'tibetan', 'lower-alpha', 'lower-latin', 'upper-alpha', 'upper-latin', 'cjk-earthly-branch',
+        'cjk-heavenly-stem', 'lower-greek', 'hiragana', 'hiragana-iroha', 'katakana', 'katakana-iroha', 'disc', 'circle', 'square',
+        'disclosure-open', 'disclosure-closed'] # https://www.w3.org/TR/css-counter-styles-3/
+
       DATE_FORMAT    = "%Y-%m-%d %H:%M:%S"
       DEFAULT_AUTHOR = 'you'
       @@to_xml       = { :save_with => Nokogiri::XML::Node::SaveOptions::DEFAULT_XHTML ^ 1, :indent => 0, :encoding => 'UTF-8' }
@@ -145,6 +153,16 @@ module Precious
       def rendered_metadata
         return '' unless page.display_metadata? && !metadata.empty?
         @rendered_metadata ||= table(metadata)
+      end
+
+      def countheads
+        !!metadata['countheads']
+      end
+
+      def countheads_style
+        if countheads
+          VALID_COUNTER_STYLES.include?(metadata['countheads']) ? metadata['countheads'] : 'decimal'
+        end
       end
 
       private

--- a/lib/gollum/views/page.rb
+++ b/lib/gollum/views/page.rb
@@ -155,13 +155,13 @@ module Precious
         @rendered_metadata ||= table(metadata)
       end
 
-      def countheads
-        !!metadata['countheads']
+      def header_enum?
+        !!metadata['header_enum']
       end
 
-      def countheads_style
-        if countheads
-          VALID_COUNTER_STYLES.include?(metadata['countheads']) ? metadata['countheads'] : 'decimal'
+      def header_enum_style
+        if header_enum?
+          VALID_COUNTER_STYLES.include?(metadata['header_enum']) ? metadata['header_enum'] : 'decimal'
         end
       end
 

--- a/test/test_page_view.rb
+++ b/test/test_page_view.rb
@@ -52,36 +52,36 @@ EOS
   end
 
   test "allow numbered headings based on metadata" do
-    title = 'countheads test'
-    @wiki.write_page(title, :markdown, "---\ncountheads: true\n---\n# Some markdown\nIn this doc")
+    title = 'header enumeration test'
+    @wiki.write_page(title, :markdown, "---\nheader_enum: true\n---\n# Some markdown\nIn this doc")
     page = @wiki.page(title)
 
     @view = Precious::Views::Page.new
     @view.instance_variable_set :@page, page
 
-    assert_equal @view.countheads, true
-    assert_equal @view.countheads_style, 'decimal'
+    assert_equal @view.header_enum?, true
+    assert_equal @view.header_enum_style, 'decimal'
 
-    title = 'countheads test2'
-    @wiki.write_page(title, :markdown, "---\ncountheads: 'lower-roman'\n---\n# Some markdown\nIn this doc")
+    title = 'header_enum test2'
+    @wiki.write_page(title, :markdown, "---\nheader_enum: 'lower-roman'\n---\n# Some markdown\nIn this doc")
     page = @wiki.page(title)
 
     @view = Precious::Views::Page.new
     @view.instance_variable_set :@page, page
 
-    assert_equal @view.countheads, true
-    assert_equal @view.countheads_style, 'lower-roman'
+    assert_equal @view.header_enum?, true
+    assert_equal @view.header_enum_style, 'lower-roman'
 
     # With invalid style
-    title = 'countheads test3'
-    @wiki.write_page(title, :markdown, "---\ncountheads: 'roman'\n---\n# Some markdown\nIn this doc")
+    title = 'header_enum test3'
+    @wiki.write_page(title, :markdown, "---\nheader_enum: 'roman'\n---\n# Some markdown\nIn this doc")
     page = @wiki.page(title)
 
     @view = Precious::Views::Page.new
     @view.instance_variable_set :@page, page
 
-    assert_equal @view.countheads, true
-    assert_equal @view.countheads_style, 'decimal'
+    assert_equal @view.header_enum?, true
+    assert_equal @view.header_enum_style, 'decimal'
   end
 
   test 'page has sha id' do

--- a/test/test_page_view.rb
+++ b/test/test_page_view.rb
@@ -51,6 +51,39 @@ context "Precious::Views::Page" do
 EOS
   end
 
+  test "allow numbered headings based on metadata" do
+    title = 'countheads test'
+    @wiki.write_page(title, :markdown, "---\ncountheads: true\n---\n# Some markdown\nIn this doc")
+    page = @wiki.page(title)
+
+    @view = Precious::Views::Page.new
+    @view.instance_variable_set :@page, page
+
+    assert_equal @view.countheads, true
+    assert_equal @view.countheads_style, 'decimal'
+
+    title = 'countheads test2'
+    @wiki.write_page(title, :markdown, "---\ncountheads: 'lower-roman'\n---\n# Some markdown\nIn this doc")
+    page = @wiki.page(title)
+
+    @view = Precious::Views::Page.new
+    @view.instance_variable_set :@page, page
+
+    assert_equal @view.countheads, true
+    assert_equal @view.countheads_style, 'lower-roman'
+
+    # With invalid style
+    title = 'countheads test3'
+    @wiki.write_page(title, :markdown, "---\ncountheads: 'roman'\n---\n# Some markdown\nIn this doc")
+    page = @wiki.page(title)
+
+    @view = Precious::Views::Page.new
+    @view.instance_variable_set :@page, page
+
+    assert_equal @view.countheads, true
+    assert_equal @view.countheads_style, 'decimal'
+  end
+
   test 'page has sha id' do
     title = 'test'
     @wiki.write_page(title, :markdown, 'Test' + "\n # 3", commit_details)


### PR DESCRIPTION
Use YAML frontmatter to enable header counting via CSS:
```
---
countheads: true
---
```
Result:
<img width="722" alt="screen shot 2018-10-15 at 01 19 42" src="https://user-images.githubusercontent.com/147111/46923576-d4568580-d019-11e8-9441-257edc3bfe8c.png">

But it is also possible to specify another counter style (also e.g. roman numerals, see `VALID_COUNTER_STYLES` in `page.rb`):

```
---
countheads: 'tibetan'
---
```
Result:
<img width="696" alt="screen shot 2018-10-15 at 01 19 28" src="https://user-images.githubusercontent.com/147111/46923578-e1737480-d019-11e8-95dc-c28416423082.png">
