### PR TITLE
Allow searching multiple keywords

### DIFF
--- a/lib/gollum/app.rb
+++ b/lib/gollum/app.rb
@@ -477,7 +477,8 @@ module Precious
       @query   = params[:q] || ''
       wiki     = wiki_new
       # Sort wiki search results by count (desc) and then by name (asc)
-      @results = wiki.search(@query).sort { |a, b| (a[:count] <=> b[:count]).nonzero? || b[:name] <=> a[:name] }.reverse
+      query_regex = @query.split(/\s/).join('|')
+      @results = wiki.search(query_regex).sort { |a, b| (a[:count] <=> b[:count]).nonzero? || b[:name] <=> a[:name] }.reverse
       @name    = @query
       mustache :search
     end


### PR DESCRIPTION
Git grep supports regex, so in this PR the term (q) is splited by any space caracter and joined using pipe (or in regex).

Now it is possible to search by multiple keywords.

This PR resolve #615.

