### PR TITLE
updated print.css to remove footer on printing

### DIFF
--- a/lib/gollum/public/gollum/css/print.css
+++ b/lib/gollum/public/gollum/css/print.css
@@ -1,8 +1,9 @@
 
 /*
   print.css
-  Removes the action buttons at the top and 
-  the delete link at the bottom for better printing.
+  Removes the action buttons at the top,
+  the delete link at the bottom,
+  and the footer for better printing.
 */
 
 ul.actions {
@@ -11,4 +12,8 @@ ul.actions {
 
 #delete-link {
 	display: none;
+}
+
+div#footer { 
+    display: none;
 }


### PR DESCRIPTION
This should resolve issue #1333. Added in display:none for the footer, and tested locally. For the master branch.