### PR TITLE
Use path helpers consistently

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -191,7 +191,7 @@ task :precompile do
       config.environment = env
       config.prefix      = Precious::Assets::ASSET_URL
       config.digest      = true
-      config.public_path = './public/assets'
+      config.public_path = ENV.fetch('assets_path', './public/assets')
       config.manifest    = manifest
     end
   puts "Precompiling assets to #{::File.expand_path('./public/assets')}..."

--- a/Rakefile
+++ b/Rakefile
@@ -191,7 +191,7 @@ task :precompile do
       config.environment = env
       config.prefix      = Precious::Assets::ASSET_URL
       config.digest      = true
-      config.public_path = ENV.fetch('assets_path', './public/assets')
+      config.public_path = ENV.fetch('GOLLUM_ASSETS_PATH', './public/assets')
       config.manifest    = manifest
     end
   puts "Precompiling assets to #{::File.expand_path('./public/assets')}..."

--- a/Rakefile
+++ b/Rakefile
@@ -177,3 +177,23 @@ task :validate do
     exit!
   end
 end
+
+desc 'Precompile assets'
+task :precompile do
+ require './lib/gollum/views/helpers.rb'
+ require './lib/gollum/assets.rb'
+ require 'sprockets'
+ require 'sprockets-helpers'
+ require 'sass'
+  env = Precious::Assets.sprockets
+  manifest = Sprockets::Manifest.new(env, './public/assets')
+    Sprockets::Helpers.configure do |config|
+      config.environment = env
+      config.prefix      = Precious::Assets::ASSET_URL
+      config.digest      = true
+      config.public_path = './public/assets'
+      config.manifest    = manifest
+    end
+  puts "Precompiling assets to #{::File.expand_path('./public/assets')}..."
+  manifest.compile(Precious::Assets::MANIFEST)
+end

--- a/bin/gollum
+++ b/bin/gollum
@@ -104,9 +104,6 @@ MSG
   opts.on("--assets [PATH]", "Set the path to look for static assets. Only used if --static is set to true, or environment is production/staging. Default: ./public/assets") do |path|
     wiki_options[:static_assets_path] = path
   end
-  opts.on("--precompile-assets [PATH]", "Precompile static assets to PATH.") do |path|
-    options[:precompile] = path || './public/assets'
-  end
   opts.on("--css", "Inject custom CSS into each page. The '<git-repo>/custom.css' file is used (must be committed).") do
     wiki_options[:css] = true
   end
@@ -262,20 +259,6 @@ if options[:irb]
     puts "Invalid Gollum wiki at #{File.expand_path(gollum_path).inspect}"
     exit 0
   end
-elsif options[:precompile]
-  require 'gollum/app'
-  env = Precious::Assets.sprockets
-  manifest = Sprockets::Manifest.new(env, options[:precompile])
-    Sprockets::Helpers.configure do |config|
-      config.environment = env
-      config.environment.context_class.class_variable_set(:@@base_url, wiki_options[:base_path])
-      config.prefix      = "#{wiki_options[:base_path]}/#{Precious::Assets::ASSET_URL}"
-      config.digest      = true
-      config.public_path = options[:precompile]
-      config.manifest    = manifest
-    end
-  puts "Precompiling assets to #{::File.expand_path(options[:precompile])}..."
-  manifest.compile(Precious::Assets::MANIFEST)
 else
   require 'gollum/app'
   Precious::App.set(:gollum_path, gollum_path)

--- a/bin/gollum
+++ b/bin/gollum
@@ -268,6 +268,7 @@ elsif options[:precompile]
   manifest = Sprockets::Manifest.new(env, options[:precompile])
     Sprockets::Helpers.configure do |config|
       config.environment = env
+      config.environment.context_class.class_variable_set(:@@base_url, wiki_options[:base_path])
       config.prefix      = "#{wiki_options[:base_path]}/#{Precious::Assets::ASSET_URL}"
       config.digest      = true
       config.public_path = options[:precompile]

--- a/lib/gollum/app.rb
+++ b/lib/gollum/app.rb
@@ -8,7 +8,6 @@ require 'stringex'
 require 'json'
 require 'sprockets'
 require 'sprockets-helpers'
-require 'uglifier'
 require 'sass'
 
 require 'gollum'

--- a/lib/gollum/public/gollum/javascript/editor/gollum.editor.js.erb
+++ b/lib/gollum/public/gollum/javascript/editor/gollum.editor.js.erb
@@ -151,7 +151,7 @@
           // get form fields
           var oldAction = $('#gollum-editor form').attr('action');
           var $form = $($('#gollum-editor form').get(0));
-          $form.attr('action', this.href || '<%= preview_path >');
+          $form.attr('action', this.href || '<%= preview_path %>');
           $form.attr('target', '_blank');
           var paths = window.location.pathname.split('/');
           $form.attr('page', paths[ paths.length - 1 ] || '')

--- a/lib/gollum/public/gollum/javascript/editor/gollum.editor.js.erb
+++ b/lib/gollum/public/gollum/javascript/editor/gollum.editor.js.erb
@@ -151,7 +151,7 @@
           // get form fields
           var oldAction = $('#gollum-editor form').attr('action');
           var $form = $($('#gollum-editor form').get(0));
-          $form.attr('action', this.href || '/preview');
+          $form.attr('action', this.href || '<%= preview_path >');
           $form.attr('target', '_blank');
           var paths = window.location.pathname.split('/');
           $form.attr('page', paths[ paths.length - 1 ] || '')
@@ -429,7 +429,7 @@
       }
 
       // attempt to load the definition for this language
-      var script_uri = baseUrl + '/assets/editor/langs/' + markup_name + '.js';
+      var script_uri = '<%= assets_path %>/editor/langs/' + markup_name + '.js';
       $.ajax({
                 url: script_uri,
                 dataType: 'script',

--- a/lib/gollum/public/gollum/javascript/editor/gollum.editor.js.erb
+++ b/lib/gollum/public/gollum/javascript/editor/gollum.editor.js.erb
@@ -151,7 +151,7 @@
           // get form fields
           var oldAction = $('#gollum-editor form').attr('action');
           var $form = $($('#gollum-editor form').get(0));
-          $form.attr('action', this.href || '<%= preview_path %>');
+          $form.attr('action', this.href || routePath('preview'));
           $form.attr('target', '_blank');
           var paths = window.location.pathname.split('/');
           $form.attr('page', paths[ paths.length - 1 ] || '')
@@ -209,7 +209,7 @@
           formData.append('file', file);
 
           $.ajax({
-            url: '<%= upload_file_path %>',
+            url: routePath('upload_file'),
             data: formData,
             cache: false,
             contentType: false,
@@ -317,49 +317,42 @@
       }
       if ( !LanguageDefinition.isLoadedFor(name) ) {
         LanguageDefinition._ACTIVE_LANG = null;
-        LanguageDefinition.loadFor( name, function(x, t) {
-          if ( t != 'success' ) {
-            debug('Failed to load language definition for ' + name);
-            // well, fake it and turn everything off for this one
-            LanguageDefinition.define( name, {} );
+
+        // update features that rely on the language definition
+        if ( EditorHas.functionBar() ) {
+          FunctionBar.refresh();
+        }
+
+        if ( LanguageDefinition.isValid() && EditorHas.formatSelector() ) {
+          FormatSelector.updateSelected();
+        }
+
+        if(LanguageDefinition.getHookFunctionFor("activate")) {
+          LanguageDefinition.getHookFunctionFor("activate")();
+        }
+
+        function hotkey( e, cmd ) {
+          e.preventDefault();
+
+          var def = LanguageDefinition.getDefinitionFor( cmd );
+          if ( typeof def == 'object' ) {
+            FunctionBar.executeAction( def );
           }
+          // Prevent bubbling of hotkey.
+          return false;
+        }
 
-          // update features that rely on the language definition
-          if ( EditorHas.functionBar() ) {
-            FunctionBar.refresh();
-          }
+        Mousetrap.bind('mod+1', function( e ){ hotkey( e, 'function-h1' ); });
+        Mousetrap.bind('mod+2', function( e ){ hotkey( e, 'function-h2' ); });
+        Mousetrap.bind('mod+3', function( e ){ hotkey( e, 'function-h3' ); });
+        Mousetrap.bind('mod+b', function( e ){ hotkey( e, 'function-bold' ); });
+        Mousetrap.bind('mod+i', function( e ){ hotkey( e, 'function-italic' ); });
+        Mousetrap.bind('mod+s', function( e ){
+          e.preventDefault();
+          $("#gollum-editor-submit").trigger("click");
+          return false;
+        });
 
-          if ( LanguageDefinition.isValid() && EditorHas.formatSelector() ) {
-            FormatSelector.updateSelected();
-          }
-
-          if(LanguageDefinition.getHookFunctionFor("activate")) {
-            LanguageDefinition.getHookFunctionFor("activate")();
-          }
-
-          function hotkey( e, cmd ) {
-            e.preventDefault();
-
-            var def = LanguageDefinition.getDefinitionFor( cmd );
-            if ( typeof def == 'object' ) {
-              FunctionBar.executeAction( def );
-            }
-            // Prevent bubbling of hotkey.
-            return false;
-          }
-
-          Mousetrap.bind('mod+1', function( e ){ hotkey( e, 'function-h1' ); });
-          Mousetrap.bind('mod+2', function( e ){ hotkey( e, 'function-h2' ); });
-          Mousetrap.bind('mod+3', function( e ){ hotkey( e, 'function-h3' ); });
-          Mousetrap.bind('mod+b', function( e ){ hotkey( e, 'function-bold' ); });
-          Mousetrap.bind('mod+i', function( e ){ hotkey( e, 'function-italic' ); });
-          Mousetrap.bind('mod+s', function( e ){
-            e.preventDefault();
-            $("#gollum-editor-submit").trigger("click");
-            return false;
-          });
-
-        } );
       } else {
         LanguageDefinition._ACTIVE_LANG = name;
         FunctionBar.refresh();
@@ -404,43 +397,6 @@
 
       return null;
     },
-
-
-    /**
-     *  loadFor
-     *  Asynchronously loads a definition file for the current markup.
-     *  Definition files are necessary to use the code editor.
-     *
-     *  @param  string  markup_name  The markup name you want to load
-     *  @return void
-     */
-    loadFor: function( markup_name, on_complete ) {
-      // Keep us from hitting 404s on our site, check the definition blacklist
-      if ( ActiveOptions.NoDefinitionsFor.length ) {
-        for ( var i=0; i < ActiveOptions.NoDefinitionsFor.length; i++ ) {
-          if ( markup_name == ActiveOptions.NoDefinitionsFor[i] ) {
-            // we don't have this. get out.
-            if ( typeof on_complete == 'function' ) {
-              on_complete( null, 'error' );
-              return;
-            }
-          }
-        }
-      }
-
-      // attempt to load the definition for this language
-      var script_uri = '<%= assets_path %>/editor/langs/' + markup_name + '.js';
-      $.ajax({
-                url: script_uri,
-                dataType: 'script',
-                complete: function( xhr, textStatus ) {
-                  if ( typeof on_complete == 'function' ) {
-                    on_complete( xhr, textStatus );
-                  }
-                }
-            });
-    },
-
 
     /**
      *  isLoadedFor

--- a/lib/gollum/public/gollum/javascript/gollum.dialog.js.erb
+++ b/lib/gollum/public/gollum/javascript/gollum.dialog.js.erb
@@ -101,7 +101,7 @@
 
       var id = fieldAttributes.id || 'upload';
       var name = fieldAttributes.name || 'file';
-      var action = fieldAttributes.action || '/upload_file';
+      var action = fieldAttributes.action || '<%= upload_file_path %>';
 
       html += '<form method=post enctype="multipart/form-data" ' +
         'action="' + action + '" ' + 'id="' + id + '">';

--- a/lib/gollum/public/gollum/javascript/gollum.dialog.js.erb
+++ b/lib/gollum/public/gollum/javascript/gollum.dialog.js.erb
@@ -101,7 +101,7 @@
 
       var id = fieldAttributes.id || 'upload';
       var name = fieldAttributes.name || 'file';
-      var action = fieldAttributes.action || '<%= upload_file_path %>';
+      var action = fieldAttributes.action || routePath('upload_file');
 
       html += '<form method=post enctype="multipart/form-data" ' +
         'action="' + action + '" ' + 'id="' + id + '">';

--- a/lib/gollum/public/gollum/javascript/gollum.js.erb
+++ b/lib/gollum/public/gollum/javascript/gollum.js.erb
@@ -1,4 +1,27 @@
 // Helpers
+
+// Get path for named route, prefixing baseUrl if necessary
+// Uses the route definitions in /lib/gollum/views/helpers.rb.
+// For example, routePath('delete') is equivalent to 'delete_path' in the mustache templates.
+function routePath(name){
+  var routes = $.parseJSON('<%= routes_to_json %>')
+  path = routes[name]
+  if (baseUrl == undefined ) {
+    console.log('Gollum error: baseUrl undefined')
+  } else if (path == undefined ) {
+    console.log('Could not find route with name: ' + name)
+  } else {
+      if ( baseUrl == "") {
+        return path;
+      } else if (baseUrl.charAt(baseUrl.length -1) == '/') {
+        result = baseUrl + path;
+      } else {
+        result = baseUrl + '/' + path;
+      }
+    return result.replace(/\/{2}/g, '/')
+  }
+}
+
 function pageName(){
   // "my/dir/file.md" => "file"
   if (typeof(pageFullPath) == 'undefined') {
@@ -48,7 +71,7 @@ $(document).ready(function() {
   $('#delete-link').click( function(e) {
     var ok = confirm($(this).data('confirm'));
     if ( ok ) {
-      $.post('<%=delete_path %>/' + pageFullPath,
+      $.post(routePath('delete') + '/' + pageFullPath,
         {},
         function (result) {
           // page successfully deleted, return to landing page
@@ -63,7 +86,7 @@ $(document).ready(function() {
     var ok = confirm($(this).data('confirm'));
     if ( ok ) {
       var element = $(this);
-      $.post('<%=delete_path %>' + $(this).data('file-path'),
+      $.post(routePath('delete') + '/' + $(this).data('file-path'),
         {},
         function (result) {
           // file successfully deleted, stay on overview but remove element from DOM
@@ -183,7 +206,7 @@ $(document).ready(function() {
           {
             type:   'file',
             context: 'Your uploaded file will be accessible at<br>/'+uploadDest+'/[filename]',
-            action: '<%= upload_file_path %>'
+            action: routePath('upload_file')
           }
         ],
         OK: function( res ) {
@@ -247,14 +270,7 @@ $(document).ready(function() {
         // In the pages view, pageFullPath isn't defined.
         // The new button will still expect a value however.
         // So we try to figure one out from window.location
-        path = window.location.pathname.substr(1)
-        // Remove the page viewer part of the url.
-        <%
-          pages_path_uri = pages_path
-          pages_path_uri = pages_path_uri[1..-1] if pages_path_uri[0] == '/'
-          pages_path_uri = pages_path_uri.gsub('/','\/')
-        %>
-        path = path.replace(/^<%= pages_path_uri %>\/?/,'')
+        path = window.location.pathname.replace(routePath('pages'), '')
         // For consistency remove the trailing /
         path = path.replace(/\/$/,'')
       }
@@ -285,7 +301,7 @@ $(document).ready(function() {
           for( var i=0; i < name_parts.length; i++ ){
             name_encoded.push(encodeURIComponent(name_parts[i]));
           }
-          window.location =  '<%= create_path %>' + name_encoded.join('/');
+          window.location =  routePath('create') + name_encoded.join('/');
         }
       });
     });
@@ -340,7 +356,7 @@ $(document).ready(function() {
   if( $("#last-edit").length ) {
     $("#page-info-toggle").click ( function () {
       $.ajax({
-        url: '<%= last_commit_info_path %>',
+        url: routePath('last_commit_info'),
         data: {path: $("#page-info-toggle").data('pagepath')},
         success: function ( data ) {
           $("#last-edit").html('Last edited by <b>' + data.author + '</b>, ' + data.date);

--- a/lib/gollum/public/gollum/stylesheets/_base.scss
+++ b/lib/gollum/public/gollum/stylesheets/_base.scss
@@ -46,10 +46,10 @@ $editor-button-img-width: 27px;
 $editor-button-img-height: 28px;
 
 //urls
-$img_fileview_doc: image-url('fileview/document.png');
-$img_fileview_trash: image-url('fileview/trashcan.png');
-$img_fileview_toggle_small: image-url('fileview/toggle-small.png');
-$img_fileview_toggle_small_expand: image-url('fileview/toggle-small-expand.png');
-$img_fileview_folder: image-url('fileview/folder-horizontal.png');
-$img_icon_sprite: image-url('icon-sprite.png');
-$img_dirty_shade: image-url('dirty-shade.png');
+$img_fileview_doc: url('../images/fileview/document.png');
+$img_fileview_trash: url('../images/fileview/trashcan.png');
+$img_fileview_toggle_small: url('../images/fileview/toggle-small.png');
+$img_fileview_toggle_small_expand: url('../images/fileview/toggle-small-expand.png');
+$img_fileview_folder: url('../images/fileview/folder-horizontal.png');
+$img_icon_sprite: url('../images/icon-sprite.png');
+$img_dirty_shade: url('../images/dirty-shade.png');

--- a/lib/gollum/templates/page.mustache
+++ b/lib/gollum/templates/page.mustache
@@ -1,7 +1,7 @@
 <script>
 Mousetrap.bind(['e'], function( e ) {
   e.preventDefault();
-  window.location = "/edit" + window.location.pathname;
+  window.location = "{{edit_path}}" + '/' + pageFullPath;
   return false;
 });
 </script>

--- a/lib/gollum/views/helpers.rb
+++ b/lib/gollum/views/helpers.rb
@@ -1,4 +1,4 @@
-require 'yaml'
+require 'json'
 
 module Precious
   module Views
@@ -26,15 +26,21 @@ module Precious
           if path.respond_to?(:keys)
             self.parse_routes(path, "#{prefix}/#{name}")
           else
+            route_path = "#{prefix}/#{path}"
+            @@route_methods[name.to_s] = route_path
             define_method :"#{name.to_s}_path" do
-              "#{base_url}/#{prefix}/#{path}".gsub(/\/{2,}/, '/') # remove double slashes
+              "#{base_url}/#{route_path}".gsub(/\/{2,}/, '/') # remove double slashes
             end
           end
         end
       end
 
       def self.included(base)
+        @@route_methods = {}
         self.parse_routes(ROUTES)
+        define_method :routes_to_json do
+          @@route_methods.to_json
+        end
       end
     end
 

--- a/lib/gollum/views/helpers.rb
+++ b/lib/gollum/views/helpers.rb
@@ -4,8 +4,8 @@ module Precious
   module Views
     module RouteHelpers
       ROUTES = {
-        assets: 'assets',
         'gollum' => {
+          assets: 'assets',
           last_commit_info: 'last_commit_info',
           latest_changes: 'latest_changes',
           upload_file: 'upload_file',

--- a/lib/gollum/views/helpers.rb
+++ b/lib/gollum/views/helpers.rb
@@ -4,6 +4,7 @@ module Precious
   module Views
     module RouteHelpers
       ROUTES = {
+        assets: 'assets',
         'gollum' => {
           last_commit_info: 'last_commit_info',
           latest_changes: 'latest_changes',

--- a/lib/gollum/views/pages.rb
+++ b/lib/gollum/views/pages.rb
@@ -57,7 +57,7 @@ module Precious
               klass = (defined? result.format) ? "page" : "file"
               url = "#{@base_url}/#{result.escaped_url_path}"
               
-              file_link = %{<li><a href="#{url}" class="#{klass}">#{result.filename}</a>#{delete_file(url) if @allow_editing}</li>}
+              file_link = %{<li><a href="#{url}" class="#{klass}">#{result.filename}</a>#{delete_file(result.escaped_url_path) if @allow_editing}</li>}
               files[result.name] = file_link
             end
           end


### PR DESCRIPTION
Found a couple of instances where the javascript was not using path helpers. I did some extensive grepping, including for `'/`, `baseUrl`, and all the currently existing route names, and moved to using the path helpers.