### PR TITLE
Implements frontend support for CriticMarkup. Related to #1016.

### DIFF
--- a/bin/gollum
+++ b/bin/gollum
@@ -135,6 +135,9 @@ MSG
     "By default, uses the 'TeX-AMS-MML_HTMLorMML' config with the 'autoload-all' extension.") do
     wiki_options[:mathjax] = true
   end
+  opts.on("--critic-markup", "Enable CriticMarkup support.") do
+    wiki_options[:critic_markup] = true
+  end
   opts.on("--irb", "Launch Gollum in 'console mode', with a predefined API.") do
     options[:irb] = true
   end

--- a/bin/gollum
+++ b/bin/gollum
@@ -135,7 +135,7 @@ MSG
     "By default, uses the 'TeX-AMS-MML_HTMLorMML' config with the 'autoload-all' extension.") do
     wiki_options[:mathjax] = true
   end
-  opts.on("--critic-markup", "Enable CriticMarkup support.") do
+  opts.on("--critic-markup", "Enable support for annotations using CriticMarkup.") do
     wiki_options[:critic_markup] = true
   end
   opts.on("--irb", "Launch Gollum in 'console mode', with a predefined API.") do

--- a/lib/gollum/app.rb
+++ b/lib/gollum/app.rb
@@ -84,6 +84,7 @@ module Precious
     before do
       settings.wiki_options[:allow_editing] = settings.wiki_options.fetch(:allow_editing, true)
       @allow_editing = settings.wiki_options[:allow_editing]
+      @critic_markup = settings.wiki_options[:critic_markup]
       forbid unless @allow_editing || request.request_method == "GET"
       Precious::App.set(:mustache, {:templates => settings.wiki_options[:template_dir]}) if settings.wiki_options[:template_dir]
       @base_url = url('/', false).chomp('/')

--- a/lib/gollum/assets.rb
+++ b/lib/gollum/assets.rb
@@ -1,6 +1,6 @@
 module Precious
   module Assets
-    MANIFEST = %w(app.js app.css fileview.css ie7.css print.css *.png *.jpg *.svg *.eot *.ttf *.woff *.woff2)
+    MANIFEST = %w(app.js app.css criticmarkup.css fileview.css ie7.css print.css *.png *.jpg *.svg *.eot *.ttf *.woff *.woff2)
     ASSET_URL = 'gollum/assets'
     
     def self.sprockets(dir = File.dirname(File.expand_path(__FILE__)))

--- a/lib/gollum/public/gollum/javascript/editor/langs/asciidoc.js
+++ b/lib/gollum/public/gollum/javascript/editor/langs/asciidoc.js
@@ -113,7 +113,34 @@ var AsciiDoc = {
                                   }
                                 });
                               }
-                            }
+                            },
+                            
+  'function-critic-accept' : {
+                              exec: function( txt, selText, $field) {
+                                var toReplace = selText.
+                                  replace(/\{\+\+(.*?)\+\+[ \t]*(\[(.*?)\])?[ \t]*\}/gm, "$1").
+                                  replace(/\{--(.*?)--[ \t]*(\[(.*?)\])?[ \t]*\}/gm, "").
+                                  replace(/\{~~(.*?)~>(.*?)~~\}/gm, "$2").
+                                  replace(/\{\=\=(.*?)[ \t]*(\[(.*?)\])?[ \t]*\=\=\}{>>(.*?)<<\}/gm, "$1").
+                                  replace(/\{>>(.*?)<<\}/gm, "")
+                                $.GollumEditor.replaceSelection( toReplace );
+                              }
+
+                          },
+
+    'function-critic-reject' : {
+                                exec: function( txt, selText, $field) {
+                                  var toReplace = selText.
+                                    replace(/\{\+\+(.*?)\+\+[ \t]*(\[(.*?)\])?[ \t]*\}/gm, "").
+                                    replace(/\{--(.*?)--[ \t]*(\[(.*?)\])?[ \t]*\}/gm, "$1").
+                                    replace(/\{~~(.*?)~>(.*?)~~\}/gm, "$1").
+                                    replace(/\{\=\=(.*?)[ \t]*(\[(.*?)\])?[ \t]*\=\=\}{>>(.*?)<<\}/gm, "$1").
+                                    replace(/\{>>(.*?)<<\}/gm, "")
+                                  $.GollumEditor.replaceSelection( toReplace );
+                                }
+
+                             }
+    
 
 };
 

--- a/lib/gollum/public/gollum/javascript/editor/langs/creole.js
+++ b/lib/gollum/public/gollum/javascript/editor/langs/creole.js
@@ -96,7 +96,33 @@ var Creole = {
                                   }
                                 });
                               }
-                            }
+                            },
+  'function-critic-accept' : {
+                              exec: function( txt, selText, $field) {
+                                var toReplace = selText.
+                                  replace(/\{\+\+(.*?)\+\+[ \t]*(\[(.*?)\])?[ \t]*\}/gm, "$1").
+                                  replace(/\{--(.*?)--[ \t]*(\[(.*?)\])?[ \t]*\}/gm, "").
+                                  replace(/\{~~(.*?)~>(.*?)~~\}/gm, "$2").
+                                  replace(/\{\=\=(.*?)[ \t]*(\[(.*?)\])?[ \t]*\=\=\}{>>(.*?)<<\}/gm, "$1").
+                                  replace(/\{>>(.*?)<<\}/gm, "")
+                                $.GollumEditor.replaceSelection( toReplace );
+                              }
+
+                          },
+
+    'function-critic-reject' : {
+                                exec: function( txt, selText, $field) {
+                                  var toReplace = selText.
+                                    replace(/\{\+\+(.*?)\+\+[ \t]*(\[(.*?)\])?[ \t]*\}/gm, "").
+                                    replace(/\{--(.*?)--[ \t]*(\[(.*?)\])?[ \t]*\}/gm, "$1").
+                                    replace(/\{~~(.*?)~>(.*?)~~\}/gm, "$1").
+                                    replace(/\{\=\=(.*?)[ \t]*(\[(.*?)\])?[ \t]*\=\=\}{>>(.*?)<<\}/gm, "$1").
+                                    replace(/\{>>(.*?)<<\}/gm, "")
+                                  $.GollumEditor.replaceSelection( toReplace );
+                                }
+
+                             }
+
 
 };
 

--- a/lib/gollum/public/gollum/javascript/editor/langs/markdown.js
+++ b/lib/gollum/public/gollum/javascript/editor/langs/markdown.js
@@ -139,7 +139,33 @@ var MarkDown = {
                                   }
                                 });
                               }
-                            }
+                            },
+                            
+  'function-critic-accept' : {
+                                exec: function( txt, selText, $field) {
+                                  var toReplace = selText.
+                                    replace(/\{\+\+(.*?)\+\+[ \t]*(\[(.*?)\])?[ \t]*\}/gm, "$1").
+                                    replace(/\{--(.*?)--[ \t]*(\[(.*?)\])?[ \t]*\}/gm, "").
+                                    replace(/\{~~(.*?)~>(.*?)~~\}/gm, "$2").
+                                    replace(/\{\=\=(.*?)[ \t]*(\[(.*?)\])?[ \t]*\=\=\}{>>(.*?)<<\}/gm, "$1").
+                                    replace(/\{>>(.*?)<<\}/gm, "")
+                                  $.GollumEditor.replaceSelection( toReplace );
+                                }
+      
+                            },
+  
+  'function-critic-reject' : {
+                                exec: function( txt, selText, $field) {
+                                  var toReplace = selText.
+                                    replace(/\{\+\+(.*?)\+\+[ \t]*(\[(.*?)\])?[ \t]*\}/gm, "").
+                                    replace(/\{--(.*?)--[ \t]*(\[(.*?)\])?[ \t]*\}/gm, "$1").
+                                    replace(/\{~~(.*?)~>(.*?)~~\}/gm, "$1").
+                                    replace(/\{\=\=(.*?)[ \t]*(\[(.*?)\])?[ \t]*\=\=\}{>>(.*?)<<\}/gm, "$1").
+                                    replace(/\{>>(.*?)<<\}/gm, "")
+                                  $.GollumEditor.replaceSelection( toReplace );
+                                }
+      
+                             }
 
 };
 

--- a/lib/gollum/public/gollum/javascript/editor/langs/org.js
+++ b/lib/gollum/public/gollum/javascript/editor/langs/org.js
@@ -105,7 +105,34 @@ var OrgMode = {
                                   }
                                 });
                               }
-                            }
+                            },
+                            
+  'function-critic-accept' : {
+                              exec: function( txt, selText, $field) {
+                                var toReplace = selText.
+                                  replace(/\{\+\+(.*?)\+\+[ \t]*(\[(.*?)\])?[ \t]*\}/gm, "$1").
+                                  replace(/\{--(.*?)--[ \t]*(\[(.*?)\])?[ \t]*\}/gm, "").
+                                  replace(/\{~~(.*?)~>(.*?)~~\}/gm, "$2").
+                                  replace(/\{\=\=(.*?)[ \t]*(\[(.*?)\])?[ \t]*\=\=\}{>>(.*?)<<\}/gm, "$1").
+                                  replace(/\{>>(.*?)<<\}/gm, "")
+                                $.GollumEditor.replaceSelection( toReplace );
+                              }
+
+                          },
+
+    'function-critic-reject' : {
+                                exec: function( txt, selText, $field) {
+                                  var toReplace = selText.
+                                    replace(/\{\+\+(.*?)\+\+[ \t]*(\[(.*?)\])?[ \t]*\}/gm, "").
+                                    replace(/\{--(.*?)--[ \t]*(\[(.*?)\])?[ \t]*\}/gm, "$1").
+                                    replace(/\{~~(.*?)~>(.*?)~~\}/gm, "$1").
+                                    replace(/\{\=\=(.*?)[ \t]*(\[(.*?)\])?[ \t]*\=\=\}{>>(.*?)<<\}/gm, "$1").
+                                    replace(/\{>>(.*?)<<\}/gm, "")
+                                  $.GollumEditor.replaceSelection( toReplace );
+                                }
+
+                             }
+
 
 };
 

--- a/lib/gollum/public/gollum/javascript/editor/langs/pod.js
+++ b/lib/gollum/public/gollum/javascript/editor/langs/pod.js
@@ -63,7 +63,34 @@ var Pod = {
                                   }
                                 });
                               }
-                            }
+                            },
+                            
+  'function-critic-accept' : {
+                              exec: function( txt, selText, $field) {
+                                var toReplace = selText.
+                                  replace(/\{\+\+(.*?)\+\+[ \t]*(\[(.*?)\])?[ \t]*\}/gm, "$1").
+                                  replace(/\{--(.*?)--[ \t]*(\[(.*?)\])?[ \t]*\}/gm, "").
+                                  replace(/\{~~(.*?)~>(.*?)~~\}/gm, "$2").
+                                  replace(/\{\=\=(.*?)[ \t]*(\[(.*?)\])?[ \t]*\=\=\}{>>(.*?)<<\}/gm, "$1").
+                                  replace(/\{>>(.*?)<<\}/gm, "")
+                                $.GollumEditor.replaceSelection( toReplace );
+                              }
+
+                          },
+
+    'function-critic-reject' : {
+                                exec: function( txt, selText, $field) {
+                                  var toReplace = selText.
+                                    replace(/\{\+\+(.*?)\+\+[ \t]*(\[(.*?)\])?[ \t]*\}/gm, "").
+                                    replace(/\{--(.*?)--[ \t]*(\[(.*?)\])?[ \t]*\}/gm, "$1").
+                                    replace(/\{~~(.*?)~>(.*?)~~\}/gm, "$1").
+                                    replace(/\{\=\=(.*?)[ \t]*(\[(.*?)\])?[ \t]*\=\=\}{>>(.*?)<<\}/gm, "$1").
+                                    replace(/\{>>(.*?)<<\}/gm, "")
+                                  $.GollumEditor.replaceSelection( toReplace );
+                                }
+
+                             }
+
 
 };
 

--- a/lib/gollum/public/gollum/javascript/editor/langs/rdoc.js
+++ b/lib/gollum/public/gollum/javascript/editor/langs/rdoc.js
@@ -65,7 +65,34 @@ var RDoc = {
   'function-h3'         :   {
                               search: /(.+)([\n]?)/gi,
                               replace: "=== $1$2"
-                            }
+                            },
+                            
+  'function-critic-accept' : {
+                              exec: function( txt, selText, $field) {
+                                var toReplace = selText.
+                                  replace(/\{\+\+(.*?)\+\+[ \t]*(\[(.*?)\])?[ \t]*\}/gm, "$1").
+                                  replace(/\{--(.*?)--[ \t]*(\[(.*?)\])?[ \t]*\}/gm, "").
+                                  replace(/\{~~(.*?)~>(.*?)~~\}/gm, "$2").
+                                  replace(/\{\=\=(.*?)[ \t]*(\[(.*?)\])?[ \t]*\=\=\}{>>(.*?)<<\}/gm, "$1").
+                                  replace(/\{>>(.*?)<<\}/gm, "")
+                                $.GollumEditor.replaceSelection( toReplace );
+                              }
+
+                          },
+
+    'function-critic-reject' : {
+                                exec: function( txt, selText, $field) {
+                                  var toReplace = selText.
+                                    replace(/\{\+\+(.*?)\+\+[ \t]*(\[(.*?)\])?[ \t]*\}/gm, "").
+                                    replace(/\{--(.*?)--[ \t]*(\[(.*?)\])?[ \t]*\}/gm, "$1").
+                                    replace(/\{~~(.*?)~>(.*?)~~\}/gm, "$1").
+                                    replace(/\{\=\=(.*?)[ \t]*(\[(.*?)\])?[ \t]*\=\=\}{>>(.*?)<<\}/gm, "$1").
+                                    replace(/\{>>(.*?)<<\}/gm, "")
+                                  $.GollumEditor.replaceSelection( toReplace );
+                                }
+
+                             }
+
 
 };
 

--- a/lib/gollum/public/gollum/javascript/editor/langs/textile.js
+++ b/lib/gollum/public/gollum/javascript/editor/langs/textile.js
@@ -102,7 +102,34 @@ var Textile = {
                                   }
                                 });
                               }
-                            }
+                            },
+                            
+  'function-critic-accept' : {
+                              exec: function( txt, selText, $field) {
+                                var toReplace = selText.
+                                  replace(/\{\+\+(.*?)\+\+[ \t]*(\[(.*?)\])?[ \t]*\}/gm, "$1").
+                                  replace(/\{--(.*?)--[ \t]*(\[(.*?)\])?[ \t]*\}/gm, "").
+                                  replace(/\{~~(.*?)~>(.*?)~~\}/gm, "$2").
+                                  replace(/\{\=\=(.*?)[ \t]*(\[(.*?)\])?[ \t]*\=\=\}{>>(.*?)<<\}/gm, "$1").
+                                  replace(/\{>>(.*?)<<\}/gm, "")
+                                $.GollumEditor.replaceSelection( toReplace );
+                              }
+
+                          },
+
+    'function-critic-reject' : {
+                                exec: function( txt, selText, $field) {
+                                  var toReplace = selText.
+                                    replace(/\{\+\+(.*?)\+\+[ \t]*(\[(.*?)\])?[ \t]*\}/gm, "").
+                                    replace(/\{--(.*?)--[ \t]*(\[(.*?)\])?[ \t]*\}/gm, "$1").
+                                    replace(/\{~~(.*?)~>(.*?)~~\}/gm, "$1").
+                                    replace(/\{\=\=(.*?)[ \t]*(\[(.*?)\])?[ \t]*\=\=\}{>>(.*?)<<\}/gm, "$1").
+                                    replace(/\{>>(.*?)<<\}/gm, "")
+                                  $.GollumEditor.replaceSelection( toReplace );
+                                }
+
+                             }
+
 
 };
 

--- a/lib/gollum/public/gollum/javascript/gollum.js.erb
+++ b/lib/gollum/public/gollum/javascript/gollum.js.erb
@@ -358,6 +358,14 @@ $(document).ready(function() {
     $.GollumEditor({ NewFile: true, MarkupType: default_markup });
   }
 
+  // CriticMarkup
+  if(criticMarkup == 'true') {
+    $('#wiki-content').addClass('criticmarkup');
+    $('ins.break').unwrap();
+    $('span.critic.comment').wrap('<span class="popover" />');
+    $('span.critic.comment').filter(function() {return $(this).text()!="";}).before('&#8225;');
+  }
+
   if( $('#wiki-history').length ){
     var lookup = {};
     $('img.identicon').each(function(index, element){

--- a/lib/gollum/public/gollum/stylesheets/app.scss
+++ b/lib/gollum/public/gollum/stylesheets/app.scss
@@ -1,4 +1,5 @@
 //= require gollum
 //= require editor
 //= require dialog
+//= require criticmarkup
 //= require template

--- a/lib/gollum/public/gollum/stylesheets/criticmarkup.scss
+++ b/lib/gollum/public/gollum/stylesheets/criticmarkup.scss
@@ -1,0 +1,42 @@
+.criticmarkup mark {
+    background-color: #fffd38;
+    text-decoration: none;
+}
+
+.criticmarkup del {
+    background-color: #f6a9a9;
+    text-decoration: line-through;
+}
+.criticmarkup ins {
+    background-color: #a9f6a9;
+    text-decoration: none;
+}
+.criticmarkup ins.break {
+	display: block;
+	line-height: 2px;
+	padding: 0 !important;
+	margin: 0 !important;
+}
+.criticmarkup ins.break span {
+	line-height: 1.5em;
+}
+.criticmarkup .popover {
+	background-color: #fffd38;
+	color: #000;
+}
+.criticmarkup .critic.comment {
+    display: none;
+}
+
+.criticmarkup .popover:hover span.critic.comment {
+    display: block;
+    position: absolute;
+    width: 200px;
+    left: 30%;
+    font-size: 0.8em; 
+    color: #ccc;
+    background-color: #333;
+    z-index: 10;
+    padding: 0.5em 1em;
+    border-radius: 0.5em;
+}

--- a/lib/gollum/public/gollum/stylesheets/editor.scss
+++ b/lib/gollum/public/gollum/stylesheets/editor.scss
@@ -367,8 +367,8 @@ a#function-h2 { @include editor-button(9); }
 a#function-h3 { @include editor-button(10); }
 a#function-link { @include editor-button(11); }
 a#function-image { @include editor-button(12); }
-a#function-plus { @include editor-button(13); }
-a#function-minus { @include editor-button(14); }
+a#function-critic-accept { @include editor-button(13); }
+a#function-critic-reject { @include editor-button(14); }
 a#function-help { @include editor-button(15); }
 a#function-search { @include editor-button(16); }
 

--- a/lib/gollum/templates/editor.mustache
+++ b/lib/gollum/templates/editor.mustache
@@ -49,6 +49,12 @@
       <span>Link</span></a>
     <a href="#" id="function-image" class="function-button" title="Image">
       <span>Image</span></a>
+	{{#critic_markup}}
+    <a href="#" id="function-critic-accept" class="function-button" title="Accept Selected CriticMarkup">
+      <span>Accept Selected CriticMarkup</span></a>
+    <a href="#" id="function-critic-reject" class="function-button" title="Reject Selected CriticMarkup">
+      <span>Reject Selected CriticMarkup</span></a>
+	{{/critic_markup}}
     <span class="function-divider">&nbsp;</span>
     <a href="#" id="function-help" class="function-button" title="Help">
       <span>Help</span></a>

--- a/lib/gollum/templates/layout.mustache
+++ b/lib/gollum/templates/layout.mustache
@@ -20,6 +20,7 @@
       {{#page}}
       var pageFullPath = '{{url_path}}';
       {{/page}}
+      var criticMarkup = '{{critic_markup}}';
   </script>
   {{#sprockets_javascript_tag}}app{{/sprockets_javascript_tag}}
   {{#use_identicon}}

--- a/lib/gollum/views/edit.rb
+++ b/lib/gollum/views/edit.rb
@@ -60,9 +60,6 @@ module Precious
         true
       end
 
-      def critic_markup
-        @critic_markup
-      end
       
       def allow_uploads
         @allow_uploads

--- a/lib/gollum/views/edit.rb
+++ b/lib/gollum/views/edit.rb
@@ -60,6 +60,10 @@ module Precious
         true
       end
 
+      def critic_markup
+        @critic_markup
+      end
+      
       def allow_uploads
         @allow_uploads
       end

--- a/lib/gollum/views/layout.rb
+++ b/lib/gollum/views/layout.rb
@@ -43,6 +43,10 @@ module Precious
       def js # custom js
         @js
       end
+      
+      def critic_markup
+        @critic_markup
+      end
 
     end
   end


### PR DESCRIPTION
This PR implements styling for CriticMarkup (backend support is already in gollum-lib: https://github.com/gollum/gollum-lib/pull/308). 

![screen shot 2018-11-08 at 16 18 21](https://user-images.githubusercontent.com/571173/48207906-f968ba80-e371-11e8-994c-087122e076c7.png)

In addition, this PR also adds two buttons to the editor for accepting or rejecting proposed changes in selected text.

