### PR TITLE
Force path variable in pages route to end with /. Resolves #1241

### DIFF
--- a/lib/gollum/app.rb
+++ b/lib/gollum/app.rb
@@ -454,7 +454,9 @@ module Precious
           /(.+) # capture any path after the "/pages" excluding the leading slash
         )?      # end the optional non-capturing group
       }x do |path|
-        @path        = extract_path(path) if path
+        if path
+          @path = path[-1] == '/' ? extract_path(path) : extract_path("#{path}/")
+        end
         wiki_options = settings.wiki_options.merge({ :page_file_dir => @path })
         wiki         = Gollum::Wiki.new(settings.gollum_path, wiki_options)
         @results     = wiki.pages


### PR DESCRIPTION
The current logic for the /pages routes assumes that the path the user requests ends with a slash. Because of the way the `extract_path` helper works, a request for `/gollum/pages/a/b` will result in the path `a`, and only `/gollum/pages/a/b/` (with trailing slash) will result int the path `a/b` being displayed.

According to #1241 embedding gollum in a rails application has the consequence that the trailing slash removed from the request path that's handed over to gollum. I don't know if that's still an issue (don't have a quick way to reproduce), but I can see how using gollum with rack middleware could result in such situations. The current PR just forces the presence of a trailing slash. I don't think that has any ill consequences, and it may help to solve/prevent such issues in the future. Without a testing environment I'm shooting blind here, however.