### PR TITLE
[WIP] Improve editor buttons: insert markup at the correct position. Resolves #504

### DIFF
--- a/lib/gollum/public/gollum/javascript/editor/gollum.editor.js.erb
+++ b/lib/gollum/public/gollum/javascript/editor/gollum.editor.js.erb
@@ -667,7 +667,35 @@
         // get the selected text from the textarea
         var editor = window.ace_editor;
         var txt = editor.getValue();
+        var rtPrefix = '';
+        var rtSuffix = '';
+        var breakBefore = false;
+        var breakAfter = false;
+        var selRange = editor.getSelectionRange();
         var selText = editor.getSelectedText();
+        if (selText === '' ) {
+          if (definitionObject.whole_line && definitionObject.whole_line == true) {
+            var line = selRange.start.row;
+            selText = editor.session.getLine(line);
+            var Range = ace.require('ace/range').Range;
+            selRange = new Range(line, 0, line, selText.length);
+          } else if (definitionObject.break_line && definitionObject.break_line == true) {
+            breakBefore = true;
+          }
+        } else if (definitionObject.break_line && definitionObject.break_line == true) {
+          breakBefore = true;
+          breakAfter  = true;
+        }
+
+        // Only prefix a newline to the replacement text if we're not already at the start of the line
+        if (breakBefore == true && selRange.start.column > 0) {
+          rtPrefix = '\n';
+        }
+
+        if (breakAfter == true) {
+          rtSuffix = '\n';
+        }
+
         var repText = selText;
         var reselect = true;
         var cursor = null;
@@ -697,7 +725,8 @@
         if ( definitionObject.replace &&
              typeof definitionObject.replace == 'string' ) {
           debug('Running replacement - using ' + definitionObject.replace);
-          var rt = definitionObject.replace;
+          var rt = definitionObject.replace
+          rt = rtPrefix + rt + rtSuffix;
 
           repText = escape( repText );
           repText = repText.replace( searchExp, rt );
@@ -732,8 +761,13 @@
         }
 
         if ( repText ) {
-          editor.session.replace(editor.selection.getRange(), repText);
+          editor.session.replace(selRange, repText);
           editor.focus();
+          if (breakAfter == true) {
+            var row = editor.getCursorPosition().row-1;
+            var column = editor.session.getLine(row).length;
+            editor.selection.moveTo(row, column)
+          }
         }
 
       },

--- a/lib/gollum/public/gollum/javascript/editor/langs/markdown.js
+++ b/lib/gollum/public/gollum/javascript/editor/langs/markdown.js
@@ -42,7 +42,8 @@ var MarkDown = {
 
   'function-ul'     :       {
                               search: /(.+)([\n]?)/g,
-                              replace: "* $1$2"
+                              replace: "* $1$2",
+                              break_line: true
                             },
   /* based on rdoc.js */
   'function-ol'   :         {
@@ -64,22 +65,28 @@ var MarkDown = {
 
   'function-blockquote' :   {
                               search: /(.+)([\n]?)/g,
-                              replace: "> $1$2"
-                            },
+                              replace: "> $1$2",
+                              break_line: true                            },
 
   'function-h1'         :   {
                               search: /(.+)([\n]?)/g,
-                              replace: "# $1$2"
+                              replace: "# $1$2",
+                              break_line: true,
+                              whole_line: true
                             },
 
   'function-h2'         :   {
                               search: /(.+)([\n]?)/g,
-                              replace: "## $1$2"
+                              replace: "## $1$2",
+                              break_line: true,
+                              whole_line: true
                             },
 
   'function-h3'         :   {
                               search: /(.+)([\n]?)/g,
-                              replace: "### $1$2"
+                              replace: "### $1$2",
+                              break_line: true,
+                              whole_line: true
                             },
 
   'function-link'       :   {


### PR DESCRIPTION
Adds two keys to the language definitions for the editor function buttons:
* `break_line`: when true, then if...
  * there is no selection, then a newline is prefixed to the inserted text
  * there is a selection, then a newline is prefixed to AND added to the end of the inserted text
  * e.g. unordered lists and block quotes should break the line, whereas e.g. bold and italic should not
  * Edge case: if the markup is inserted at the beginning of the line, then no newline is prefixed
* `whole_line`: when true, then if there is no selection, then the markup is applied to the whole line
  * e.g. h1-h3 should be applied to the whole line, whereas e.g. unordered lists and bold should not

I've set `break_line` and `whole_line` to true where applicable, but only for the markdown language definition for now. I can add it to the other languages definitions if this general approach is approved (help appreciated in determining which buttons in which languages should be `break_line` and `whole_line`, respectively).