### PR TITLE
Implement infrastructure for detecting and handling simultaneous edits

### DIFF
--- a/lib/gollum/app.rb
+++ b/lib/gollum/app.rb
@@ -287,7 +287,8 @@ module Precious
         
         return if page.nil?
         if etag != page.sha
-          halt 412, 'For future use: some helpful data for resolving the conflict here.'
+          # Signal edit collision and return the page's most recent version
+          halt 412, {etag: page.sha, text_data: page.text_data}.to_json
         end
         
         committer = Gollum::Committer.new(wiki, commit_message)

--- a/lib/gollum/app.rb
+++ b/lib/gollum/app.rb
@@ -176,7 +176,7 @@ module Precious
               @page         = page
               @page.version = wiki.repo.log(wiki.ref, @page.path).first
               @content      = page.text_data
-              @etag       = Digest::SHA1.hexdigest(@content)
+              @etag         = page.sha
               mustache :edit
           else
             redirect_to("/create/#{encodeURIComponent(@name)}")
@@ -279,14 +279,14 @@ module Precious
       end
 
       post '/edit/*' do
-        etag = params[:etag]        
+        etag      = params[:etag]        
         path      = "/#{clean_url(sanitize_empty_params(params[:path]))}"
         page_name = CGI.unescape(params[:page])
         wiki      = wiki_new
         page      = wiki.paged(page_name, path, exact = true)
         
         return if page.nil?
-        if etag != Digest::SHA1.hexdigest(page.text_data) 
+        if etag != page.sha
           halt 412, 'For future use: some helpful data for resolving the conflict here.'
         end
         

--- a/lib/gollum/public/gollum/javascript/gollum.js.erb
+++ b/lib/gollum/public/gollum/javascript/gollum.js.erb
@@ -367,6 +367,34 @@ $(document).ready(function() {
       window.onbeforeunload = function(){ return "Leaving will discard all edits!" };
     });
     $.GollumEditor();
+    $("#gollum-editor-submit").click( function(e) {
+      e.preventDefault();
+      // Prevent button from being clicked again
+      $(this).attr('disabled', true);
+
+      var formData = new FormData($('#gollum-editor-form').get(0));
+      var endpoint = $('#gollum-editor-form').attr("action");
+
+      $.ajax({
+        url: endpoint,
+        type: 'POST',
+        data: formData,
+        processData: false,
+        contentType: false,
+        success: function(data) {
+          window.location = window.location.href.replace(/gollum\/edit\//, '')
+        },
+        error: function(data, textStatus, errorThrown) {
+          if (data.status == 412) {
+            $('#gollum-editor-submit').attr('disabled', false)
+            alert('Someone else has modified this page while you were editing it. Please store your version on disk outside of the browser, reload this page and reapply your modifications.');
+          } else {
+            alert('Error updating page: ' + textStatus + ' ' + errorThrown);
+          }  
+        }
+      });
+      
+    });
   }
 
   if( $("#last-edit").length ) {

--- a/lib/gollum/templates/editor.mustache
+++ b/lib/gollum/templates/editor.mustache
@@ -1,9 +1,9 @@
 <div id="gollum-editor" data-escaped-name="{{escaped_name}}" class="{{#is_create_page}}create{{/is_create_page}}{{#is_edit_page}}edit{{/is_edit_page}} {{#allow_uploads}}uploads-allowed{{/allow_uploads}}">
 {{#is_create_page}}
-<form name="gollum-editor" action="{{create_path}}" method="post">
+<form id="gollum-editor-form" name="gollum-editor" action="{{create_path}}" method="post">
 {{/is_create_page}}
 {{#is_edit_page}}
-<form name="gollum-editor" action="{{edit_path}}/{{escaped_name}}" method="post">
+<form id="gollum-editor-form" name="gollum-editor" action="{{edit_path}}/{{escaped_name}}" method="post">
 {{/is_edit_page}}
   <fieldset id="gollum-editor-fields">
   {{#is_create_page}}
@@ -17,6 +17,7 @@
   {{/is_create_page}}
   {{#is_edit_page}}
   <input type="hidden" name="page" id="gollum-editor-page-title" value="{{page_name}}">
+  <input type="hidden" name="etag" id="gollum-editor-etag" value="{{etag}}">
   {{/is_edit_page}}
   <input type="hidden" name="path" id="gollum-editor-page-path" value="{{path}}">
   <div id="gollum-editor-function-bar">

--- a/lib/gollum/views/edit.rb
+++ b/lib/gollum/views/edit.rb
@@ -60,6 +60,9 @@ module Precious
         true
       end
 
+      def etag
+        @etag
+      end
       
       def allow_uploads
         @allow_uploads

--- a/test/test_unicode.rb
+++ b/test/test_unicode.rb
@@ -57,8 +57,7 @@ context "Frontend Unicode support" do
     page = @wiki.page('PG')
     assert_equal '다른 text', utf8(page.raw_data)
 
-    post '/gollum/edit/PG', :page => 'PG', :content => '바뀐 text', :message => 'ghi'
-    follow_redirect!
+    post '/gollum/edit/PG', :page => 'PG', :content => '바뀐 text', :message => 'ghi', :etag => page.sha
     assert last_response.ok?
 
     @wiki = Gollum::Wiki.new(@path)
@@ -79,8 +78,7 @@ context "Frontend Unicode support" do
     assert_equal '다른 text', utf8(page.raw_data)
 
     post '/gollum/edit/' + CGI.escape('한글'), :page => 'k', :content => '바뀐 text',
-         :format                            => 'markdown', :message => 'ghi'
-    follow_redirect!
+         :format => 'markdown', :message => 'ghi', :etag => page.sha
     assert last_response.ok?
 
     @wiki = Gollum::Wiki.new(@path)


### PR DESCRIPTION
This PR implements the infrastructure for detecting and handling simultaneous edits. It does this on the basis of a hash of the contents of the page. The hash is generated in the `get 'edit/*'` action and passed into the `gollum-editor-form` form as a hidden field named `etag`. When, after editing the page, the form is submitted via an ajax call to `post 'edit/*'` the original hash is compared to a new hash of the contents of the page before the new changes are applied. If the hashes match, this means that the page has not been modified since the user started editing. If the hashes do not match, the page has been changed in the meantime, and action has to be taken to resolve the version conflict. In the current implementation, a conflict results in a notification warning the user about the conflict. In a future implementation, this could be expanded to offer the user a user-friendly way of merging the two versions.

![screen shot 2018-11-16 at 14 41 49](https://user-images.githubusercontent.com/571173/48624853-d8294f00-e9ad-11e8-9741-baeede28cf46.png)

Caveats:
* This is not thread-safe. It is technically possible that while the two hashes are being compared for  request A, the page is updated by B and subsequently overwritten by A's changes.
* Even if this code was thread-safe, it cannot be guaranteed that the page is not updated via the CLI simultaneously.

Still, having this mechanism in place seems better than not having anything at all (the current situation). Comments welcome!