### PR TITLE
Do not attempt to normalize uploaded files unless they have valid page extensions.

### DIFF
--- a/lib/gollum/app.rb
+++ b/lib/gollum/app.rb
@@ -227,9 +227,11 @@ module Precious
           options.merge! author
         end
 
+        normalize = !(Gollum::File.image?(fullname) || Gollum::File.binary?(fullname))
+
         begin
           committer = Gollum::Committer.new(wiki, options)
-          committer.add_to_index(dir, filename, format, contents)
+          committer.add_to_index(dir, filename, format, contents, {normalize: normalize})
           committer.after_commit do |committer, sha|
             wiki.clear_cache
             committer.update_working_dir(dir, filename, format)

--- a/lib/gollum/app.rb
+++ b/lib/gollum/app.rb
@@ -227,7 +227,7 @@ module Precious
           options.merge! author
         end
 
-        normalize = !(Gollum::File.image?(fullname) || Gollum::File.binary?(fullname))
+        normalize = Gollum::Page.valid_extension?(fullname)
 
         begin
           committer = Gollum::Committer.new(wiki, options)


### PR DESCRIPTION
Fairly straightforward fix since the relevant code will live in `gollum-lib`. Basically, the proposal is to add to class methods to `Gollum::File`, namely `image?(filename)` and `binary?(filename)`. Thoughts?

NB. This PR should not be merged until `gollum-lib-5.x` implements these methods.