### PR TITLE
Implements a breadcrumb for normal wiki pages. Resolves #629.

### DIFF
--- a/lib/gollum/public/gollum/stylesheets/gollum.scss
+++ b/lib/gollum/public/gollum/stylesheets/gollum.scss
@@ -34,6 +34,7 @@ a {
   margin: 1em 0 0;
   padding: 0;
   overflow: hidden;
+  width: 100%;
 
   @include desktop-breakpoint {
     border-bottom: $border-standard;
@@ -46,13 +47,23 @@ a {
     float: left;
     line-height: normal;
     margin: 0;
-    margin-top: 2em;
+    margin-top: 3em;
     padding: 0 0 0 0.667em;
 
     @include desktop-breakpoint {
       font-size: 2.5em;
       padding: 2px 0 0 0;
     }
+  }
+  
+  div.breadcrumb {
+    margin: 0;
+    padding: 0;
+    position: absolute;
+    margin-top: 3.5em;
+    float: none;
+    overflow: auto;
+    font-size: 1.5em;
   }
 
   ul.actions {

--- a/lib/gollum/templates/page.mustache
+++ b/lib/gollum/templates/page.mustache
@@ -6,7 +6,7 @@ Mousetrap.bind(['e'], function( e ) {
 });
 </script>
 <div id="wiki-wrapper" class="page">
-<div id="head">
+<div id="head"> 
   <h1>{{page_header}}</h1>
   <ul class="actions">
 		<li class="minibutton"><a href="{{base_url}}/"
@@ -43,6 +43,7 @@ Mousetrap.bind(['e'], function( e ) {
     <li class="minibutton"><a href="{{latest_changes_path}}"
        class="action-page-history">Latest Changes</a></li>
   </ul>
+  <div class="breadcrumb">{{{breadcrumb}}}</div>
 </div>
 <div id="wiki-content">
 <div class="{{#has_header}}has-header{{/has_header}}{{#has_footer}} has-footer{{/has_footer}}{{#has_sidebar}} has-sidebar has-{{bar_side}}bar{{/has_sidebar}}{{#has_toc}} has-toc{{/has_toc}}">

--- a/lib/gollum/views/page.rb
+++ b/lib/gollum/views/page.rb
@@ -18,11 +18,22 @@ module Precious
 
       def title
         h1 = @h1_title ? page_header_from_content(@content) : false
-        h1 || @page.url_path_title
+        h1 || @page.title
       end
 
       def page_header
         title
+      end
+      
+      def breadcrumb
+        path = Pathname.new(@page.url_path_title)
+        breadcrumb = []
+        path.descend do |crumb|
+          element = "#{crumb.basename}"
+          next if element == @page.title
+          breadcrumb << %{<a href="#{pages_path}/#{crumb}/">#{element}</a>}
+        end
+        breadcrumb.empty? ? "" : breadcrumb.join(" / ") << " /"
       end
 
       def content


### PR DESCRIPTION
Notice that this breadcrumb trail will currently include `page-file-dir` as an element when it is enabled. However, since `page-fir-dir` [is set to become internal](https://github.com/gollum/gollum/issues/1052), this should resolve itself once https://github.com/gollum/gollum/issues/1052 is implemented.