### PR TITLE
Correct matching of '/pages' and '/compare'.

### DIFF
--- a/lib/gollum/app.rb
+++ b/lib/gollum/app.rb
@@ -435,7 +435,7 @@ module Precious
     end
 
     get %r{
-      /compare/ # match any URL beginning with /compare/
+      ^/compare/ # match any URL beginning with /compare/
       (.+)      # extract the full path (including any directories)
       /         # match the final slash
       ([^.]+)   # match the first SHA1
@@ -483,7 +483,7 @@ module Precious
     end
 
     get %r{
-      /pages  # match any URL beginning with /pages
+      ^/pages # match any URL beginning with /pages
       (?:     # begin an optional non-capturing group
         /(.+) # capture any path after the "/pages" excluding the leading slash
       )?      # end the optional non-capturing group


### PR DESCRIPTION
So far, these keywords were matched anywhere in the path. This means that folders with these names are not possible anywhere, and if they exist, they lead to unexpected behavior.