### PR TITLE
Fix h1-title at org-mode

### DIFF
--- a/lib/gollum/views/page.rb
+++ b/lib/gollum/views/page.rb
@@ -157,8 +157,6 @@ module Precious
         case @page.format
           when :asciidoc
             doc.css("div#gollum-root > h1:first-child")
-          when :org
-            doc.css("div#gollum-root > p.title:first-child")
           when :pod
             doc.css("div#gollum-root > a.dummyTopAnchor:first-child + h1")
           when :rest


### PR DESCRIPTION
h1-title cannot fetched H1 tag at org-mode.
It fixed.

## before

`H1 Title1` should be the page title.

![before](https://user-images.githubusercontent.com/122881/54448605-804df980-478f-11e9-8805-cb8f59bbf71b.png)

## after

`H1 Title1` is the page title.

![after](https://user-images.githubusercontent.com/122881/54448625-86dc7100-478f-11e9-816d-85388f70de7d.png)

##  content

This is page content.

![content](https://user-images.githubusercontent.com/122881/54448634-8d6ae880-478f-11e9-8759-e64f563ec90c.png)
