### PR TITLE
Fix h1-title at org-mode

### DIFF
--- a/lib/gollum/views/page.rb
+++ b/lib/gollum/views/page.rb
@@ -186,8 +186,6 @@ module Precious
         case @page.format
           when :asciidoc
             doc.css("div#gollum-root > h1:first-child")
-          when :org
-            doc.css("div#gollum-root > p.title:first-child")
           when :pod
             doc.css("div#gollum-root > a.dummyTopAnchor:first-child + h1")
           when :rest


### PR DESCRIPTION
h1-title cannot fetched H1 tag at org-mode.
It fixed.

ref: #1372

## before

`H1 Title1` should be the page title.

![Screen Shot 2019-03-20 at 22 22 53](https://user-images.githubusercontent.com/122881/54687469-f7eca180-4b5e-11e9-8d8e-bfe82f6c66fc.png)

```
$ bundle exec ./bin/gollum --versions
Gollum 5.0.1b
Running on: x86_64-darwin18 with Ruby version 2.5.3
Using:
gollum-grit_adapter 1.0.1
gollum-lib 5.0.a.4
rugged 0.28.1
gollum-rugged_adapter 0.4.4
With the following renderers:
kramdown 1.17.0
org-ruby 0.9.12
```


## after

`H1 Title1` is the page title.

![Screen Shot 2019-03-20 at 22 22 10](https://user-images.githubusercontent.com/122881/54687480-fae79200-4b5e-11e9-8c65-47f98406f4be.png)


##  content

This is page content.

![Screen Shot 2019-03-20 at 22 23 23](https://user-images.githubusercontent.com/122881/54687446-ed320c80-4b5e-11e9-811d-00ef816652bb.png)

