### PR TITLE
Gemspec: drop EOL'd property rubyforge_project

### DIFF
--- a/gollum.gemspec
+++ b/gollum.gemspec
@@ -7,7 +7,6 @@ Gem::Specification.new do |s|
   s.name              = 'gollum'
   s.version           = '4.1.4'
   s.date              = '2018-10-01'
-  s.rubyforge_project = 'gollum'
   s.license           = 'MIT'
 
   s.summary     = 'A simple, Git-powered wiki.'


### PR DESCRIPTION
The RubyGems gemspec property `rubyforge_project` has been removed without a replacement. This PR removes that property.

## Background

* [RubyForge was closed down in 2013][1].
* [rubygems/rubygems#2436 deprecated the `rubyforge_project` property][2].

[1]: https://twitter.com/evanphx/status/399552820380053505
[2]: rubygems/rubygems#2436