### PR TITLE
Pagination for history and latest changes.

### DIFF
--- a/lib/gollum/app.rb
+++ b/lib/gollum/app.rb
@@ -388,7 +388,7 @@ module Precious
         unless @page.nil?
           @versions = @page.versions(
             per_page: @max_count,
-            page: @page_num,
+            page_num: @page_num,
             follow: settings.wiki_options.fetch(:follow_renames,
               ::Gollum::GIT_ADAPTER == 'rjgit' ? false : true)
           )
@@ -402,7 +402,7 @@ module Precious
         @wiki = wiki_new
         @page_num = [params[:page_num].to_i, 1].max
         @max_count = settings.wiki_options.fetch(:pagination_count, 10)
-        @versions = @wiki.latest_changes(::Gollum::Page.log_pagination_options(per_page: @max_count, page: @page_num))
+        @versions = @wiki.latest_changes(::Gollum::Page.log_pagination_options(per_page: @max_count, page_num: @page_num))
         mustache :latest_changes
       end
 

--- a/lib/gollum/app.rb
+++ b/lib/gollum/app.rb
@@ -385,9 +385,9 @@ module Precious
         @name     = wikip.fullname
         @page     = wikip.page
         @page_num = [params[:page_num].to_i, 1].max
-        @max_count = settings.wiki_options.fetch(:latest_changes_count, 10)
+        @max_count = settings.wiki_options.fetch(:pagination_count, 10)
         unless @page.nil?
-          @versions = @page.versions(:max_count => @max_count, :skip => (@page_num-1) * @max_count, :follow => settings.wiki_options.fetch(:follow_renames, ::Gollum::GIT_ADAPTER == 'rjgit' ? false : true))
+          @versions = @page.versions(:per_page => @max_count, :page => @page_num, :follow => settings.wiki_options.fetch(:follow_renames, ::Gollum::GIT_ADAPTER == 'rjgit' ? false : true))
           mustache :history
         else
           redirect to("/")
@@ -397,7 +397,7 @@ module Precious
       get '/latest_changes' do
         @wiki = wiki_new
         @page_num = [params[:page_num].to_i, 1].max
-        @max_count = settings.wiki_options.fetch(:latest_changes_count, 10)
+        @max_count = settings.wiki_options.fetch(:pagination_count, 10)
         @versions = @wiki.latest_changes({:max_count => @max_count, :skip => (@page_num-1) * @max_count})
         mustache :latest_changes
       end

--- a/lib/gollum/app.rb
+++ b/lib/gollum/app.rb
@@ -389,7 +389,8 @@ module Precious
           @versions = @page.versions(
             per_page: @max_count,
             page: @page_num,
-            follow: settings.wiki_options.fetch(:follow_renames, ::Gollum::GIT_ADAPTER == 'rjgit' ? false : true)
+            follow: settings.wiki_options.fetch(:follow_renames,
+              ::Gollum::GIT_ADAPTER == 'rjgit' ? false : true)
           )
           mustache :history
         else
@@ -401,10 +402,7 @@ module Precious
         @wiki = wiki_new
         @page_num = [params[:page_num].to_i, 1].max
         @max_count = settings.wiki_options.fetch(:pagination_count, 10)
-        @versions = @wiki.latest_changes(::Gollum::Page.log_pagination_options(
-          per_page: @max_count,
-          page: @page_num
-        ))
+        @versions = @wiki.latest_changes(::Gollum::Page.log_pagination_options(per_page: @max_count, page: @page_num))
         mustache :latest_changes
       end
 

--- a/lib/gollum/app.rb
+++ b/lib/gollum/app.rb
@@ -386,7 +386,11 @@ module Precious
         @page_num = [params[:page_num].to_i, 1].max
         @max_count = settings.wiki_options.fetch(:pagination_count, 10)
         unless @page.nil?
-          @versions = @page.versions(:per_page => @max_count, :page => @page_num, :follow => settings.wiki_options.fetch(:follow_renames, ::Gollum::GIT_ADAPTER == 'rjgit' ? false : true))
+          @versions = @page.versions(
+            per_page: @max_count,
+            page: @page_num,
+            follow: settings.wiki_options.fetch(:follow_renames, ::Gollum::GIT_ADAPTER == 'rjgit' ? false : true)
+          )
           mustache :history
         else
           redirect to("/")
@@ -397,7 +401,10 @@ module Precious
         @wiki = wiki_new
         @page_num = [params[:page_num].to_i, 1].max
         @max_count = settings.wiki_options.fetch(:pagination_count, 10)
-        @versions = @wiki.latest_changes({:max_count => @max_count, :skip => (@page_num-1) * @max_count})
+        @versions = @wiki.latest_changes(::Gollum::Page.log_pagination_options(
+          per_page: @max_count,
+          page: @page_num
+        ))
         mustache :latest_changes
       end
 

--- a/lib/gollum/app.rb
+++ b/lib/gollum/app.rb
@@ -357,8 +357,7 @@ module Precious
         else
           sha2, sha1 = sha1, "#{sha1}^" if !sha2
           @versions  = [sha1, sha2]
-          diffs      = wiki.repo.diff(@versions.first, @versions.last, @page.path)
-          @diff      = diffs.first
+          @diff      = wiki.full_reverse_diff_for(@page, @versions.first, @versions.last)
           @message   = "The patch does not apply."
           mustache :compare
         end
@@ -430,8 +429,7 @@ module Precious
         @versions = [start_version, end_version]
         wiki      = wikip.wiki
         @page     = wikip.page
-        diffs     = wiki.repo.diff(@versions.first, @versions.last, @page.path)
-        @diff     = diffs.first
+        @diff     = wiki.full_reverse_diff_for(@page, @versions.first, @versions.last)
         mustache :compare
       end
 

--- a/lib/gollum/public/gollum/javascript/gollum.js.erb
+++ b/lib/gollum/public/gollum/javascript/gollum.js.erb
@@ -364,9 +364,21 @@ $(document).ready(function() {
     if( $("#page-history #pagination").length) {
 
       var maxSelected = 2;
+      var selectionColors = ["bg-green-light", "bg-red-light"];
 
       var toggleInputs = function () {
-        var numSelected = $("#selection-form input").length;
+        var numSelected = 0;
+        $("#selection-form input").each(function (index, element) {
+          var value = $(element).val();
+          var input = $('#version-form input[value="' + value + '"]');
+          input.prop('checked', true);
+          if (index == 0) {
+            input.closest("li").removeClass(selectionColors[1]).addClass(selectionColors[index]);
+          } else if (index == 1) {
+            input.closest("li").addClass(selectionColors[index]); 
+          }
+          numSelected = numSelected + 1;
+        });
         if (numSelected == maxSelected) {
           $('#version-form input:not(:checked)').prop('disabled', true);
           $('.history button.action-compare-revision').prop('disabled', false);
@@ -388,6 +400,7 @@ $(document).ready(function() {
 
       var onCheckboxUnselect = function( box ) {
         $('#selection-form #' + $(box).val()).remove();
+        $(box).closest("li").removeClass(selectionColors.join(" "));
         toggleInputs();
       };
 
@@ -412,15 +425,18 @@ $(document).ready(function() {
               var rowDiv = $('#page-history-list', data);
               var new_pagination = $('#pagination', data);
 
-              $('#pagination #next')[0].hidden = new_pagination.find('#next')[0].hidden;
-              $('#pagination #prev')[0].hidden = new_pagination.find('#prev')[0].hidden;
+              next = $('#pagination #next');
+              prev = $('#pagination #prev');
+              new_next = new_pagination.find('#next');
+              new_prev = new_pagination.find('#prev');
+
+              next[0].hidden = new_next[0].hidden;
+              prev[0].hidden = new_prev[0].hidden;
+
+              next.children('a').attr('href', new_next.children('a').attr('href'));
+              prev.children('a').attr('href', new_prev.children('a').attr('href'));
 
               $('#page-history-list').replaceWith(rowDiv);
-
-              $("#selection-form input").each(function (index, element) {
-                var value = $(element).val();
-                $('#version-form input[value="' + value + '"]').prop('checked', true);
-              });
 
               setCheckboxEvents();
               toggleInputs();

--- a/lib/gollum/public/gollum/javascript/gollum.js.erb
+++ b/lib/gollum/public/gollum/javascript/gollum.js.erb
@@ -97,91 +97,6 @@ $(document).ready(function() {
     e.preventDefault();
   } );
 
-
-  var nodeSelector = {
-    node1: null,
-    node2: null,
-
-    selectNodeRange: function( n1, n2 ) {
-      if ( nodeSelector.node1 && nodeSelector.node2 ) {
-        $('#wiki-history td.selected').removeClass('selected');
-        nodeSelector.node1.addClass('selected');
-        nodeSelector.node2.addClass('selected');
-
-        // swap the nodes around if they went in reverse
-        if ( nodeSelector.nodeComesAfter( nodeSelector.node1,
-                                          nodeSelector.node2 ) ) {
-          var n = nodeSelector.node1;
-          nodeSelector.node1 = nodeSelector.node2;
-          nodeSelector.node2 = n;
-        }
-
-        var s = true;
-        var $nextNode = nodeSelector.node1.next();
-        while ( $nextNode ) {
-          $nextNode.addClass('selected');
-          if ( $nextNode[0] == nodeSelector.node2[0] ) {
-            break;
-          }
-          $nextNode = $nextNode.next();
-        }
-      }
-    },
-
-    nodeComesAfter: function ( n1, n2 ) {
-      var s = false;
-      $(n1).prevAll().each(function() {
-        if ( $(this)[0] == $(n2)[0] ) {
-          s = true;
-        }
-      });
-      return s;
-    },
-
-    checkNode: function( nodeCheckbox ) {
-      var $nodeCheckbox = nodeCheckbox;
-      var $node = $(nodeCheckbox).parent().parent();
-      // if we're unchecking
-      if ( !$nodeCheckbox.is(':checked') ) {
-
-        // remove the range, since we're breaking it
-        $('#wiki-history tr.selected').each(function() {
-          if ( $(this).find('td.checkbox input').is(':checked') ) {
-            return;
-          }
-          $(this).removeClass('selected');
-        });
-
-        // no longer track this
-        if ( $node[0] == nodeSelector.node1[0] ) {
-          nodeSelector.node1 = null;
-          if ( nodeSelector.node2 ) {
-            nodeSelector.node1 = nodeSelector.node2;
-            nodeSelector.node2 = null;
-          }
-        } else if ( $node[0] == nodeSelector.node2[0] ) {
-          nodeSelector.node2 = null;
-        }
-
-      } else {
-        if ( !nodeSelector.node1 ) {
-          nodeSelector.node1 = $node;
-          nodeSelector.node1.addClass('selected');
-        } else if ( !nodeSelector.node2 ) {
-          // okay, we don't have a node 2 but have a node1
-          nodeSelector.node2 = $node;
-          nodeSelector.node2.addClass('selected');
-          nodeSelector.selectNodeRange( nodeSelector.node1,
-                                        nodeSelector.node2 );
-        } else {
-          // we have two selected already
-          $nodeCheckbox[0].checked = false;
-        }
-      }
-    }
-  };
-
-
   // ua detection
   if ($.browser.mozilla) {
     $('body').addClass('ff');
@@ -443,6 +358,10 @@ $(document).ready(function() {
       });
       
     });
+  }
+
+  if( $("#page-history").length) {
+
   }
 
   if( $("#last-edit").length ) {

--- a/lib/gollum/public/gollum/javascript/gollum.js.erb
+++ b/lib/gollum/public/gollum/javascript/gollum.js.erb
@@ -266,7 +266,7 @@ $(document).ready(function() {
 
     if ($('.history button.action-compare-revision').length) {
       $('.history button.action-compare-revision').click(function() {
-        $("#version-form").submit();
+        $("#selection-form").submit();
       });
     }
   }
@@ -361,7 +361,80 @@ $(document).ready(function() {
   }
 
   if( $("#page-history").length) {
+    if( $("#page-history #pagination").length) {
 
+      var maxSelected = 2;
+
+      var toggleInputs = function () {
+        var numSelected = $("#selection-form input").length;
+        if (numSelected == maxSelected) {
+          $('#version-form input:not(:checked)').prop('disabled', true);
+          $('.history button.action-compare-revision').prop('disabled', false);
+        } else if (numSelected < maxSelected) {
+          $('#version-form input').prop('disabled', false);
+          $('.history button.action-compare-revision').prop('disabled', true);
+        }
+      };
+
+      var onCheckboxSelect = function ( box ) {
+        $('<input>').attr({
+          type: 'hidden',
+          id: $(box).val(),
+          name: 'versions[]',
+          value: $(box).val()
+        }).appendTo($("#selection-form"));
+        toggleInputs();
+      };
+
+      var onCheckboxUnselect = function( box ) {
+        $('#selection-form #' + $(box).val()).remove();
+        toggleInputs();
+      };
+
+      var setCheckboxEvents = function () {
+        $("#version-form input").on('change', function () {
+          if (this.checked) {
+            onCheckboxSelect(this);
+          } else {
+            onCheckboxUnselect(this);
+          }
+        });
+      };
+      setCheckboxEvents();
+      toggleInputs();
+
+      var clickPageNav = function (e) {
+        e.preventDefault();
+        $.ajax({
+            url: $(this).attr('href'),
+            type: 'GET',
+            success: function(data) {
+              var rowDiv = $('#page-history-list', data);
+              var new_pagination = $('#pagination', data);
+
+              $('#pagination #next')[0].hidden = new_pagination.find('#next')[0].hidden;
+              $('#pagination #prev')[0].hidden = new_pagination.find('#prev')[0].hidden;
+
+              $('#page-history-list').replaceWith(rowDiv);
+
+              $("#selection-form input").each(function (index, element) {
+                var value = $(element).val();
+                $('#version-form input[value="' + value + '"]').prop('checked', true);
+              });
+
+              setCheckboxEvents();
+              toggleInputs();
+            },
+            error: function(data, textStatus, errorThrown) {
+              console.log('something went wrong: ' + textStatus + errorThrown)
+            }
+        });
+      };
+
+      $("#pagination #next a, #pagination #prev a").each(function(index, element) {
+       $(element).on("click", clickPageNav);
+      });
+    }
   }
 
   if( $("#last-edit").length ) {

--- a/lib/gollum/public/gollum/stylesheets/template.scss
+++ b/lib/gollum/public/gollum/stylesheets/template.scss
@@ -727,14 +727,3 @@ a {
     }
   } 
 }
-
-#pagination {
-  padding-bottom: 5px;
-  span.prev {
-    padding-left: 15px;
-  }
-  span.next {
-    float: right;
-    padding-right: 15px;
-  }
-}

--- a/lib/gollum/public/gollum/stylesheets/template.scss
+++ b/lib/gollum/public/gollum/stylesheets/template.scss
@@ -727,3 +727,14 @@ a {
     }
   } 
 }
+
+#pagination {
+  padding-bottom: 5px;
+  span.prev {
+    padding-left: 15px;
+  }
+  span.next {
+    float: right;
+    padding-right: 15px;
+  }
+}

--- a/lib/gollum/templates/history.mustache
+++ b/lib/gollum/templates/history.mustache
@@ -1,16 +1,17 @@
 <div id="wiki-wrapper" class="history">
 <div id="head">
 	{{>navbar}}
-  <h1 class="py-4"><span class="f1-light text-gray-light"> History for</span> {{name}}</h1>
+  <h1 class="py-4"><span class="f1-light text-gray-light">History for</span> {{name}}</h1>
 </div>
 <div id="page-history">
 
   {{>pagination}}
 
-	<div class="Box Box--condensed flex-auto">
-		<form name="compare-versions" id="version-form" method="post"
-	   action="{{compare_path}}/{{escaped_url_path}}">
-			<ul>
+    <form name="selection-form" id="selection-form" method="post" action="{{compare_path}}/{{escaped_url_path}}"></form>
+
+	<div id="page-history-list" class="Box Box--condensed flex-auto">
+		<form id="version-form">
+			<ul> 	
 	    	{{#versions}}
 				<li class="Box-row border-top Box-row--hover-gray d-flex flex-items-center">
 					<span class="pr-2"><input class="checkbox" type="checkbox" name="versions[]" value="{{id}}"></span>
@@ -30,6 +31,5 @@
 	<div class="pt-4">
   	<button class="btn btn-sm action-compare-revision" type="submit">Compare Revisions</button>
 	</div>
-	<div class="pt-2"><a href="#" class="action-back-to-top">Back to Top</a></div>
 </div>
 </div>

--- a/lib/gollum/templates/history.mustache
+++ b/lib/gollum/templates/history.mustache
@@ -7,6 +7,8 @@
 
   <div class="pb-4"><button class="btn btn-sm action-compare-revision" type="submit">Compare Revisions</button></div>
 
+  {{>pagination}}
+
 	<div class="Box Box--condensed flex-auto">
 		<form name="compare-versions" id="version-form" method="post"
 	   action="{{compare_path}}/{{escaped_url_path}}">

--- a/lib/gollum/templates/history.mustache
+++ b/lib/gollum/templates/history.mustache
@@ -5,8 +5,6 @@
 </div>
 <div id="page-history">
 
-  <div class="pb-4"><button class="btn btn-sm action-compare-revision" type="submit">Compare Revisions</button></div>
-
   {{>pagination}}
 
 	<div class="Box Box--condensed flex-auto">

--- a/lib/gollum/templates/history_authors/none.mustache
+++ b/lib/gollum/templates/history_authors/none.mustache
@@ -1,3 +1,1 @@
-<a href="javascript:void(0)">
     {{author}}
-</a>

--- a/lib/gollum/templates/latest_changes.mustache
+++ b/lib/gollum/templates/latest_changes.mustache
@@ -3,6 +3,9 @@
 	{{>navbar}}
   <h1 class="py-4">{{title}}</h1>
 </div>
+
+{{>pagination}}
+
 <div id="wiki-history">
 
 <div class="Box flex-auto">

--- a/lib/gollum/templates/layout.mustache
+++ b/lib/gollum/templates/layout.mustache
@@ -21,7 +21,7 @@
 	  uploadDest = uploadDest + window.location.pathname.replace(/.*gollum\/[-\w]+\//, "/").replace(/\.[^/.]+$/, "")
 	}
 	{{#page}}
-	  var pageFullPath = '{{url_path.source_location}}';
+	  var pageFullPath = '{{escaped_url_path}}';
 	{{/page}}
 
   </script>

--- a/lib/gollum/templates/pagination.mustache
+++ b/lib/gollum/templates/pagination.mustache
@@ -1,15 +1,11 @@
-<div id="pagination" class="pb-2 pl-3 pr-3">
-	{{#previous_page}}
-	  <span id="prev">
+<div id="pagination" class="pb-2 px-3">
+	  <span id="prev" {{^previous_page}}hidden{{/previous_page}}>
 	    <a href="?page_num={{previous_page}}">&laquo; Previous</a>
 	  </span>
-	{{/previous_page}}
 
 	<span>&nbsp;</span>
 
-	{{#next_page}}
-	  <span id="next" class="float-right">
+	  <span id="next" class="float-right" {{^next_page}}hidden{{/next_page}}>
 	    <a href="?page_num={{next_page}}">Next &raquo;</a>
 	  </span>
-	{{/next_page}}
 </div>

--- a/lib/gollum/templates/pagination.mustache
+++ b/lib/gollum/templates/pagination.mustache
@@ -1,0 +1,15 @@
+<div id="pagination">
+	{{#previous_page}}
+	  <span class="prev">
+	    <a href="?page_num={{previous_page}}">&laquo; Previous</a>
+	  </span>
+	{{/previous_page}}
+
+	<span>&nbsp;</span>
+
+	{{#next_page}}
+	  <span class="next">
+	    <a href="?page_num={{next_page}}">Next &raquo;</a>
+	  </span>
+	{{/next_page}}
+</div>

--- a/lib/gollum/templates/pagination.mustache
+++ b/lib/gollum/templates/pagination.mustache
@@ -1,6 +1,6 @@
-<div id="pagination">
+<div id="pagination" class="pb-2 pl-3 pr-3">
 	{{#previous_page}}
-	  <span class="prev">
+	  <span id="prev">
 	    <a href="?page_num={{previous_page}}">&laquo; Previous</a>
 	  </span>
 	{{/previous_page}}
@@ -8,7 +8,7 @@
 	<span>&nbsp;</span>
 
 	{{#next_page}}
-	  <span class="next">
+	  <span id="next" class="float-right">
 	    <a href="?page_num={{next_page}}">Next &raquo;</a>
 	  </span>
 	{{/next_page}}

--- a/lib/gollum/templates/wiki_content.mustache
+++ b/lib/gollum/templates/wiki_content.mustache
@@ -53,7 +53,7 @@
 		{{/preview}}
 	  {{/historical}}
 	  {{#historical}}
-	    <p>This version of the page was edited by {{author}} at {{date}}. <a href="{{full_url_path}}">View the most recent version.</a></p>
+	    <p>This version of the page was edited by <b>{{author}}</b> at {{date}}. <a href="{{full_url_path}}">View the most recent version.</a></p>
 	  {{/historical}}
 	</div>
 

--- a/lib/gollum/templates/wiki_content.mustache
+++ b/lib/gollum/templates/wiki_content.mustache
@@ -42,14 +42,19 @@
 
 
 	<div id="footer" class="pt-4">
+	  {{^historical}}
 		{{^preview}}
 		  <p id="last-edit"><a id="page-info-toggle" data-pagepath="{{escaped_url_path}}">When was this page last modified?</a></p>
 		  {{#allow_editing}}
 		    <p>
 		      <a id="delete-link" href="{{escaped_url_path}}" data-confirm="Are you sure you want to delete this page?"><span>Delete this Page</span></a>
 		    </p>
-	  {{/allow_editing}}
+	      {{/allow_editing}}
 		{{/preview}}
+	  {{/historical}}
+	  {{#historical}}
+	    <p>This version of the page was edited by {{author}} at {{date}}. <a href="{{full_url_path}}">View the most recent version.</a></p>
+	  {{/historical}}
 	</div>
 
 	

--- a/lib/gollum/views/compare.rb
+++ b/lib/gollum/views/compare.rb
@@ -19,7 +19,7 @@ module Precious
 
       def lines
         lines = []
-        @diff.diff.split("\n")[2..-1].each_with_index do |line, line_index|
+        @diff.split("\n")[2..-1].each_with_index do |line, line_index|
           lines << { :line  => line,
                      :class => line_class(line),
                      :ldln  => left_diff_line_number(0, line),

--- a/lib/gollum/views/has_page.rb
+++ b/lib/gollum/views/has_page.rb
@@ -15,5 +15,9 @@ module Precious
     def id
       @page.sha
     end
+
+    def full_url_path
+      ::File.join(@base_url, escaped_url_path)
+    end
   end
 end

--- a/lib/gollum/views/history.rb
+++ b/lib/gollum/views/history.rb
@@ -2,10 +2,11 @@ module Precious
   module Views
     class History < Layout
       include HasPage
+      include Pagination
       include Sprockets::Helpers
       include Precious::Views::SprocketsHelpers
 
-      attr_reader :page, :page_num, :allow_editing
+      attr_reader :page, :allow_editing
 
       def title
         @page.title
@@ -68,26 +69,6 @@ module Precious
       
       def editable
         @editable
-      end
-
-      def previous_link
-        label = "&laquo; Previous"
-        if @page_num == 1
-          %(<span class="disabled">#{label}</span>)
-        else
-          link = url("/history/#{@page.name}?page=#{@page_num-1}")
-          %(<a href="#{link}" hotkey="h">#{label}</a>)
-        end
-      end
-
-      def next_link
-        label = "Next &raquo;"
-        if @versions.size == Gollum::Page.per_page
-          link = "/history/#{@page.name}?page=#{@page_num+1}"
-          %(<a href="#{link}" hotkey="l">#{label}</a>)
-        else
-          %(<span class="disabled">#{label}</span>)
-        end
       end
     end
   end

--- a/lib/gollum/views/latest_changes.rb
+++ b/lib/gollum/views/latest_changes.rb
@@ -1,6 +1,7 @@
 module Precious
   module Views
     class LatestChanges < Layout
+      include Pagination
 
       attr_reader :wiki
 

--- a/lib/gollum/views/overview.rb
+++ b/lib/gollum/views/overview.rb
@@ -1,4 +1,4 @@
-require "pathname"
+require 'pathname'
 
 module Precious
   module Views

--- a/lib/gollum/views/page.rb
+++ b/lib/gollum/views/page.rb
@@ -3,7 +3,7 @@ module Precious
     class Page < Layout
       include HasPage
 
-      attr_reader :content, :page, :header, :footer, :preview
+      attr_reader :content, :page, :header, :footer, :preview, :historical
       
       VALID_COUNTER_STYLES = ['decimal', 'decimal-leading-zero', 'arabic-indic', 'armenian', 'upper-armenian',
         'lower-armenian', 'bengali', 'cambodian', 'khmer', 'cjk-decimal', 'devanagari', 'georgian', 'gujarati', 'gurmukhi',
@@ -42,13 +42,13 @@ module Precious
       end
 
       def author
-        first = page.last_version
+        first = @version ? page.version : page.last_version
         return DEFAULT_AUTHOR unless first
         first.author.name.respond_to?(:force_encoding) ? first.author.name.force_encoding('UTF-8') : first.author.name
       end
 
       def date
-        first = page.last_version
+        first = @version ? page.version : page.last_version
         return Time.now.strftime(DATE_FORMAT) unless first
         first.authored_date.strftime(DATE_FORMAT)
       end

--- a/lib/gollum/views/pagination.rb
+++ b/lib/gollum/views/pagination.rb
@@ -1,0 +1,11 @@
+module Precious
+  module Pagination 
+	  def next_page
+	    @versions.length < @max_count ? nil : (@page_num + 1).to_s
+	  end
+
+	  def previous_page
+	    @page_num == 1 ? nil : (@page_num - 1).to_s
+	  end
+  end
+end

--- a/test/test_app.rb
+++ b/test/test_app.rb
@@ -714,7 +714,7 @@ context "Frontend with lotr" do
     assert last_response.ok?
     assert_equal last_response.body.include?('delete-link'), false
     assert_equal last_response.body.include?('page-info-toggle'), false
-    assert last_response.body.include?("<p>This version of the page was edited by Tom Preston-Werner at 2010-04-07 21:49:43. <a href=\"/Bilbo-Baggins.md\">View the most recent version.</a></p>")
+    assert last_response.body.include?("This version of the page was edited by <b>Tom Preston-Werner</b> at 2010-04-07 21:49:43. <a href=\"/Bilbo-Baggins.md\">View the most recent version.</a></p>")
   end
 
   test "show revision of specific file" do

--- a/test/test_app.rb
+++ b/test/test_app.rb
@@ -714,7 +714,8 @@ context "Frontend with lotr" do
     assert last_response.ok?
     assert_equal last_response.body.include?('delete-link'), false
     assert_equal last_response.body.include?('page-info-toggle'), false
-    assert last_response.body.include?('This version of the page was edited by <b>Tom Preston-Werner</b> at 2010-04-07 21:49:43.')
+    assert last_response.body.include?('This version of the page was edited by <b>Tom Preston-Werner</b> at 2010-04-07')
+    assert last_response.body.include?("<a href=\"/Bilbo-Baggins.md\">View the most recent version.</a></p>")
   end
 
   test "show revision of specific file" do

--- a/test/test_app.rb
+++ b/test/test_app.rb
@@ -714,7 +714,7 @@ context "Frontend with lotr" do
     assert last_response.ok?
     assert_equal last_response.body.include?('delete-link'), false
     assert_equal last_response.body.include?('page-info-toggle'), false
-    assert last_response.body.include?("This version of the page was edited by <b>Tom Preston-Werner</b> at 2010-04-07 21:49:43. <a href=\"/Bilbo-Baggins.md\">View the most recent version.</a></p>")
+    assert last_response.body.include?('This version of the page was edited by <b>Tom Preston-Werner</b> at 2010-04-07 21:49:43.')
   end
 
   test "show revision of specific file" do

--- a/test/test_app.rb
+++ b/test/test_app.rb
@@ -701,6 +701,22 @@ context "Frontend with lotr" do
     assert_match /not so big smelly creatures/, last_response.body
   end
 
+  test 'editable pages have footer' do
+    get 'Bilbo-Baggings'
+    assert_equal last_response.body.include?('delete-link'), false
+    assert_equal last_response.body.include?('page-info-toggle'), false
+  end
+
+  test 'show specific revision of page' do
+    old_sha = '5bc1aaec6149e854078f1d0f8b71933bbc6c2e43'
+    page = 'Bilbo-Baggins'
+    get "#{page}/#{old_sha}"
+    assert last_response.ok?
+    assert_equal last_response.body.include?('delete-link'), false
+    assert_equal last_response.body.include?('page-info-toggle'), false
+    assert last_response.body.include?("<p>This version of the page was edited by Tom Preston-Werner at 2010-04-07 21:49:43. <a href=\"/Bilbo-Baggins.md\">View the most recent version.</a></p>")
+  end
+
   test "show revision of specific file" do
     old_sha = "df26e61e707116f81ebc6b935ec6d1676b7e96c4"
     update_sha = "f803c64d11407b23797325e3843f3f378b78f611"

--- a/test/test_latest_changes_view.rb
+++ b/test/test_latest_changes_view.rb
@@ -19,8 +19,8 @@ context "Precious::Views::LatestChanges" do
   test "displays_latest_changes" do
     get('/gollum/latest_changes')
     body = last_response.body
-        
-    assert body.include?("<span class=\"float-left col-2\"><a href=\"javascript:void(0)\">\n    Charles Pence\n</a>\n</span>"), "/latest_changes should include Author Charles Pence"
+
+    assert body.include?("Charles Pence</span>"), "/latest_changes should include Author Charles Pence"
     assert body.include?('1db89eb'), "/latest_changes should include the :pagination_count commit"
     assert !body.include?('a8ad3c0'), "/latest_changes should not include more than :pagination_count commits"
     assert body.include?('<a href="Data-Two.csv/874f597a5659b4c3b153674ea04e406ff393975e">Data-Two.csv</a>'), "/latest_changes include links to modified files in #{body}"

--- a/test/test_latest_changes_view.rb
+++ b/test/test_latest_changes_view.rb
@@ -13,7 +13,7 @@ context "Precious::Views::LatestChanges" do
     @path = cloned_testpath("examples/lotr.git")
     @wiki = Gollum::Wiki.new(@path)
     Precious::App.set(:gollum_path, @path)
-    Precious::App.set(:wiki_options, {:latest_changes_count => 10})
+    Precious::App.set(:wiki_options, {:pagination_count => 10})
   end
 
   test "displays_latest_changes" do
@@ -21,8 +21,8 @@ context "Precious::Views::LatestChanges" do
     body = last_response.body
         
     assert body.include?("<span class=\"float-left col-2\"><a href=\"javascript:void(0)\">\n    Charles Pence\n</a>\n</span>"), "/latest_changes should include Author Charles Pence"
-    assert body.include?('1db89eb'), "/latest_changes should include the :latest_changes_count commit"
-    assert !body.include?('a8ad3c0'), "/latest_changes should not include more than latest_changes_count commits"
+    assert body.include?('1db89eb'), "/latest_changes should include the :pagination_count commit"
+    assert !body.include?('a8ad3c0'), "/latest_changes should not include more than :pagination_count commits"
     assert body.include?('<a href="Data-Two.csv/874f597a5659b4c3b153674ea04e406ff393975e">Data-Two.csv</a>'), "/latest_changes include links to modified files in #{body}"
     assert body.include?('<a href="Hobbit.md/874f597a5659b4c3b153674ea04e406ff393975e">Hobbit.md</a>'), "/latest_changes should include links to modified pages in #{body}"
   end


### PR DESCRIPTION
Add pagination for the latest_changes and history views.

Results:
<img width="1160" alt="Screenshot 2019-08-18 at 17 03 28" src="https://user-images.githubusercontent.com/147111/63227436-de6f8480-c1e6-11e9-9d9f-08483bf2ea01.png">
<img width="1103" alt="Screenshot 2019-08-18 at 17 03 40" src="https://user-images.githubusercontent.com/147111/63227439-e2030b80-c1e6-11e9-847f-88c160c3008b.png">

(There is only a 'Next' link on the first screenshot because it's the first page)

I also noticed that when you'd view an old version of a file (e.g. by getting `Bilbo-Baggins.md/59721c7d7ca4fa6a07a50d76b3b0c92adfb8c3db`) the 'Delete Page' and 'When was this page last edited?' links were still visible in the footer. On historical pages, I've replaced this with the following:

<img width="1171" alt="Screenshot 2019-08-18 at 17 24 16" src="https://user-images.githubusercontent.com/147111/63227459-24c4e380-c1e7-11e9-851a-c4f7273599ac.png">
