### PR TITLE
Show subpages in preview

### DIFF
--- a/lib/gollum/app.rb
+++ b/lib/gollum/app.rb
@@ -366,6 +366,9 @@ module Precious
         wiki           = wiki_new
         @name          = params[:page] || "Preview"
         @page          = wiki.preview_page(@name, params[:content], params[:format])
+        ['sidebar', 'header', 'footer'].each do |subpage|
+          @page.send("set_#{subpage}".to_sym, params[subpage]) if params[subpage]
+        end
         @content       = @page.formatted_data
         @toc_content   = wiki.universal_toc ? @page.toc_data : nil
         @mathjax       = wiki.mathjax


### PR DESCRIPTION
Show subpages on preview page. They are rendered dynamically based on the content of the subpage textareas in the editor -- so it's an actual preview, rather than rendering the committed sidebar/header/footer!

Requires merge of https://github.com/gollum/gollum-lib/pull/333

Result:
<img width="1104" alt="Screenshot 2019-08-18 at 19 41 20" src="https://user-images.githubusercontent.com/147111/63228257-b9800f00-c1f0-11e9-8e54-c820a435c3c6.png">
