### PR TITLE
Fix RTL button. Rename Edit Mode label to Markup.

### DIFF
--- a/lib/gollum/public/gollum/javascript/editor/gollum.editor.js.erb
+++ b/lib/gollum/public/gollum/javascript/editor/gollum.editor.js.erb
@@ -208,7 +208,8 @@
         }
 
         if ( EditorHas.dir() ) {
-          $('#function-dir').click(function( e ) {
+          $('#function-text-direction').click(function( e ) {
+            e.preventDefault();
             switchRtl(!window.ace_editor.session.$bidiHandler.$isRtl);
           });
         }
@@ -570,7 +571,7 @@
      *  @return boolean
      */
     dir: function() {
-      return ($('#gollum-editor #function-dir').length );
+      return ($('#gollum-editor #function-text-direction').length );
     },
 
 
@@ -634,7 +635,7 @@
             $(this).click( FunctionBar.evtFunctionButtonClick );
             $(this).removeClass('disabled');
           }
-          else if ( !['function-help', 'function-dir'].includes( $(this).attr('id') ) ) {
+          else if ( !['function-help', 'function-text-direction'].includes( $(this).attr('id') ) ) {
             $(this).addClass('disabled');
           }
         });

--- a/lib/gollum/templates/editor.mustache
+++ b/lib/gollum/templates/editor.mustache
@@ -55,7 +55,7 @@
         <option>vim</option>
         <option>emacs</option>
       </select>
-      <label for="format">Edit Mode</label>
+      <label for="format">Markup</label>
       <select id="wiki_format" name="format" class="form-select">
       {{#formats}}
       {{#enabled}}


### PR DESCRIPTION
Fix RTL button that broke in the Primer.css merge commit by changing the button's `id`.