### PR TITLE
Align symbol for reStructuredText with github-markup

### DIFF
--- a/lib/gollum/public/gollum/javascript/editor/gollum.editor.js.erb
+++ b/lib/gollum/public/gollum/javascript/editor/gollum.editor.js.erb
@@ -25,7 +25,7 @@
     mediawiki: 'text',
     bib: 'latex',
     org: 'text',
-    rest: 'rst',
+    rst: 'rst',
     txt: 'text',
     pod: 'text',
     rdoc: 'rdoc',

--- a/lib/gollum/views/page.rb
+++ b/lib/gollum/views/page.rb
@@ -209,7 +209,7 @@ module Precious
             doc.css("div#gollum-root > h1:first-child")
           when :pod
             doc.css("div#gollum-root > a.dummyTopAnchor:first-child + h1")
-          when :rest
+          when :rst
             doc.css("div#gollum-root > div > div > h1:first-child")
           else
             doc.css("div#gollum-root > h1:first-child")


### PR DESCRIPTION
As per https://github.com/gollum/gollum-lib/pull/332#issuecomment-525348251, this PR aligns the symbol gollum uses for reStructuredText with that of `github-markup`.