### PR TITLE
DRY language definitions

### DIFF
--- a/lib/gollum/public/gollum/javascript/app.js
+++ b/lib/gollum/public/gollum/javascript/app.js
@@ -5,6 +5,7 @@
 //= require gollum.dialog
 //= require gollum.placeholder
 //= require editor/gollum.editor
+//= require editor/langs/default
 //= require_tree ./editor/langs
 //= require ace/ace
 //= require ace/mode-markdown

--- a/lib/gollum/public/gollum/javascript/editor/gollum.editor.js
+++ b/lib/gollum/public/gollum/javascript/editor/gollum.editor.js
@@ -636,9 +636,11 @@
           if ( LanguageDefinition.getDefinitionFor( $(this).attr('id') ) ) {
             $(this).click( FunctionBar.evtFunctionButtonClick );
             $(this).removeClass('disabled');
+            $(this).attr('disabled', false);
           }
           else if ( !['function-help', 'function-text-direction'].includes( $(this).attr('id') ) ) {
             $(this).addClass('disabled');
+            $(this).attr('disabled', true);
           }
         });
 

--- a/lib/gollum/public/gollum/javascript/editor/gollum.editor.js
+++ b/lib/gollum/public/gollum/javascript/editor/gollum.editor.js
@@ -162,7 +162,6 @@
           $(this).parent().toggleClass('collapsed');
 
           buttons = $(this).parent().children("button");
-          console.log(buttons);
           hidden_button = buttons.filter(':hidden')[0];
           shown_button  = buttons.not(':hidden')[0];
           hidden_button.hidden = false;
@@ -623,7 +622,6 @@
 
       isActive: false,
 
-
       /**
        *  FunctionBar.activate
        *  Activates the function bar, attaching all click events
@@ -651,7 +649,7 @@
 
 
       deactivate: function() {
-        $('#gollum-editor-function-bar a.function-button').unbind('click');
+        $('#gollum-editor-function-bar button.function-button').unbind('click');
         $('#gollum-editor-function-bar').removeClass( 'active' );
         FunctionBar.isActive = false;
       },
@@ -786,7 +784,7 @@
         if ( EditorHas.functionBar() ) {
           debug('Refreshing function bar');
           if ( LanguageDefinition.isValid() ) {
-            $('#gollum-editor-function-bar a.function-button').unbind('click');
+            $('#gollum-editor-function-bar button.function-button').unbind('click');
             FunctionBar.activate();
             if ( Help ) {
               Help.setActiveHelp( LanguageDefinition.getActiveLanguage() );

--- a/lib/gollum/public/gollum/javascript/editor/gollum.editor.js
+++ b/lib/gollum/public/gollum/javascript/editor/gollum.editor.js
@@ -713,7 +713,7 @@
           // the text area, but on the editor. But since a lot functions
           // does not use the third args, this works in these cases. But
           // we shall fix it.
-          definitionObject.exec( txt, selText, $('#gollum-editor-body') );
+          definitionObject.exec( txt, selText, $('#gollum-editor-body'), selRange );
           return;
         }
 

--- a/lib/gollum/public/gollum/javascript/editor/langs/asciidoc.js
+++ b/lib/gollum/public/gollum/javascript/editor/langs/asciidoc.js
@@ -1,38 +1,50 @@
 /**
  *  AsciiDoc Language Definition
+ *  See default.js for documentation
  *
  */
 
 (function($) {
 
-  var AsciiDoc = $.extend(true, {}, $.DefaultLang); // Use default language definition (markdown) as a base, and modify where necessary
-
-  AsciiDoc['function-bold']['replace'] = "*$1*$2";
-  AsciiDoc['function-hr'] = undefined;
-  AsciiDoc['function-blockquote']['replace'] = "----\n$1$2\n----";
-
-  // Set h1-h3 functions
-  for (var i=1; i < 4; i++) {
-    AsciiDoc['function-h' + i.toString()]['replace'] = "=".repeat(i) + " $1$2";
-  }
-
-  AsciiDoc['function-link']['replace'] = function ( res ) {
-    var rep = '';
-    if ( res['text'] && res['href'] ) {
-      rep = res['href'] + '[' + res['text'] + ']';
+  //No need to set all the replacements, only those different from the default language (Markdown).
+  var AsciiDoc = {
+    'function-bold': {
+      'replace': "*$1*$2"
+    },
+    'function-hr': undefined,
+    'function-blockquote': {
+      'replace': "----\n$1$2\n----"
+    },
+    'function-h1': {
+      'replace': "= $1$2"
+    },
+    'function-h2': {
+      'replace': "== $1$2"
+    },
+    'function-h3': {
+      'replace': "=== $1$2"
+    },
+    'function-link': {
+      'replace': function ( res ) {
+        var rep = '';
+        if ( res['text'] && res['href'] ) {
+          rep = res['href'] + '[' + res['text'] + ']';
+        }
+        return rep;
+      }
+    },
+    'function-image': {
+      'replace': function ( res ) {
+        var rep = '';
+        if ( res['url'] && res['alt'] ) {
+          rep = 'image::' + res['url'] + '[' + res['alt'] + ']';
+        }
+        return rep;        
+      }
     }
-    return rep;
-  };
-  
-  AsciiDoc['function-image']['replace'] = function ( res ) {
-    var rep = '';
-    if ( res['url'] && res['alt'] ) {
-      rep = 'image::' + res['url'] + '[' + res['alt'] + ']';
-    }
-    return rep;
   };
 
-  $.GollumEditor.defineLanguage('asciidoc', AsciiDoc);
+  $.GollumEditor.defineLanguage('asciidoc', $.constructLanguageDefinition(AsciiDoc));
 
   var AsciiDocHelp = [
     {

--- a/lib/gollum/public/gollum/javascript/editor/langs/asciidoc.js
+++ b/lib/gollum/public/gollum/javascript/editor/langs/asciidoc.js
@@ -5,227 +5,92 @@
 
 (function($) {
 
-var AsciiDoc = {
+  var AsciiDoc = $.extend(true, {}, $.DefaultLang); // Use default language definition (markdown) as a base, and modify where necessary
 
-  'function-bold' :         {
-                              search: /([^\n]+)([\n\s]*)/g,
-                              replace: "*$1*$2"
-                            },
+  AsciiDoc['function-bold']['replace'] = "*$1*$2";
+  AsciiDoc['function-hr'] = undefined;
+  AsciiDoc['function-blockquote']['replace'] = "----\n$1$2\n----";
 
-  'function-italic' :       {
-                              search: /([^\n]+)([\n\s]*)/g,
-                              replace: "_$1_$2"
-                            },
-
-  'function-code'   :       {
-                              search: /([^\n]+)([\n\s]*)/g,
-                              replace: "`$1`$2"
-                            },
-
-  'function-ul'     :       {
-                              exec: function( txt, selText, $field ) {
-                                var repText = '';
-                                var lines = selText.split("\n");
-                                for ( var i = 0; i < lines.length; i++ ) {
-                                  repText += '* ' + lines[i] + "\n";
-                                }
-                                repText = repText.substring(0, repText.length-1)
-                                $.GollumEditor.replaceSelection( repText, true, true );
-                              },
-                            },
-
-  'function-ol'   :         {
-                              exec: function( txt, selText, $field ) {
-                                var repText = '';
-                                var lines = selText.split("\n");
-                                for ( var i = 0; i < lines.length; i++ ) {
-                                  repText += '. ' + lines[i] + "\n";
-                                }
-                                repText = repText.substring(0, repText.length-1)
-                                $.GollumEditor.replaceSelection( repText, true, true );
-                              },
-                            },
-
-  'function-blockquote' :   {
-                              search: /(.+)([\n]?)/g,
-                              replace: "----\n$1$2\n----",
-                              break_line: true,
-                            },
-
-  'function-h1' :           {
-                              search: /(.+)([\n]?)/g,
-                              replace: "= $1$2",
-                              break_line: true,
-                              whole_line: true
-                            },
-
-  'function-h2' :           {
-                              search: /(.+)([\n]?)/g,
-                              replace: "== $1$2",
-                              break_line: true,
-                              whole_line: true
-                            },
-
-  'function-h3' :           {
-                              search: /(.+)([\n]?)/g,
-                              replace: "=== $1$2",
-                              break_line: true,
-                              whole_line: true
-                            },
-
-  'function-link'       :   {
-                              exec: function( txt, selText, $field ) {
-                                var results = null;
-                                $.GollumEditor.Dialog.init({
-                                  title: 'Insert Link',
-                                  fields: [
-                                    {
-                                      id:   'text',
-                                      name: 'Link Text',
-                                      type: 'text',
-                                      help: 'The text to display to the user.',
-                                      defaultValue: selText
-                                    },
-                                    {
-                                      id:   'href',
-                                      name: 'URL',
-                                      type: 'text',
-                                      help: 'The URL to link to.'
-                                    }
-                                  ],
-                                  OK: function( res ) {
-                                   var h = '';
-                                   if ( res['text'] && res['href'] ) {
-                                      h = res['href'] + '[' +
-                                          res['text'] + ']';
-                                    }
-                                    $.GollumEditor.replaceSelection( h );
-                                  }
-                                });
-
-
-                              }
-                            },
-
-  'function-image'      :   {
-                              exec: function( txt, selText, $field ) {
-                                var results = null;
-                                $.GollumEditor.Dialog.init({
-                                  title: 'Insert Image',
-                                  fields: [
-                                    {
-                                      id: 'url',
-                                      name: 'Image URL',
-                                      type: 'text'
-                                    },
-                                    {
-                                      id: 'alt',
-                                      name: 'Alt Text',
-                                      type: 'text'
-                                    }
-                                  ],
-                                  OK: function( res ) {
-                                    var h = '';
-                                    if ( res['url'] && res['alt'] ) {
-                                      h = 'image::' + res['url'] +
-                                          '[' + res['alt'] + ']';
-                                    }
-                                    $.GollumEditor.replaceSelection( h );
-                                  }
-                                });
-                              }
-                            },
-                            
-  'function-critic-accept' : {
-                              exec: function( txt, selText, $field) {
-                                var toReplace = selText.
-                                  replace(/\{\+\+(.*?)\+\+[ \t]*(\[(.*?)\])?[ \t]*\}/gm, "$1").
-                                  replace(/\{--(.*?)--[ \t]*(\[(.*?)\])?[ \t]*\}/gm, "").
-                                  replace(/\{~~(.*?)~>(.*?)~~\}/gm, "$2").
-                                  replace(/\{\=\=(.*?)[ \t]*(\[(.*?)\])?[ \t]*\=\=\}{>>(.*?)<<\}/gm, "$1").
-                                  replace(/\{>>(.*?)<<\}/gm, "")
-                                $.GollumEditor.replaceSelection( toReplace );
-                              }
-
-                          },
-
-    'function-critic-reject' : {
-                                exec: function( txt, selText, $field) {
-                                  var toReplace = selText.
-                                    replace(/\{\+\+(.*?)\+\+[ \t]*(\[(.*?)\])?[ \t]*\}/gm, "").
-                                    replace(/\{--(.*?)--[ \t]*(\[(.*?)\])?[ \t]*\}/gm, "$1").
-                                    replace(/\{~~(.*?)~>(.*?)~~\}/gm, "$1").
-                                    replace(/\{\=\=(.*?)[ \t]*(\[(.*?)\])?[ \t]*\=\=\}{>>(.*?)<<\}/gm, "$1").
-                                    replace(/\{>>(.*?)<<\}/gm, "")
-                                  $.GollumEditor.replaceSelection( toReplace );
-                                }
-
-                             }
-    
-
-};
-
-$.GollumEditor.defineLanguage('asciidoc', AsciiDoc);
-
-
-var AsciiDocHelp = [
-  {
-    menuName: 'Text Formatting',
-    content: [
-      {
-        menuName: 'Headers',
-        data: '<p>AsciiDoc headers can be written in two ways: with differing underlines or with different indentation using <code>=</code> (equals sign). AsciiDoc supports headings 1-4. The editor will automatically use the <code>=</code> notation. To create a level one header, prefix your line with one <code>=</code>. Level two headers are created with <code>==</code> and so on.</p>'
-      },
-      {
-        menuName: 'Bold / Italic',
-        data: '<p>To display text as <strong>bold</strong>, wrap the text in <code>*</code> (asterisks). To display text as <em>italic</em>, wrap the text in <code>_</code> (underscores). To create <code>monospace</code> text, wrap the text in <code>`</code> (backtick).'
-      },
-      {
-        menuName: 'Scripts',
-        data: '<p>Superscript and subscript is created the same way as other inline formats. To create superscript text, wrap your text in <code>^</code> (carats). To create subscript text, wrap your text in <code>~</code> (tildes).</p>'
-      },
-      {
-        menuName: 'Special Characters',
-        data: '<p>AsciiDoc will automatically convert textual representations of commonly-used special characters. For example, <code>(R)</code> becomes &reg;, <code>(C)</code> becomes &copy; and <code>(TM)</code> becomes &trade;.</p>'
-      }
-    ]
-  },
-  {
-    menuName: 'Blocks',
-    content: [
-      {
-        menuName: 'Paragraphs',
-        data: '<p>AsciiDoc allows paragraphs to have optional titles or icons to denote special sections. To make a normal paragraph, simply add a line between blocks and a new paragraph will start. If you want to title your paragraphs, adda line prefixed by <code>.</code> (full stop). An example paragraph with optional title is displayed below:<br><br><code>.Optional Title<br><br>This is my paragraph. It is two sentences long.</code></p>'
-      },
-      {
-        menuName: 'Source Blocks',
-        data: '<p>To create source blocks (long blocks of code), follow the same syntax as above but with an extra line denoting the inline source and lines of four dashes (<code>----</code>) delimiting the source block.. An example of Python source is below:<br><br><code>.python.py<br>[source,python]<br>----<br># i just wrote a comment in python<br># and maybe one more<br>----</code></p>'
-      },
-      {
-        menuName: 'Comment Blocks',
-        data: '<p>Comment blocks are useful if you want to keep notes for yourself inline but do not want them displayed to the public. To create a comment block, simply wrap the paragraph in dividers with four slashes (<code>////</code>). An example comment block is below:<br><br><code>////<br>My comment block is here now<br><br>It can be multiple paragraphs. Really.<br>////</p>'
-      },
-      {
-        menuName: 'Quote Blocks',
-        data: '<p>Quote blocks work much like comment blocks &mdash; simply create dividers using four underscores (<code>____</code>) around your quote. An example quote block is displayed below:<br><code>____<br>This is my quote block. Quote something nice here, otherwise there is no point in quoting.<br>____</code></p>'
-      }
-    ]
-  },
-  {
-    menuName: 'Macros',
-    content: [
-      {
-        menuName: 'Links',
-        data: '<p>To create links to external pages, you can simply write the URI if you want the URI to link to itself. (i.e., <code>http://github.com/</code> will automatically be parsed to <a href="javascript:void(0);">http://github.com/</a>. If you want different text to be displayed, simply append it to the end of the URI in between <code>[</code> (brackets.) For example, <code>http://github.com/[GitHub]</code> will be parsed as <a href="javascript:void(0);">GitHub</a>, with the URI pointing to <code>http://github.com</code>.</p>'
-      },
-      {
-        menuName: 'Images',
-        data: '<p>Images in AsciiDoc work much like hyperlinks, but image URLs are prefixed with <code>image:</code>. For example, to link to an image at <code>images/icons/home.png</code>, write <code>image:images/icons/home.png</code>. Alt text can be added by appending the text to the URI in <code>[</code> (brackets).</p>'
-      }
-    ]
+  for (var i=1; i < 4; i++) {
+    AsciiDoc['function-h' + i.toString()]['replace'] = "=".repeat(i) + " $1$2";
   }
-];
 
-$.GollumEditor.defineHelp('asciidoc', AsciiDocHelp);
+  AsciiDoc['function-link']['replace'] = function ( res ) {
+    var rep = '';
+    if ( res['text'] && res['href'] ) {
+      rep = res['href'] + '[' + res['text'] + ']';
+    }
+    return rep;
+  };
+  
+  AsciiDoc['function-image']['replace'] = function ( res ) {
+    var rep = '';
+    if ( res['url'] && res['alt'] ) {
+      rep = 'image::' + res['url'] + '[' + res['alt'] + ']';
+    }
+    return rep;
+  };
+
+  $.GollumEditor.defineLanguage('asciidoc', AsciiDoc);
+
+  var AsciiDocHelp = [
+    {
+      menuName: 'Text Formatting',
+      content: [
+        {
+          menuName: 'Headers',
+          data: '<p>AsciiDoc headers can be written in two ways: with differing underlines or with different indentation using <code>=</code> (equals sign). AsciiDoc supports headings 1-4. The editor will automatically use the <code>=</code> notation. To create a level one header, prefix your line with one <code>=</code>. Level two headers are created with <code>==</code> and so on.</p>'
+        },
+        {
+          menuName: 'Bold / Italic',
+          data: '<p>To display text as <strong>bold</strong>, wrap the text in <code>*</code> (asterisks). To display text as <em>italic</em>, wrap the text in <code>_</code> (underscores). To create <code>monospace</code> text, wrap the text in <code>`</code> (backtick).'
+        },
+        {
+          menuName: 'Scripts',
+          data: '<p>Superscript and subscript is created the same way as other inline formats. To create superscript text, wrap your text in <code>^</code> (carats). To create subscript text, wrap your text in <code>~</code> (tildes).</p>'
+        },
+        {
+          menuName: 'Special Characters',
+          data: '<p>AsciiDoc will automatically convert textual representations of commonly-used special characters. For example, <code>(R)</code> becomes &reg;, <code>(C)</code> becomes &copy; and <code>(TM)</code> becomes &trade;.</p>'
+        }
+      ]
+    },
+    {
+      menuName: 'Blocks',
+      content: [
+        {
+          menuName: 'Paragraphs',
+          data: '<p>AsciiDoc allows paragraphs to have optional titles or icons to denote special sections. To make a normal paragraph, simply add a line between blocks and a new paragraph will start. If you want to title your paragraphs, adda line prefixed by <code>.</code> (full stop). An example paragraph with optional title is displayed below:<br><br><code>.Optional Title<br><br>This is my paragraph. It is two sentences long.</code></p>'
+        },
+        {
+          menuName: 'Source Blocks',
+          data: '<p>To create source blocks (long blocks of code), follow the same syntax as above but with an extra line denoting the inline source and lines of four dashes (<code>----</code>) delimiting the source block.. An example of Python source is below:<br><br><code>.python.py<br>[source,python]<br>----<br># i just wrote a comment in python<br># and maybe one more<br>----</code></p>'
+        },
+        {
+          menuName: 'Comment Blocks',
+          data: '<p>Comment blocks are useful if you want to keep notes for yourself inline but do not want them displayed to the public. To create a comment block, simply wrap the paragraph in dividers with four slashes (<code>////</code>). An example comment block is below:<br><br><code>////<br>My comment block is here now<br><br>It can be multiple paragraphs. Really.<br>////</p>'
+        },
+        {
+          menuName: 'Quote Blocks',
+          data: '<p>Quote blocks work much like comment blocks &mdash; simply create dividers using four underscores (<code>____</code>) around your quote. An example quote block is displayed below:<br><code>____<br>This is my quote block. Quote something nice here, otherwise there is no point in quoting.<br>____</code></p>'
+        }
+      ]
+    },
+    {
+      menuName: 'Macros',
+      content: [
+        {
+          menuName: 'Links',
+          data: '<p>To create links to external pages, you can simply write the URI if you want the URI to link to itself. (i.e., <code>http://github.com/</code> will automatically be parsed to <a href="javascript:void(0);">http://github.com/</a>. If you want different text to be displayed, simply append it to the end of the URI in between <code>[</code> (brackets.) For example, <code>http://github.com/[GitHub]</code> will be parsed as <a href="javascript:void(0);">GitHub</a>, with the URI pointing to <code>http://github.com</code>.</p>'
+        },
+        {
+          menuName: 'Images',
+          data: '<p>Images in AsciiDoc work much like hyperlinks, but image URLs are prefixed with <code>image:</code>. For example, to link to an image at <code>images/icons/home.png</code>, write <code>image:images/icons/home.png</code>. Alt text can be added by appending the text to the URI in <code>[</code> (brackets).</p>'
+        }
+      ]
+    }
+  ];
+
+  $.GollumEditor.defineHelp('asciidoc', AsciiDocHelp);
 
 })(jQuery);

--- a/lib/gollum/public/gollum/javascript/editor/langs/asciidoc.js
+++ b/lib/gollum/public/gollum/javascript/editor/langs/asciidoc.js
@@ -11,6 +11,7 @@
   AsciiDoc['function-hr'] = undefined;
   AsciiDoc['function-blockquote']['replace'] = "----\n$1$2\n----";
 
+  // Set h1-h3 functions
   for (var i=1; i < 4; i++) {
     AsciiDoc['function-h' + i.toString()]['replace'] = "=".repeat(i) + " $1$2";
   }

--- a/lib/gollum/public/gollum/javascript/editor/langs/asciidoc.js
+++ b/lib/gollum/public/gollum/javascript/editor/langs/asciidoc.js
@@ -6,42 +6,50 @@
 
 (function($) {
 
-  //No need to set all the replacements, only those different from the default language (Markdown).
+  // No need to set all the replacements, only those different from the default language (Markdown).
   var AsciiDoc = {
-    'function-bold': {
-      'replace': "*$1*$2"
-    },
-    'function-hr': undefined,
-    'function-blockquote': {
-      'replace': "----\n$1$2\n----"
-    },
-    'function-h1': {
-      'replace': "= $1$2"
-    },
-    'function-h2': {
-      'replace': "== $1$2"
-    },
-    'function-h3': {
-      'replace': "=== $1$2"
-    },
-    'function-link': {
-      'replace': function ( res ) {
-        var rep = '';
-        if ( res['text'] && res['href'] ) {
-          rep = res['href'] + '[' + res['text'] + ']';
-        }
-        return rep;
-      }
-    },
-    'function-image': {
-      'replace': function ( res ) {
-        var rep = '';
-        if ( res['url'] && res['alt'] ) {
-          rep = 'image::' + res['url'] + '[' + res['alt'] + ']';
-        }
-        return rep;        
-      }
-    }
+
+    'function-bold':            {
+                                  'replace': "*$1*$2"
+                                },
+
+    'function-hr':              undefined,
+
+    'function-blockquote':      {
+                                  'replace': "----\n$1$2\n----"
+                                },
+
+    'function-h1':              {
+                                  'replace': "= $1$2"
+                                },
+
+    'function-h2':              {
+                                  'replace': "== $1$2"
+                                },
+
+    'function-h3':              {
+                                  'replace': "=== $1$2"
+                                },
+
+    'function-link':            {
+                                  'replace': function ( res ) {
+                                    var rep = '';
+                                    if ( res['text'] && res['href'] ) {
+                                      rep = res['href'] + '[' + res['text'] + ']';
+                                    }
+                                    return rep;
+                                  }
+                                },
+
+    'function-image':           {
+                                  'replace': function ( res ) {
+                                    var rep = '';
+                                    if ( res['url'] && res['alt'] ) {
+                                      rep = 'image::' + res['url'] + '[' + res['alt'] + ']';
+                                    }
+                                    return rep;        
+                                  }
+                                }
   };
 
   $.GollumEditor.defineLanguage('asciidoc', $.constructLanguageDefinition(AsciiDoc));

--- a/lib/gollum/public/gollum/javascript/editor/langs/creole.js
+++ b/lib/gollum/public/gollum/javascript/editor/langs/creole.js
@@ -1,43 +1,60 @@
 /**
  *  Creole Language Definition
+ *  See default.js for documentation
  *
  */
 (function($) {
-  var Creole = $.extend(true, {}, $.DefaultLang); // Use default language definition (markdown) as a base, and modify where necessary
 
-  Creole['function-italic']['replace'] = "//$1//$2";
-  Creole['function-code']['replace'] = "{{{$1}}}$2";
-  Creole['function-hr']['append'] = "\n\n----\n\n";
-  Creole['function-blockquote'] = undefined;
-
-  // Set h1-h3 functions
-  for (var i=1; i < 4; i++) {
-    Creole['function-h' + i.toString()]['replace'] = "=" + "=".repeat(i) + " $1$2";
-  }
-
-  Creole['function-ol']['line'] = function ( index, line) {
-    return '# ' + line + "\n";
-  }
-
-  Creole['function-link']['replace'] = function ( res ) {
-    var rep = '';
-    if ( res['text'] && res['href'] ) {
-      rep = '[[' + res['href'] + '|' + res['text'] + ']]';
-    }
-    return rep;
-  };
-  
-  Creole['function-image']['replace'] = function ( res ) {
-    var rep = '';
-    if ( res['url'] && res['alt'] ) {
-      rep = '{{' + res['url'];
-      if ( res['alt'] != '' ) {
-        rep += '|' + res['alt'];
+  //No need to set all the replacements, only those different from the default language (Markdown).
+  var Creole = {
+    'function-italic': {
+      'replace': "//$1//$2"
+    },
+    'function-code': {
+      'replace': "{{{$1}}}$2"
+    },
+    'function-hr': {
+      'append': "\n\n----\n\n"
+    },
+    'function-blockquote': undefined,
+    'function-ol': {
+      'line': function ( index, line) {
+        return '# ' + line + "\n";
+      } 
+    },
+    'function-h1': {
+      'replace': "== $1$2"
+    },
+    'function-h2': {
+      'replace': "=== $1$2"
+    },
+    'function-h3': {
+      'replace': "==== $1$2"
+    },
+    'function-link': {
+      'replace': function ( res ) {
+        var rep = '';
+        if ( res['text'] && res['href'] ) {
+          rep = '[[' + res['href'] + '|' + res['text'] + ']]';
+        }
+        return rep;
       }
-      rep = rep + '}}';
+    },
+    'function-image': {
+      'replace': function ( res ) {
+        var rep = '';
+        if ( res['url'] && res['alt'] ) {
+          rep = '{{' + res['url'];
+          if ( res['alt'] != '' ) {
+            rep += '|' + res['alt'];
+          }
+          rep = rep + '}}';
+        }
+        return rep;
+      }
     }
-    return rep;
   };
 
-  $.GollumEditor.defineLanguage('creole', Creole);
+$.GollumEditor.defineLanguage('creole', $.constructLanguageDefinition(Creole));
+
 })(jQuery);

--- a/lib/gollum/public/gollum/javascript/editor/langs/creole.js
+++ b/lib/gollum/public/gollum/javascript/editor/langs/creole.js
@@ -5,54 +5,64 @@
  */
 (function($) {
 
-  //No need to set all the replacements, only those different from the default language (Markdown).
+  // No need to set all the replacements, only those different from the default language (Markdown).
   var Creole = {
-    'function-italic': {
-      'replace': "//$1//$2"
-    },
-    'function-code': {
-      'replace': "{{{$1}}}$2"
-    },
-    'function-hr': {
-      'append': "\n\n----\n\n"
-    },
-    'function-blockquote': undefined,
-    'function-ol': {
-      'line': function ( index, line) {
-        return '# ' + line + "\n";
-      } 
-    },
-    'function-h1': {
-      'replace': "== $1$2"
-    },
-    'function-h2': {
-      'replace': "=== $1$2"
-    },
-    'function-h3': {
-      'replace': "==== $1$2"
-    },
-    'function-link': {
-      'replace': function ( res ) {
-        var rep = '';
-        if ( res['text'] && res['href'] ) {
-          rep = '[[' + res['href'] + '|' + res['text'] + ']]';
-        }
-        return rep;
-      }
-    },
-    'function-image': {
-      'replace': function ( res ) {
-        var rep = '';
-        if ( res['url'] && res['alt'] ) {
-          rep = '{{' + res['url'];
-          if ( res['alt'] != '' ) {
-            rep += '|' + res['alt'];
-          }
-          rep = rep + '}}';
-        }
-        return rep;
-      }
-    }
+
+    'function-italic':                {
+                                        'replace': "//$1//$2"
+                                      },
+
+    'function-code':                  {
+                                        'replace': "{{{$1}}}$2"
+                                      },
+
+    'function-hr':                    {
+                                        'append': "\n\n----\n\n"
+                                      },
+
+    'function-blockquote':            undefined,
+
+    'function-ol':                    {
+                                        'line': function ( index, line) {
+                                          return '# ' + line + "\n";
+                                        } 
+                                      },
+
+    'function-h1':                    {
+                                        'replace': "== $1$2"
+                                      },
+
+    'function-h2':                    {
+                                        'replace': "=== $1$2"
+                                      },
+
+    'function-h3':                    {
+                                        'replace': "==== $1$2"
+                                      },
+
+    'function-link':                  {
+                                        'replace': function ( res ) {
+                                          var rep = '';
+                                          if ( res['text'] && res['href'] ) {
+                                            rep = '[[' + res['href'] + '|' + res['text'] + ']]';
+                                          }
+                                          return rep;
+                                        }
+                                      },
+
+    'function-image':                 {
+                                        'replace': function ( res ) {
+                                          var rep = '';
+                                          if ( res['url'] && res['alt'] ) {
+                                            rep = '{{' + res['url'];
+                                            if ( res['alt'] != '' ) {
+                                              rep += '|' + res['alt'];
+                                            }
+                                            rep = rep + '}}';
+                                          }
+                                          return rep;
+                                        }
+                                      }
   };
 
 $.GollumEditor.defineLanguage('creole', $.constructLanguageDefinition(Creole));

--- a/lib/gollum/public/gollum/javascript/editor/langs/creole.js
+++ b/lib/gollum/public/gollum/javascript/editor/langs/creole.js
@@ -3,143 +3,41 @@
  *
  */
 (function($) {
+  var Creole = $.extend(true, {}, $.DefaultLang); // Use default language definition (markdown) as a base, and modify where necessary
 
-var Creole = {
+  Creole['function-italic']['replace'] = "//$1//$2";
+  Creole['function-code']['replace'] = "{{{$1}}}$2";
+  Creole['function-hr']['append'] = "\n\n----\n\n";
+  Creole['function-blockquote'] = undefined;
 
-  'function-bold' :         {
-                              search: /([^\n]+)([\n]*)/gi,
-                              replace: "**$1**$2"
-                            },
+  // Set h1-h3 functions
+  for (var i=1; i < 4; i++) {
+    Creole['function-h' + i.toString()]['replace'] = "=" + "=".repeat(i) + " $1$2";
+  }
 
-  'function-italic' :       {
-                              search: /([^\n]+)([\n]*)/gi,
-                              replace: "//$1//$2"
-                            },
+  Creole['function-ol']['line'] = function ( index, line) {
+    return '# ' + line + "\n";
+  }
 
-  'function-code'   :       {
-                              search: /([^\n]+)([\n]*)/gi,
-                              replace: "{{{$1}}}$2"
-                            },
+  Creole['function-link']['replace'] = function ( res ) {
+    var rep = '';
+    if ( res['text'] && res['href'] ) {
+      rep = '[[' + res['href'] + '|' + res['text'] + ']]';
+    }
+    return rep;
+  };
+  
+  Creole['function-image']['replace'] = function ( res ) {
+    var rep = '';
+    if ( res['url'] && res['alt'] ) {
+      rep = '{{' + res['url'];
+      if ( res['alt'] != '' ) {
+        rep += '|' + res['alt'];
+      }
+      rep = rep + '}}';
+    }
+    return rep;
+  };
 
-  'function-hr'     :       {
-                              append: "\n\n----\n\n"
-                            },
-
-  'function-ul'     :       {
-                              exec: function( txt, selText, $field ) {
-                                var repText = '';
-                                var lines = selText.split("\n");
-                                for ( var i = 0; i < lines.length; i++ ) {
-                                  repText += '* ' + lines[i] + "\n";
-                                }
-                                repText = repText.substring(0, repText.length-1)
-                                $.GollumEditor.replaceSelection( repText, true, true );
-                              },
-                            },
-
-  /* This looks silly but is completely valid Markdown */
-  'function-ol'   :         {
-                              exec: function( txt, selText, $field ) {
-                                var repText = '';
-                                var lines = selText.split("\n");
-                                for ( var i = 0; i < lines.length; i++ ) {
-                                  repText += '# ' + lines[i] + "\n";
-                                }
-                                repText = repText.substring(0, repText.length-1)
-                                $.GollumEditor.replaceSelection( repText, true, true );
-                              },
-                            },
-
-  'function-link'       :   {
-                              exec: function( txt, selText, $field ) {
-                                var results = null;
-                                $.GollumEditor.Dialog.init({
-                                  title: 'Insert Link',
-                                  fields: [
-                                    {
-                                      id:   'text',
-                                      name: 'Link Text',
-                                      type: 'text',
-                                      help: 'The text to display to the user.',
-                                      defaultValue: selText
-                                    },
-                                    {
-                                      id:   'href',
-                                      name: 'URL',
-                                      type: 'text',
-                                      help: 'The URL to link to.'
-                                    }
-                                  ],
-                                  OK: function( res ) {
-                                   var h = '[[' + res['href'] + '|' +
-                                           res['text'] + ']]';
-                                   $.GollumEditor.replaceSelection( h );
-                                  }
-                                });
-
-
-                              }
-                            },
-
-  'function-image'      :   {
-                              exec: function( txt, selText, $field ) {
-                                var results = null;
-                                $.GollumEditor.Dialog.init({
-                                  title: 'Insert Image',
-                                  fields: [
-                                    {
-                                      id: 'url',
-                                      name: 'Image URL',
-                                      type: 'text'
-                                    },
-                                    {
-                                      id: 'alt',
-                                      name: 'Alt Text',
-                                      type: 'text'
-                                    }
-                                  ],
-                                  OK: function( res ) {
-                                    var h = '';
-                                    if ( res['url'] && res['alt'] ) {
-                                      h = '{{' + res['url'];
-                                      if ( res['alt'] != '' ) {
-                                        h += '|' + res['alt'] + '}}';
-                                      }
-                                    }
-                                    $.GollumEditor.replaceSelection( h );
-                                  }
-                                });
-                              }
-                            },
-  'function-critic-accept' : {
-                              exec: function( txt, selText, $field) {
-                                var toReplace = selText.
-                                  replace(/\{\+\+(.*?)\+\+[ \t]*(\[(.*?)\])?[ \t]*\}/gm, "$1").
-                                  replace(/\{--(.*?)--[ \t]*(\[(.*?)\])?[ \t]*\}/gm, "").
-                                  replace(/\{~~(.*?)~>(.*?)~~\}/gm, "$2").
-                                  replace(/\{\=\=(.*?)[ \t]*(\[(.*?)\])?[ \t]*\=\=\}{>>(.*?)<<\}/gm, "$1").
-                                  replace(/\{>>(.*?)<<\}/gm, "")
-                                $.GollumEditor.replaceSelection( toReplace );
-                              }
-
-                          },
-
-    'function-critic-reject' : {
-                                exec: function( txt, selText, $field) {
-                                  var toReplace = selText.
-                                    replace(/\{\+\+(.*?)\+\+[ \t]*(\[(.*?)\])?[ \t]*\}/gm, "").
-                                    replace(/\{--(.*?)--[ \t]*(\[(.*?)\])?[ \t]*\}/gm, "$1").
-                                    replace(/\{~~(.*?)~>(.*?)~~\}/gm, "$1").
-                                    replace(/\{\=\=(.*?)[ \t]*(\[(.*?)\])?[ \t]*\=\=\}{>>(.*?)<<\}/gm, "$1").
-                                    replace(/\{>>(.*?)<<\}/gm, "")
-                                  $.GollumEditor.replaceSelection( toReplace );
-                                }
-
-                             }
-
-
-};
-
-$.GollumEditor.defineLanguage('creole', Creole);
-
+  $.GollumEditor.defineLanguage('creole', Creole);
 })(jQuery);

--- a/lib/gollum/public/gollum/javascript/editor/langs/default.js
+++ b/lib/gollum/public/gollum/javascript/editor/langs/default.js
@@ -57,12 +57,16 @@
                               },
     /* based on rdoc.js */
     'function-ol'   :         {
+                                line: function ( index, line) {
+                                  // This function generates the markup for a line of the ol, based on the line number (index) and the content of the line (line).
+                                  // Override this function for alternative markups when needed.
+                                  return index.toString() + '. ' + line + "\n"; // result e.g. "1. Previously existing text\n"
+                                },
                                 exec: function( txt, selText, $field ) {
                                   var repText = '';
                                   var lines = selText.split("\n");
                                   for ( var i = 0; i < lines.length; i++ ) {
-                                    repText += (i+1).toString() + '. ' +
-                                    lines[i] + "\n";
+                                    repText += this.line(i+1, lines[i]);
                                   }
                                   repText = repText.substring(0, repText.length-1)
                                   $.GollumEditor.replaceSelection( repText, true, true );
@@ -98,6 +102,8 @@
 
     'function-link'       :   {
                                 replace: function ( res ) {
+                                  // The replace function generates the markup to be inserted from the result of the Dialog (res).
+                                  // Set a different replace function if your markup requires it.
                                   var rep = '';
                                   if ( res['text'] && res['href'] ) {
                                     rep = '[' + res['text'] + '](' + res['href'] + ')';
@@ -122,8 +128,9 @@
                               },
     'function-image'      :   {
                                 replace: function( res ) {
+                                  // The replace function generates the markup to be inserted from the result of the Dialog (res).
+                                  // Set a different replace function if your markup requires it.
                                   var rep = '';
-                                  console.log('repping')
                                   if ( res['url'] && res['alt'] ) {
                                     rep = '![' + res['alt'] + ']' + '(' + res['url'] + ')';
                                   }

--- a/lib/gollum/public/gollum/javascript/editor/langs/default.js
+++ b/lib/gollum/public/gollum/javascript/editor/langs/default.js
@@ -12,11 +12,13 @@
  *
  *  If the 'append' property is set for a function, its value will be appended at the cursor position.
  *  
- *  Some functions have the 'break_line' and 'whole_line' properties set.
- *  You can use these to indicate whether a function should insert a newline (break_line),
- *  and whether just the selection or the whole line should be replaced (whole_line).
+ *  Some functions have the 'break_line' and 'whole_line' boolean properties set.
+ *  You can use these to indicate whether a function inserts a newline (break_line),
+ *  and whether just the selection or the whole line should be replaced (whole_line). 
+ *  These also influence cursor placement after text in the editor has been replaced.
  *
 **/
+
 (function($) {
 
   $.constructLanguageDefinition = function (newLang) {

--- a/lib/gollum/public/gollum/javascript/editor/langs/default.js
+++ b/lib/gollum/public/gollum/javascript/editor/langs/default.js
@@ -1,19 +1,35 @@
 /**
  *  Default Language Definition
  *
- *  A language definition for string manipulation operations which can be used
- *  to customize others. The default rules describe the Markdown markup
- *  language (so the Markdown defintion is just a clone of $DefaultLanguage).
+ *  Standard language definition for string manipulation operations which can be used
+ *  to generate others language definition. The default rules below describe 
+ *  the Markdown markup language. (The Markdown definition is therefore just a
+ *  deep clone of $.DefaultLanguage.)
+ *  
  *  Language definitions use regexes for various functions by default.
  *  If regexes won't do and you need to do some serious manipulation,
  *  you can declare a function in the object instead.
  *
+ *  If the 'append' property is set for a function, its value will be appended at the cursor position.
+ *  
+ *  Some functions have the 'break_line' and 'whole_line' properties set.
+ *  You can use these to indicate whether a function should insert a newline (break_line),
+ *  and whether just the selection or the whole line should be replaced (whole_line).
  *
 **/
 (function($) {
 
+  $.constructLanguageDefinition = function (newLang) {
+    var result = $.extend(true, {}, $.DefaultLang, newLang);
+    Object.keys(newLang).forEach(function (key) {
+     if(typeof newLang[key] === 'undefined'){
+        delete result[key];
+      }
+    });
+    return result;
+  };
+
   var initDialog = function( title, fields, onResult) {
-    var results = null;
     $.GollumEditor.Dialog.init({
       title: title,
       fields: fields,

--- a/lib/gollum/public/gollum/javascript/editor/langs/default.js
+++ b/lib/gollum/public/gollum/javascript/editor/langs/default.js
@@ -1,0 +1,176 @@
+/**
+ *  Default Language Definition
+ *
+ *  A language definition for string manipulation operations which can be used
+ *  to customize others. The default rules describe the Markdown markup
+ *  language (so the Markdown defintion is just a clone of $DefaultLanguage).
+ *  Language definitions use regexes for various functions by default.
+ *  If regexes won't do and you need to do some serious manipulation,
+ *  you can declare a function in the object instead.
+ *
+ *
+**/
+(function($) {
+
+  var initDialog = function( title, fields, onResult) {
+    var results = null;
+    $.GollumEditor.Dialog.init({
+      title: title,
+      fields: fields,
+      OK: function( res ) {
+        $.GollumEditor.replaceSelection( onResult(res) );
+      }
+    });
+  };
+
+  $.DefaultLang = {
+
+    'function-bold' :         {
+                                search: /([^\n]+)([\n\s]*)/g,
+                                replace: "**$1**$2"
+                              },
+
+    'function-italic' :       {
+                                search: /([^\n]+)([\n\s]*)/g,
+                                replace: "_$1_$2"
+                              },
+
+    'function-code'   :       {
+                                search: /([^\n]+)([\n\s]*)/g,
+                                replace: "`$1`$2"
+                              },
+
+    'function-hr'     :       {
+                                append: "\n***\n"
+                              },
+
+    'function-ul'     :       {
+                                exec: function( txt, selText, $field ) {
+                                  var repText = '';
+                                  var lines = selText.split("\n");
+                                  for ( var i = 0; i < lines.length; i++ ) {
+                                    repText += '* ' + lines[i] + "\n";
+                                  }
+                                  repText = repText.substring(0, repText.length-1)
+                                  $.GollumEditor.replaceSelection( repText, true, true );
+                                },
+                              },
+    /* based on rdoc.js */
+    'function-ol'   :         {
+                                exec: function( txt, selText, $field ) {
+                                  var repText = '';
+                                  var lines = selText.split("\n");
+                                  for ( var i = 0; i < lines.length; i++ ) {
+                                    repText += (i+1).toString() + '. ' +
+                                    lines[i] + "\n";
+                                  }
+                                  repText = repText.substring(0, repText.length-1)
+                                  $.GollumEditor.replaceSelection( repText, true, true );
+                                },
+                              },
+
+    'function-blockquote' :   {
+                                search: /(.+)([\n]?)/g,
+                                replace: "> $1$2",
+                                break_line: true,
+                              },
+
+    'function-h1'         :   {
+                                search: /(.+)([\n]?)/g,
+                                replace: "# $1$2",
+                                break_line: true,
+                                whole_line: true
+                              },
+
+    'function-h2'         :   {
+                                search: /(.+)([\n]?)/g,
+                                replace: "## $1$2",
+                                break_line: true,
+                                whole_line: true
+                              },
+
+    'function-h3'         :   {
+                                search: /(.+)([\n]?)/g,
+                                replace: "### $1$2",
+                                break_line: true,
+                                whole_line: true
+                              },
+
+    'function-link'       :   {
+                                replace: function ( res ) {
+                                  var rep = '';
+                                  if ( res['text'] && res['href'] ) {
+                                    rep = '[' + res['text'] + '](' + res['href'] + ')';
+                                  }
+                                  return rep;
+                                },
+                                exec: function (txt, selText, $field) {
+                                  initDialog('Insert Link', [
+                                      {
+                                        id:   'text',
+                                        name: 'Link Text',
+                                        type: 'text',
+                                        defaultValue: selText
+                                      },
+                                      {
+                                        id:   'href',
+                                        name: 'URL',
+                                        type: 'text'
+                                      }
+                                    ], this.replace)
+                                }
+                              },
+    'function-image'      :   {
+                                replace: function( res ) {
+                                  var rep = '';
+                                  console.log('repping')
+                                  if ( res['url'] && res['alt'] ) {
+                                    rep = '![' + res['alt'] + ']' + '(' + res['url'] + ')';
+                                  }
+                                  return rep;
+                                },
+                                exec: function (txt, selText, $field) {
+                                  initDialog('Insert Image', [
+                                      {
+                                        id:   'url',
+                                        name: 'Image Url',
+                                        type: 'text',
+                                        defaultValue: selText
+                                      },
+                                      {
+                                        id:   'alt',
+                                        name: 'Alt Text',
+                                        type: 'text'
+                                      }
+                                    ], this.replace)
+                                }
+                              },
+    'function-critic-accept' : {
+                                  exec: function( txt, selText, $field) {
+                                    var toReplace = selText.
+                                      replace(/\{\+\+(.*?)\+\+[ \t]*(\[(.*?)\])?[ \t]*\}/gm, "$1").
+                                      replace(/\{--(.*?)--[ \t]*(\[(.*?)\])?[ \t]*\}/gm, "").
+                                      replace(/\{~~(.*?)~>(.*?)~~\}/gm, "$2").
+                                      replace(/\{\=\=(.*?)[ \t]*(\[(.*?)\])?[ \t]*\=\=\}{>>(.*?)<<\}/gm, "$1").
+                                      replace(/\{>>(.*?)<<\}/gm, "")
+                                    $.GollumEditor.replaceSelection( toReplace );
+                                  }
+        
+                              },
+    
+    'function-critic-reject' : {
+                                  exec: function( txt, selText, $field) {
+                                    var toReplace = selText.
+                                      replace(/\{\+\+(.*?)\+\+[ \t]*(\[(.*?)\])?[ \t]*\}/gm, "").
+                                      replace(/\{--(.*?)--[ \t]*(\[(.*?)\])?[ \t]*\}/gm, "$1").
+                                      replace(/\{~~(.*?)~>(.*?)~~\}/gm, "$1").
+                                      replace(/\{\=\=(.*?)[ \t]*(\[(.*?)\])?[ \t]*\=\=\}{>>(.*?)<<\}/gm, "$1").
+                                      replace(/\{>>(.*?)<<\}/gm, "")
+                                    $.GollumEditor.replaceSelection( toReplace );
+                                  }
+        
+                               }
+
+  };
+
+})(jQuery);

--- a/lib/gollum/public/gollum/javascript/editor/langs/markdown.js
+++ b/lib/gollum/public/gollum/javascript/editor/langs/markdown.js
@@ -17,167 +17,13 @@
  *                         }
  *
 **/
+
 (function($) {
 
-var MarkDown = {
+var MarkDown = $.extend(true, {}, $.DefaultLang); // The default language definition is markdown.
+$.GollumEditor.defineLanguage('markdown', MarkDown);
+console.log(MarkDown);
 
-  'function-bold' :         {
-                              search: /([^\n]+)([\n\s]*)/g,
-                              replace: "**$1**$2"
-                            },
-
-  'function-italic' :       {
-                              search: /([^\n]+)([\n\s]*)/g,
-                              replace: "_$1_$2"
-                            },
-
-  'function-code'   :       {
-                              search: /([^\n]+)([\n\s]*)/g,
-                              replace: "`$1`$2"
-                            },
-
-  'function-hr'     :       {
-                              append: "\n***\n"
-                            },
-
-  'function-ul'     :       {
-                              exec: function( txt, selText, $field ) {
-                                var repText = '';
-                                var lines = selText.split("\n");
-                                for ( var i = 0; i < lines.length; i++ ) {
-                                  repText += '* ' + lines[i] + "\n";
-                                }
-                                repText = repText.substring(0, repText.length-1)
-                                $.GollumEditor.replaceSelection( repText, true, true );
-                              },
-                            },
-  /* based on rdoc.js */
-  'function-ol'   :         {
-                              exec: function( txt, selText, $field ) {
-                                var repText = '';
-                                var lines = selText.split("\n");
-                                for ( var i = 0; i < lines.length; i++ ) {
-                                  repText += (i+1).toString() + '. ' +
-                                  lines[i] + "\n";
-                                }
-                                repText = repText.substring(0, repText.length-1)
-                                $.GollumEditor.replaceSelection( repText, true, true );
-                              },
-                            },
-
-  'function-blockquote' :   {
-                              search: /(.+)([\n]?)/g,
-                              replace: "> $1$2",
-                              break_line: true,
-                            },
-
-  'function-h1'         :   {
-                              search: /(.+)([\n]?)/g,
-                              replace: "# $1$2",
-                              break_line: true,
-                              whole_line: true
-                            },
-
-  'function-h2'         :   {
-                              search: /(.+)([\n]?)/g,
-                              replace: "## $1$2",
-                              break_line: true,
-                              whole_line: true
-                            },
-
-  'function-h3'         :   {
-                              search: /(.+)([\n]?)/g,
-                              replace: "### $1$2",
-                              break_line: true,
-                              whole_line: true
-                            },
-
-  'function-link'       :   {
-                              exec: function( txt, selText, $field ) {
-                                var results = null;
-                                $.GollumEditor.Dialog.init({
-                                  title: 'Insert Link',
-                                  fields: [
-                                    {
-                                      id:   'text',
-                                      name: 'Link Text',
-                                      type: 'text',
-                                      defaultValue: selText
-                                    },
-                                    {
-                                      id:   'href',
-                                      name: 'URL',
-                                      type: 'text'
-                                    }
-                                  ],
-                                  OK: function( res ) {
-                                   var rep = '';
-                                   if ( res['text'] && res['href'] ) {
-                                      rep = '[' + res['text'] + '](' +
-                                             res['href'] + ')';
-                                    }
-                                    $.GollumEditor.replaceSelection( rep );
-                                  }
-                                });
-                              }
-                            },
-
-  'function-image'      :   {
-                              exec: function( txt, selText, $field ) {
-                                var results = null;
-                                $.GollumEditor.Dialog.init({
-                                  title: 'Insert Image',
-                                  fields: [
-                                    {
-                                      id: 'url',
-                                      name: 'Image URL',
-                                      type: 'text'
-                                    },
-                                    {
-                                      id: 'alt',
-                                      name: 'Alt Text',
-                                      type: 'text'
-                                    }
-                                  ],
-                                  OK: function( res ) {
-                                    var rep = '';
-                                    if ( res['url'] && res['alt'] ) {
-                                      rep = '![' + res['alt'] + ']' +
-                                            '(' + res['url'] + ')';
-                                    }
-                                    $.GollumEditor.replaceSelection( rep );
-                                  }
-                                });
-                              }
-                            },
-                            
-  'function-critic-accept' : {
-                                exec: function( txt, selText, $field) {
-                                  var toReplace = selText.
-                                    replace(/\{\+\+(.*?)\+\+[ \t]*(\[(.*?)\])?[ \t]*\}/gm, "$1").
-                                    replace(/\{--(.*?)--[ \t]*(\[(.*?)\])?[ \t]*\}/gm, "").
-                                    replace(/\{~~(.*?)~>(.*?)~~\}/gm, "$2").
-                                    replace(/\{\=\=(.*?)[ \t]*(\[(.*?)\])?[ \t]*\=\=\}{>>(.*?)<<\}/gm, "$1").
-                                    replace(/\{>>(.*?)<<\}/gm, "")
-                                  $.GollumEditor.replaceSelection( toReplace );
-                                }
-      
-                            },
-  
-  'function-critic-reject' : {
-                                exec: function( txt, selText, $field) {
-                                  var toReplace = selText.
-                                    replace(/\{\+\+(.*?)\+\+[ \t]*(\[(.*?)\])?[ \t]*\}/gm, "").
-                                    replace(/\{--(.*?)--[ \t]*(\[(.*?)\])?[ \t]*\}/gm, "$1").
-                                    replace(/\{~~(.*?)~>(.*?)~~\}/gm, "$1").
-                                    replace(/\{\=\=(.*?)[ \t]*(\[(.*?)\])?[ \t]*\=\=\}{>>(.*?)<<\}/gm, "$1").
-                                    replace(/\{>>(.*?)<<\}/gm, "")
-                                  $.GollumEditor.replaceSelection( toReplace );
-                                }
-      
-                             }
-
-};
 
 var MarkDownHelp = [
 
@@ -257,8 +103,6 @@ var MarkDownHelp = [
   }
 ];
 
-
-$.GollumEditor.defineLanguage('markdown', MarkDown);
 $.GollumEditor.defineHelp('markdown', MarkDownHelp);
 
 })(jQuery);

--- a/lib/gollum/public/gollum/javascript/editor/langs/markdown.js
+++ b/lib/gollum/public/gollum/javascript/editor/langs/markdown.js
@@ -22,8 +22,6 @@
 
 var MarkDown = $.extend(true, {}, $.DefaultLang); // The default language definition is markdown.
 $.GollumEditor.defineLanguage('markdown', MarkDown);
-console.log(MarkDown);
-
 
 var MarkDownHelp = [
 

--- a/lib/gollum/public/gollum/javascript/editor/langs/markdown.js
+++ b/lib/gollum/public/gollum/javascript/editor/langs/markdown.js
@@ -6,7 +6,7 @@
 
 (function($) {
 
-var MarkDown = $.extend(true, {}, $.DefaultLang); // The default language definition is markdown.
+var MarkDown = $.extend(true, {}, $.DefaultLang); // The default language definition is markdown, so copy it into a new variable.
 $.GollumEditor.defineLanguage('markdown', MarkDown);
 
 var MarkDownHelp = [

--- a/lib/gollum/public/gollum/javascript/editor/langs/markdown.js
+++ b/lib/gollum/public/gollum/javascript/editor/langs/markdown.js
@@ -1,20 +1,6 @@
 /**
  *  Markdown Language Definition
- *
- *  A language definition for string manipulation operations, in this case
- *  for the Markdown, uh, markup language. Uses regexes for various functions
- *  by default. If regexes won't do and you need to do some serious
- *  manipulation, you can declare a function in the object instead.
- *
- *  Code example:
- *  'functionbar-id'  :   {
- *                          exec: function(text, selectedText) {
- *                                   functionStuffHere();
- *                                },
- *                          search: /somesearchregex/gi,
- *                          replace: 'replace text for RegExp.replace',
- *                          append: "just add this where the cursor is"
- *                         }
+ *  See default.js for documentation
  *
 **/
 

--- a/lib/gollum/public/gollum/javascript/editor/langs/mediawiki.js
+++ b/lib/gollum/public/gollum/javascript/editor/langs/mediawiki.js
@@ -9,12 +9,10 @@
 var MediaWiki = {
 
   'function-bold' :         {
-                              search: /([^\n]+)([\n\s]*)/g,
                               replace: "'''$1'''$2"
                             },
 
   'function-italic' :       {
-                              search: /([^\n]+)([\n\s]*)/g,
                               replace: "''$1''$2"
                             },
   'function-hr'     :       {
@@ -22,125 +20,41 @@ var MediaWiki = {
                             },
 
   'function-code'   :       {
-                              search: /([^\n]+)([\n\s]*)/g,
                               replace: "<code>$1</code>$2"
                             },
-
-  'function-ul'     :       {
-                              exec: function( txt, selText, $field ) {
-                                var repText = '';
-                                var lines = selText.split("\n");
-                                for ( var i = 0; i < lines.length; i++ ) {
-                                  repText += '* ' + lines[i] + "\n";
-                                }
-                                repText = repText.substring(0, repText.length-1)
-                                $.GollumEditor.replaceSelection( repText, true, true );
-                              },
-                            },
-
   'function-ol'   :         {
-                              exec: function( txt, selText, $field ) {
-                                var repText = '';
-                                var lines = selText.split("\n");
-                                for ( var i = 0; i < lines.length; i++ ) {
-                                  repText += '# ' + lines[i] + "\n";
-                                }
-                                repText = repText.substring(0, repText.length-1)
-                                $.GollumEditor.replaceSelection( repText, true, true );
-                              },
+                              link: function ( index, line) {
+                                return '# ' + line + "\n";
+                              } 
                             },
-
   'function-blockquote' :   {
-                              search: /(.+)([\n]?)/g,
                               replace: "<blockquote>\n$1$2\n</blockquote>",
-                              break_line: true,
                             },
 
   'function-h1' :           {
-                              search: /(.+)([\n]?)/g,
                               replace: "= $1$2 =",
-                              break_line: true,
-                              whole_line: true
                             },
 
   'function-h2' :           {
-                              search: /(.+)([\n]?)/g,
                               replace: "== $1$2 ==",
-                              break_line: true,
-                              whole_line: true
                             },
 
   'function-h3' :           {
-                              search: /(.+)([\n]?)/g,
                               replace: "=== $1$2 ===",
-                              break_line: true,
-                              whole_line: true
                             },
 
-  'function-link'       :   {
-                              exec: function( txt, selText, $field ) {
-                                var results = null;
-                                $.GollumEditor.Dialog.init({
-                                  title: 'Insert Link',
-                                  fields: [
-                                    {
-                                      id:   'text',
-                                      name: 'Link Text',
-                                      type: 'text',
-                                      help: 'The text to display to the user.',
-                                      defaultValue: selText
-                                    },
-                                    {
-                                      id:   'href',
-                                      name: 'URL',
-                                      type: 'text',
-                                      help: 'The URL to link to.'
-                                    }
-                                  ],
-                                  OK: function( res ) {
-                                   var h = '';
-                                   if ( res['text'] && res['href'] ) {
-                                      h = '[' + res['href'] + ' | ' +
-                                             res['text'] + ']';
-                                    }
-                                    $.GollumEditor.replaceSelection( h );
-                                  }
-                                });
-
-
-                              }
-                            },
-                            
-  'function-critic-accept' : {
-                              exec: function( txt, selText, $field) {
-                                var toReplace = selText.
-                                  replace(/\{\+\+(.*?)\+\+[ \t]*(\[(.*?)\])?[ \t]*\}/gm, "$1").
-                                  replace(/\{--(.*?)--[ \t]*(\[(.*?)\])?[ \t]*\}/gm, "").
-                                  replace(/\{~~(.*?)~>(.*?)~~\}/gm, "$2").
-                                  replace(/\{\=\=(.*?)[ \t]*(\[(.*?)\])?[ \t]*\=\=\}{>>(.*?)<<\}/gm, "$1").
-                                  replace(/\{>>(.*?)<<\}/gm, "")
-                                $.GollumEditor.replaceSelection( toReplace );
-                              }
-
-                          },
-
-    'function-critic-reject' : {
-                                exec: function( txt, selText, $field) {
-                                  var toReplace = selText.
-                                    replace(/\{\+\+(.*?)\+\+[ \t]*(\[(.*?)\])?[ \t]*\}/gm, "").
-                                    replace(/\{--(.*?)--[ \t]*(\[(.*?)\])?[ \t]*\}/gm, "$1").
-                                    replace(/\{~~(.*?)~>(.*?)~~\}/gm, "$1").
-                                    replace(/\{\=\=(.*?)[ \t]*(\[(.*?)\])?[ \t]*\=\=\}{>>(.*?)<<\}/gm, "$1").
-                                    replace(/\{>>(.*?)<<\}/gm, "")
-                                  $.GollumEditor.replaceSelection( toReplace );
+  'function-link' :         {
+                              replace: function( res ) {
+                                var rep = '';
+                                if ( res['text'] && res['href'] ) {
+                                  rep = '[' + res['href'] + ' | ' + res['text'] + ']';
                                 }
-
-                             }
-    
-
+                                return rep;
+                              }
+                            }
 };
 
-$.GollumEditor.defineLanguage('mediawiki', MediaWiki);
+$.GollumEditor.defineLanguage('mediawiki', $.constructLanguageDefinition(MediaWiki));
 
 
 var MediaWikiHelp = [

--- a/lib/gollum/public/gollum/javascript/editor/langs/mediawiki.js
+++ b/lib/gollum/public/gollum/javascript/editor/langs/mediawiki.js
@@ -6,6 +6,7 @@
 
 (function($) {
 
+// No need to set all the replacements, only those different from the default language (Markdown).
 var MediaWiki = {
 
   'function-bold' :         {

--- a/lib/gollum/public/gollum/javascript/editor/langs/mediawiki.js
+++ b/lib/gollum/public/gollum/javascript/editor/langs/mediawiki.js
@@ -1,5 +1,6 @@
 /**
  *  MediaWiki Language Definition
+ *  See default.js for documentation
  *
  */
 

--- a/lib/gollum/public/gollum/javascript/editor/langs/org.js
+++ b/lib/gollum/public/gollum/javascript/editor/langs/org.js
@@ -1,6 +1,8 @@
 /**
  *  Org-mode Language Definition
+ *  See default.js for documentation
 **/
+
 (function($) {
 
 var OrgMode = {

--- a/lib/gollum/public/gollum/javascript/editor/langs/org.js
+++ b/lib/gollum/public/gollum/javascript/editor/langs/org.js
@@ -5,159 +5,64 @@
 
 (function($) {
 
+// No need to set all the replacements, only those different from the default language (Markdown).
 var OrgMode = {
 
-  'function-bold' :         {
-                              search: /([^\n]+)([\n\s]*)/g,
+  'function-bold':          {
                               replace: "*$1*$2"
                             },
 
-  'function-italic' :       {
-                              search: /([^\n]+)([\n\s]*)/g,
+  'function-italic':        {
                               replace: "/$1/$2"
                             },
 
-  'function-code'   :       {
-                              search: /(^[\n]+)([\n\s]*)/g,
+  'function-code':          {
                               replace: "=$1=$2"
                             },
 
-  'function-ul'     :       {
-                              exec: function( txt, selText, $field ) {
-                                var repText = '';
-                                var lines = selText.split("\n");
-                                for ( var i = 0; i < lines.length; i++ ) {
-                                  repText += '* ' + lines[i] + "\n";
-                                }
-                                repText = repText.substring(0, repText.length-1)
-                                $.GollumEditor.replaceSelection( repText, true, true );
-                              },
-                            },
-
-  'function-ol'   :         {
-                              exec: function( txt, selText, $field ) {
-                                var repText = '';
-                                var lines = selText.split("\n");
-                                for ( var i = 0; i < lines.length; i++ ) {
-                                  repText += (i+1).toString() + '. ' +
-                                  lines[i] + "\n";
-                                }
-                                repText = repText.substring(0, repText.length-1)
-                                $.GollumEditor.replaceSelection( repText, true, true );
-                              },
-                            },
+  'function-hr':            undefined,
 
   'function-blockquote' :   {
-                              search: /(.+)([\n]?)/g,
-                              replace: "#+BEGIN_QUOTE\n$1$2\n#+END_QUOTE",
-                              break_line: true,
+                              replace: "#+BEGIN_QUOTE\n$1$2\n#+END_QUOTE"
                             },
 
   'function-h1'         :   {
-                              search: /(.+)([\n]?)/g,
-                              replace: "* $1$2",
-                              break_line: true,
-                              whole_line: true
+                              replace: "* $1$2"
                             },
 
   'function-h2'         :   {
-                              search: /(.+)([\n]?)/g,
-                              replace: "** $1$2",
-                              break_line: true,
-                              whole_line: true
+                              replace: "** $1$2"
                             },
 
   'function-h3'         :   {
-                              search: /(.+)([\n]?)/g,
-                              replace: "*** $1$2",
-                              break_line: true,
-                              whole_line: true
+                              replace: "*** $1$2"
                             },
 
   'function-link'       :   {
-                              exec: function( txt, selText, $field ) {
-                                var results = null;
-                                $.GollumEditor.Dialog.init({
-                                  title: 'Insert Link',
-                                  fields: [
-                                    {
-                                      id:   'text',
-                                      name: 'Link Text',
-                                      type: 'text',
-                                      defaultValue: selText
-                                    },
-                                    {
-                                      id:   'href',
-                                      name: 'URL',
-                                      type: 'text'
-                                    }
-                                  ],
-                                  OK: function( res ) {
-                                   var rep = '';
-                                   if ( res['text'] && res['href'] ) {
-                                      rep = '[[' + res['href'] + '][' +
-                                             res['text'] + ']]';
-                                    }
-                                    else if ( res['href'] ) {
-                                      rep = '[[' + res['href'] + ']]';
-                                    }
-                                    $.GollumEditor.replaceSelection( rep );
-                                  }
-                                });
+                              replace: function ( res ) {
+                                var rep = '';
+                                if ( res['text'] && res['href'] ) {
+                                  rep = '[[' + res['href'] + '][' + res['text'] + ']]';
+                                }
+                                else if ( res['href'] ) {
+                                  rep = '[[' + res['href'] + ']]';
+                                }
+                                return rep;
                               }
                             },
 
   'function-image'      :   {
-                              exec: function( txt, selText, $field ) {
-                                var results = null;
-                                $.GollumEditor.Dialog.init({
-                                  title: 'Insert Image',
-                                  fields: [
-                                    {
-                                      id: 'url',
-                                      name: 'Image URL',
-                                      type: 'text'
-                                    }
-                                  ],
-                                  OK: function( res ) {
-                                    var rep = '';
-                                    if ( res['url'] ) {
-                                      rep = '[[' + res['url'] + ']]';
-                                    }
-                                    $.GollumEditor.replaceSelection( rep );
-                                  }
-                                });
-                              }
-                            },
-                            
-  'function-critic-accept' : {
-                              exec: function( txt, selText, $field) {
-                                var toReplace = selText.
-                                  replace(/\{\+\+(.*?)\+\+[ \t]*(\[(.*?)\])?[ \t]*\}/gm, "$1").
-                                  replace(/\{--(.*?)--[ \t]*(\[(.*?)\])?[ \t]*\}/gm, "").
-                                  replace(/\{~~(.*?)~>(.*?)~~\}/gm, "$2").
-                                  replace(/\{\=\=(.*?)[ \t]*(\[(.*?)\])?[ \t]*\=\=\}{>>(.*?)<<\}/gm, "$1").
-                                  replace(/\{>>(.*?)<<\}/gm, "")
-                                $.GollumEditor.replaceSelection( toReplace );
-                              }
-
-                          },
-
-    'function-critic-reject' : {
-                                exec: function( txt, selText, $field) {
-                                  var toReplace = selText.
-                                    replace(/\{\+\+(.*?)\+\+[ \t]*(\[(.*?)\])?[ \t]*\}/gm, "").
-                                    replace(/\{--(.*?)--[ \t]*(\[(.*?)\])?[ \t]*\}/gm, "$1").
-                                    replace(/\{~~(.*?)~>(.*?)~~\}/gm, "$1").
-                                    replace(/\{\=\=(.*?)[ \t]*(\[(.*?)\])?[ \t]*\=\=\}{>>(.*?)<<\}/gm, "$1").
-                                    replace(/\{>>(.*?)<<\}/gm, "")
-                                  $.GollumEditor.replaceSelection( toReplace );
+                              replace: function ( res ) {
+                                var rep = '';
+                                if ( res['url'] ) {
+                                  rep = '[[' + res['url'] + ']]';
                                 }
-
-                             }
-
-
+                                return rep;
+                              }
+                            }
 };
+
+$.GollumEditor.defineLanguage('org', $.constructLanguageDefinition(OrgMode));
 
 var OrgModeHelp = [
 
@@ -218,7 +123,6 @@ var OrgModeHelp = [
 ];
 
 
-$.GollumEditor.defineLanguage('org', OrgMode);
 $.GollumEditor.defineHelp('org', OrgModeHelp);
 
 })(jQuery);

--- a/lib/gollum/public/gollum/javascript/editor/langs/pod.js
+++ b/lib/gollum/public/gollum/javascript/editor/langs/pod.js
@@ -4,104 +4,51 @@
 **/
 (function($) {
 
+// No need to set all the replacements, only those different from the default language (Markdown).
 var Pod = {
 
   'function-bold' :         {         
-                              search: /([^\n]+)([\n\s]*)/g,
                               replace: "B<$1>$2"
                             },
 
   'function-italic' :       {
-                              search: /([^\n]+)([\n\s]*)/g,
                               replace: "I<$1>$2"
                             },
 
+  'function-hr' :           undefined,
+
   'function-code'   :       {
-                              search: /([^\n]+)([\n\s]*)/g,
                               replace: "C<$1>$2"
                             },
 
   'function-h1'         :   {
-                              search: /(.+)([\n]?)/gi,
-                              replace: "=head1 $1$2",
-                              break_line: true,
-                              whole_line: true
+                              replace: "=head1 $1$2"
                             },
 
   'function-h2'         :   {
-                              search: /(.+)([\n]?)/gi,
-                              replace: "=head2 $1$2",
-                              break_line: true,
-                              whole_line: true
+                              replace: "=head2 $1$2"
                             },
 
   'function-h3'         :   {
-                              search: /(.+)([\n]?)/gi,
-                              replace: "=head3 $1$2",
-                              break_line: true,
-                              whole_line: true
+                              replace: "=head3 $1$2"
                             },
 
   'function-link'       :   {
-                              exec: function( txt, selText, $field ) {
-                                var results = null;
-                                $.GollumEditor.Dialog.init({
-                                  title: 'Insert Link',
-                                  fields: [
-                                    {
-                                      id:   'text',
-                                      name: 'Link Text',
-                                      type: 'text',
-                                      defaultValue: selText
-                                    },
-                                    {
-                                      id:   'href',
-                                      name: 'URL',
-                                      type: 'text'
-                                    }
-                                  ],
-                                  OK: function( res ) {
-                                   var rep = '';
-                                   if ( res['text'] && res['href'] ) {
-                                      rep = 'L<' + res['text'] + '|' +
-                                             res['href'] + '>';
-                                    }
-                                    $.GollumEditor.replaceSelection( rep );
-                                  }
-                                });
+                              replace: function ( res ) {
+                                var rep = '';
+                                if ( res['text'] && res['href'] ) {
+                                  rep = 'L<' + res['text'] + '|' + res['href'] + '>';
+                                }
+                                return rep;
                               }
                             },
-                            
-  'function-critic-accept' : {
-                              exec: function( txt, selText, $field) {
-                                var toReplace = selText.
-                                  replace(/\{\+\+(.*?)\+\+[ \t]*(\[(.*?)\])?[ \t]*\}/gm, "$1").
-                                  replace(/\{--(.*?)--[ \t]*(\[(.*?)\])?[ \t]*\}/gm, "").
-                                  replace(/\{~~(.*?)~>(.*?)~~\}/gm, "$2").
-                                  replace(/\{\=\=(.*?)[ \t]*(\[(.*?)\])?[ \t]*\=\=\}{>>(.*?)<<\}/gm, "$1").
-                                  replace(/\{>>(.*?)<<\}/gm, "")
-                                $.GollumEditor.replaceSelection( toReplace );
-                              }
-
-                          },
-
-    'function-critic-reject' : {
-                                exec: function( txt, selText, $field) {
-                                  var toReplace = selText.
-                                    replace(/\{\+\+(.*?)\+\+[ \t]*(\[(.*?)\])?[ \t]*\}/gm, "").
-                                    replace(/\{--(.*?)--[ \t]*(\[(.*?)\])?[ \t]*\}/gm, "$1").
-                                    replace(/\{~~(.*?)~>(.*?)~~\}/gm, "$1").
-                                    replace(/\{\=\=(.*?)[ \t]*(\[(.*?)\])?[ \t]*\=\=\}{>>(.*?)<<\}/gm, "$1").
-                                    replace(/\{>>(.*?)<<\}/gm, "")
-                                  $.GollumEditor.replaceSelection( toReplace );
-                                }
-
-                             }
-
-
+  'function-image'      :   undefined,
+  'function-ul'         :   undefined,
+  'function-ol'         :   undefined,
+  'function-blockquote' :   undefined
 };
 
-$.GollumEditor.defineLanguage('pod', Pod);
+$.GollumEditor.defineLanguage('pod', $.constructLanguageDefinition(Pod));
 
 
 var PodHelp = [

--- a/lib/gollum/public/gollum/javascript/editor/langs/pod.js
+++ b/lib/gollum/public/gollum/javascript/editor/langs/pod.js
@@ -1,5 +1,6 @@
 /**
  *  Pod Language Definition
+ *  See default.js for documentation
 **/
 (function($) {
 

--- a/lib/gollum/public/gollum/javascript/editor/langs/rdoc.js
+++ b/lib/gollum/public/gollum/javascript/editor/langs/rdoc.js
@@ -1,20 +1,6 @@
 /**
- *  Markdown Language Definition
- *
- *  A language definition for string manipulation operations, in this case
- *  for the Markdown, uh, markup language. Uses regexes for various functions
- *  by default. If regexes won't do and you need to do some serious
- *  manipulation, you can declare a function in the object instead.
- *
- *  Code example:
- *  'functionbar-id'  :   {
- *                          exec: function(text, selectedText) {
- *                                   functionStuffHere();
- *                                },
- *                          search: /somesearchregex/gi,
- *                          replace: 'replace text for RegExp.replace',
- *                          append: "just add this where the cursor is"
- *                         }
+ *  Rdoc Language Definition
+ *  See default.js for documentation
  *
 **/
 (function($) {

--- a/lib/gollum/public/gollum/javascript/editor/langs/rdoc.js
+++ b/lib/gollum/public/gollum/javascript/editor/langs/rdoc.js
@@ -5,92 +5,19 @@
 **/
 (function($) {
 
+// No need to set all the replacements, only those different from the default language (Markdown).
+// RDoc is pretty bare bones, so we only need to unset some functions.
 var RDoc = {
-
-  'function-bold' :         {
-                              search: /([^\n]+)([\n\s]*)/g,
-                              replace: "((*$1*))$2"
-                            },
-  'function-code'   :       {
-                              search: /([^\n]+)([\n\s]*)/g,
-                              replace: "(({$1}))$2"
-                            },
-
-  'function-ul'     :       {
-                              exec: function( txt, selText, $field ) {
-                                var repText = '';
-                                var lines = selText.split("\n");
-                                for ( var i = 0; i < lines.length; i++ ) {
-                                  repText += '* ' + lines[i] + "\n";
-                                }
-                                repText = repText.substring(0, repText.length-1)
-                                $.GollumEditor.replaceSelection( repText, true, true );
-                              },
-                            },
-
-  'function-ol'   :         {
-                              exec: function( txt, selText, $field ) {
-                                var repText = '';
-                                var lines = selText.split("\n");
-                                for ( var i = 0; i < lines.length; i++ ) {
-                                  repText += (i+1).toString() + '. ' +
-                                  lines[i] + "\n";
-                                }
-                                repText = repText.substring(0, repText.length-1)
-                                $.GollumEditor.replaceSelection( repText, true, true );
-                              },
-                            },
-
-  'function-h1'         :   {
-                              search: /(.+)([\n]?)/gi,
-                              replace: "= $1$2",
-                              break_line: true,
-                              whole_line: true
-                            },
-
-  'function-h2'         :   {
-                              search: /(.+)([\n]?)/gi,
-                              replace: "== $1$2",
-                              break_line: true,
-                              whole_line: true
-                            },
-
-  'function-h3'         :   {
-                              search: /(.+)([\n]?)/gi,
-                              replace: "=== $1$2",
-                              break_line: true,
-                              whole_line: true,
-                            },
-                            
-  'function-critic-accept' : {
-                              exec: function( txt, selText, $field) {
-                                var toReplace = selText.
-                                  replace(/\{\+\+(.*?)\+\+[ \t]*(\[(.*?)\])?[ \t]*\}/gm, "$1").
-                                  replace(/\{--(.*?)--[ \t]*(\[(.*?)\])?[ \t]*\}/gm, "").
-                                  replace(/\{~~(.*?)~>(.*?)~~\}/gm, "$2").
-                                  replace(/\{\=\=(.*?)[ \t]*(\[(.*?)\])?[ \t]*\=\=\}{>>(.*?)<<\}/gm, "$1").
-                                  replace(/\{>>(.*?)<<\}/gm, "")
-                                $.GollumEditor.replaceSelection( toReplace );
-                              }
-
-                          },
-
-    'function-critic-reject' : {
-                                exec: function( txt, selText, $field) {
-                                  var toReplace = selText.
-                                    replace(/\{\+\+(.*?)\+\+[ \t]*(\[(.*?)\])?[ \t]*\}/gm, "").
-                                    replace(/\{--(.*?)--[ \t]*(\[(.*?)\])?[ \t]*\}/gm, "$1").
-                                    replace(/\{~~(.*?)~>(.*?)~~\}/gm, "$1").
-                                    replace(/\{\=\=(.*?)[ \t]*(\[(.*?)\])?[ \t]*\=\=\}{>>(.*?)<<\}/gm, "$1").
-                                    replace(/\{>>(.*?)<<\}/gm, "")
-                                  $.GollumEditor.replaceSelection( toReplace );
-                                }
-
-                             }
-
-
+  'function-code'       :   undefined,
+  'function-h1'         :   undefined,
+  'function-h2'         :   undefined,
+  'function-h3'         :   undefined,
+  'function-link'       :   undefined,
+  'function-image'      :   undefined,
+  'function-hr'         :   undefined,
+  'function-blockquote' :   undefined,
 };
 
-$.GollumEditor.defineLanguage('rdoc', RDoc);
+$.GollumEditor.defineLanguage('rdoc', $.constructLanguageDefinition(RDoc));
 
 })(jQuery);

--- a/lib/gollum/public/gollum/javascript/editor/langs/rest.js
+++ b/lib/gollum/public/gollum/javascript/editor/langs/rest.js
@@ -1,20 +1,6 @@
 /**
  *  reStructuredText Language Definition
- *
- *  A language definition for string manipulation operations, in this case
- *  for the reStructuredText markup language. Uses regexes for various 
- *  functions by default. If regexes won't do and you need to do some serious
- *  manipulation, you can declare a function in the object instead.
- *
- *  Code example:
- *  'functionbar-id'  :   {
- *                          exec: function(text, selectedText) {
- *                                   functionStuffHere();
- *                                },
- *                          search: /somesearchregex/gi,
- *                          replace: 'replace text for RegExp.replace',
- *                          append: "just add this where the cursor is"
- *                         }
+ *  See default.js for documentation
  *
 **/
 (function($) {

--- a/lib/gollum/public/gollum/javascript/editor/langs/rest.js
+++ b/lib/gollum/public/gollum/javascript/editor/langs/rest.js
@@ -5,249 +5,158 @@
 **/
 (function($) {
 
-var reStructuredText = {
 
-  'function-bold' :         {
-                              search: /([^\n]+)([\n\s]*)/g,
-                              replace: "**$1**$2"
-                            },
+  var headerFunc = function (selText, selectedRange, symbol) {
+    adornment = symbol.repeat(selText.length);
+    repText = selText + "\n" + adornment + "\n";
+    $.GollumEditor.replaceSelection(repText, false, false, selectedRange);
+  };
 
-  'function-italic' :       {
-                              search: /([^\n]+)([\n\s]*)/g,
-                              replace: "*$1*$2"
-                            },
+  // No need to set all the replacements, only those different from the default language (Markdown).
+  var reStructuredText = {
 
-  'function-code'   :       {
-                              search: /([^\n]+)([\n\s]*)/g,
-                              replace: "``$1``$2"
-                            },
+    'function-bold' :         {
+                                replace: "**$1**$2"
+                              },
 
-  'function-hr'     :       {
-                              append: "\n\n----\n\n"
-                            },
+    'function-italic' :       {
+                                replace: "*$1*$2"
+                              },
 
-  'function-ul'     :       {
-			                        exec: function(txt, selText, $field) {
-	                              var pfx = "* ";
-                                var lines = selText.split("\n");
+    'function-code'   :       {
+                                replace: "``$1``$2"
+                              },
+
+    'function-hr'     :       {
+                                append: "\n\n----\n\n"
+                              },
+
+    'function-blockquote' :   { 
+                                exec: function( txt, selText, $field) {
+                                  var pfx = "    ";
+                                  var lines = selText.split("\n");
                                   for ( var i = 0; i < lines.length; i++ ) {
                                       lines[i] = pfx + lines[i];
-				  }
+                                  }
                                   var repText = lines.join("\n");
                                   $.GollumEditor.replaceSelection(repText);
                                 }
-                            },
-
-  'function-ol'   :         {
-                              exec: function( txt, selText, $field) {
-                                var lines = selText.split("\n");
-                                for ( var i = 0; i < lines.length; i++ ) {
-                                    pfx = (i + 1).toString() + ". ";
-                                    lines[i] = pfx + lines[i];
+                              },
+                              
+    'function-h1'         :   { 
+                                symbol: '=',
+                                exec: function( txt, selText, $field, selectedRange) {
+                                  headerFunc(selText, selectedRange, this.symbol);
                                 }
-                                var repText = lines.join("\n");
-                                $.GollumEditor.replaceSelection(repText);
-                              }
-                            },
+                              },
 
-  'function-blockquote' :   {
-                              exec: function( txt, selText, $field) {
-                                var pfx = "    ";
-                                var lines = selText.split("\n");
-                                for ( var i = 0; i < lines.length; i++ ) {
-                                    lines[i] = pfx + lines[i];
-                                }
-                                var repText = lines.join("\n");
-                                $.GollumEditor.replaceSelection(repText);
-                              }
-                            },
-
-  'function-h1'         :   {
-                              exec: function( txt, selText, $field) {
-                                var lines = selText.split("\n");
-                                title = lines.shift();
-                                subtitle = lines.join(' ');
-                                title_adornment = "=".repeat(title.length);
-                                subtitle_adornment = "~".repeat(subtitle.length);
-
-                                if (title != "" && subtitle != "") {
-                                  repText = title_adornment + "\n" + title + "\n" + title_adornment + "\n" +
-                                            subtitle_adornment + "\n" + subtitle + "\n" + subtitle_adornment;
-                                } else if (title != ""){
-                                  repText = title_adornment + "\n" + title + "\n" + title_adornment;
-                                }
-                                $.GollumEditor.replaceSelection(repText);
-                              }
-                            },
-                            
-  'function-h2'         :   {
-                              exec: function( txt, selText, $field) {
-                                var lines = selText.split("\n");
-                                header = lines.shift();
-                                tail = lines.join("\n");
-                                adornment = "=".repeat(header.length);
-                                repText = header + "\n" + adornment + "\n" + tail;
-                                $.GollumEditor.replaceSelection(repText);
-                              }
-                            },             
-  
-  'function-critic-accept' : {
-                              exec: function( txt, selText, $field) {
-                                var toReplace = selText.
-                                  replace(/\{\+\+(.*?)\+\+[ \t]*(\[(.*?)\])?[ \t]*\}/gm, "$1").
-                                  replace(/\{--(.*?)--[ \t]*(\[(.*?)\])?[ \t]*\}/gm, "").
-                                  replace(/\{~~(.*?)~>(.*?)~~\}/gm, "$2").
-                                  replace(/\{\=\=(.*?)[ \t]*(\[(.*?)\])?[ \t]*\=\=\}{>>(.*?)<<\}/gm, "$1").
-                                  replace(/\{>>(.*?)<<\}/gm, "")
-                                $.GollumEditor.replaceSelection( toReplace );
-                              }
-
-                          },
-
-    'function-critic-reject' : {
-                                exec: function( txt, selText, $field) {
-                                  var toReplace = selText.
-                                    replace(/\{\+\+(.*?)\+\+[ \t]*(\[(.*?)\])?[ \t]*\}/gm, "").
-                                    replace(/\{--(.*?)--[ \t]*(\[(.*?)\])?[ \t]*\}/gm, "$1").
-                                    replace(/\{~~(.*?)~>(.*?)~~\}/gm, "$1").
-                                    replace(/\{\=\=(.*?)[ \t]*(\[(.*?)\])?[ \t]*\=\=\}{>>(.*?)<<\}/gm, "$1").
-                                    replace(/\{>>(.*?)<<\}/gm, "")
-                                  $.GollumEditor.replaceSelection( toReplace );
+    'function-h2'         :   { 
+                                symbol: '-',
+                                exec: function( txt, selText, $field, selectedRange) {
+                                  headerFunc(selText, selectedRange, this.symbol);
                                 }
 
-                             },
-                             
+                              },
+                              
+    'function-h3'         :   { 
+                                symbol: '~',
+                                exec: function( txt, selText, $field, selectedRange) {
+                                  headerFunc(selText, selectedRange, this.symbol);
+                                }
+                              },
+
     'function-link'       :   {
-                              exec: function( txt, selText, $field ) {
-                                var results = null;
-                                $.GollumEditor.Dialog.init({
-                                  title: 'Insert Link',
-                                  fields: [
-                                    {
-                                      id:   'text',
-                                      name: 'Link Text',
-                                      type: 'text',
-                                      defaultValue: selText
-                                    },
-                                    {
-                                      id:   'href',
-                                      name: 'URL',
-                                      type: 'text'
-                                    }
-                                  ],
-                                  OK: function( res ) {
-                                   var rep = '';
-                                   if ( res['text'] && res['href'] ) {
-                                      rep = '`' + res['text'] + ' ' +
-                                             '<' + res['href'] + '>`_';
-                                    }
-                                    $.GollumEditor.replaceSelection( rep );
+                                replace: function( res ) {
+                                 var rep = '';
+                                 if ( res['text'] && res['href'] ) {
+                                    rep = '`' + res['text'] + ' ' + '<' + res['href'] + '>`_';
                                   }
-                                });
-                              }
-                            },
+                                  return rep;
+                                }
+                              },
 
-  'function-image'      :   {
-                              exec: function( txt, selText, $field ) {
-                                var results = null;
-                                $.GollumEditor.Dialog.init({
-                                  title: 'Insert Image',
-                                  fields: [
-                                    {
-                                      id: 'url',
-                                      name: 'Image URL',
-                                      type: 'text'
-                                    },
-                                    {
-                                      id: 'alt',
-                                      name: 'Alt Text',
-                                      type: 'text'
-                                    }
-                                  ],
-                                  OK: function( res ) {
-                                    var rep = "";
-                                    if ( res['url'] && res['alt'] ) {
-                                      rep = ".. image:: " + res['url'] + "\n" +
-                                            '    :alt: ' + res['alt'];
-                                    }
-                                    $.GollumEditor.replaceSelection( rep );
+    'function-image'      :   {
+                                replace: function( res ) {
+                                  var rep = '';
+                                  if ( res['url'] && res['alt'] ) {
+                                    rep = '.. image:: ' + res['url'] + "\n" + '    :alt: ' + res['alt'];
                                   }
-                                });
+                                  return rep;
+                                }
                               }
-                            }
 
-};
+  };
 
-var reStructuredTextHelp = [
+  $.GollumEditor.defineLanguage('rst', $.constructLanguageDefinition(reStructuredText));
 
-  {
-    menuName: 'Block Elements',
-    content: [
-                {
-                  menuName: 'Paragraphs &amp; Breaks',
-                  data: '<p>To create a paragraph, simply create a block of text that is not separated by one or more blank lines. Blocks of text separated by one or more blank lines will be parsed as paragraphs.</p>'
-                },
-                {
-                  menuName: 'Headers',
-                  data: '<p>Rest uses overline/underline adornments to indicate headers. To create a header, underline your header text with adornment characters such as the <code>=, ~, +, ^</code> characters. Make sure that the adornment is of the same length (or longer) as the header text. Use a different adornment character to specify a different heading depth.</p>'
-                },
-                {
-                  menuName: 'Blockquotes',
-                  data: '<p>Rest creates blockquotes using indentation. This looks best if you use four spaces per level of indentation.</p>'
-                },
-                {
-                  menuName: 'Lists',
-                  data: '<p>Rest supports both ordered and unordered lists. To create an ordered list, simply prefix each line with a number, or use <code>#</code> for auto enumeration. To create an unordered list, you can prefix each line with <code>*</code>, <code>+</code> or <code>-</code>.</p>'
-                },
-                {
-                  menuName: 'Code Blocks',
-                  data: '<p>Rest wraps code blocks in pre-formatted tags to preserve indentation in your code blocks. To create a code block, indent the entire block by at least 4 spaces or one tab. Rest will strip the extra indentation you&rsquo;ve added to the code block.</p>'
-                },
-                {
-                  menuName: 'Horizontal Rules',
-                  data: '<p>Horizontal rules are created by placing four or more hyphens, asterisks or underscores on a line by themselves.</p>'
-                }
-              ]
-  },
+  var reStructuredTextHelp = [
 
-  {
-    menuName: 'Span Elements',
-    content: [
-                {
-                  menuName: 'Links',
-                  data: '<p>To create an inline link, create a set of backticks, include the link title first, followed by the url in angled brackets (e.g., <code>`Python <http://www.python.org/>`_</code>).</p>'
-                },
+    {
+      menuName: 'Block Elements',
+      content: [
+                  {
+                    menuName: 'Paragraphs &amp; Breaks',
+                    data: '<p>To create a paragraph, simply create a block of text that is not separated by one or more blank lines. Blocks of text separated by one or more blank lines will be parsed as paragraphs.</p>'
+                  },
+                  {
+                    menuName: 'Headers',
+                    data: '<p>Rest uses overline/underline adornments to indicate headers. To create a header, underline your header text with adornment characters such as the <code>=, ~, +, ^</code> characters. Make sure that the adornment is of the same length (or longer) as the header text. Use a different adornment character to specify a different heading depth.</p>'
+                  },
+                  {
+                    menuName: 'Blockquotes',
+                    data: '<p>Rest creates blockquotes using indentation. This looks best if you use four spaces per level of indentation.</p>'
+                  },
+                  {
+                    menuName: 'Lists',
+                    data: '<p>Rest supports both ordered and unordered lists. To create an ordered list, simply prefix each line with a number, or use <code>#</code> for auto enumeration. To create an unordered list, you can prefix each line with <code>*</code>, <code>+</code> or <code>-</code>.</p>'
+                  },
+                  {
+                    menuName: 'Code Blocks',
+                    data: '<p>Rest wraps code blocks in pre-formatted tags to preserve indentation in your code blocks. To create a code block, indent the entire block by at least 4 spaces or one tab. Rest will strip the extra indentation you&rsquo;ve added to the code block.</p>'
+                  },
+                  {
+                    menuName: 'Horizontal Rules',
+                    data: '<p>Horizontal rules are created by placing four or more hyphens, asterisks or underscores on a line by themselves.</p>'
+                  }
+                ]
+    },
 
-                {
-                  menuName: 'Emphasis',
-                  data: '<p>Asterisks (<code>*</code>) are treated as emphasis and are wrapped with an <code>&lt;em&gt;</code> tag, which usually displays as italics in most browsers. Double asterisks (<code>**</code>) are treated as bold using the <code>&lt;strong&gt;</code> tag. To create italic or bold text, simply wrap your words in single/double asterisks. For example, <code>**My double emphasis text**</code> becomes <strong>My double emphasis text</strong>, and <code>*My single emphasis text*</code> becomes <em>My single emphasis text</em>.</p>'
-                },
+    {
+      menuName: 'Span Elements',
+      content: [
+                  {
+                    menuName: 'Links',
+                    data: '<p>To create an inline link, create a set of backticks, include the link title first, followed by the url in angled brackets (e.g., <code>`Python <http://www.python.org/>`_</code>).</p>'
+                  },
 
-                {
-                  menuName: 'Code',
-                  data: '<p>To create inline spans of code, simply wrap the code in backticks (<code>`</code>). Rest will turn <code>`myFunction`</code> into <code>myFunction</code>.</p>'
-                },
+                  {
+                    menuName: 'Emphasis',
+                    data: '<p>Asterisks (<code>*</code>) are treated as emphasis and are wrapped with an <code>&lt;em&gt;</code> tag, which usually displays as italics in most browsers. Double asterisks (<code>**</code>) are treated as bold using the <code>&lt;strong&gt;</code> tag. To create italic or bold text, simply wrap your words in single/double asterisks. For example, <code>**My double emphasis text**</code> becomes <strong>My double emphasis text</strong>, and <code>*My single emphasis text*</code> becomes <em>My single emphasis text</em>.</p>'
+                  },
 
-                {
-                  menuName: 'Images',
-                  data: '<p>Rest image syntax is two dots, followed by a space, the word "image", two colons, another space, and the url: <code>.. image:: http://image.com/image.png</code>.</p>'
-                }
-              ]
-  },
+                  {
+                    menuName: 'Code',
+                    data: '<p>To create inline spans of code, simply wrap the code in backticks (<code>`</code>). Rest will turn <code>`myFunction`</code> into <code>myFunction</code>.</p>'
+                  },
 
-  {
-    menuName: 'Miscellaneous',
-    content: [
-                {
-                  menuName: 'Escaping',
-                  data: '<p>If you want to use a special Rest character in your document (such as displaying literal asterisks), you can escape the character with the backslash (<code>\\</code>). Rest will ignore the character directly after a backslash.'
-                }
-              ]
-  }
-];
+                  {
+                    menuName: 'Images',
+                    data: '<p>Rest image syntax is two dots, followed by a space, the word "image", two colons, another space, and the url: <code>.. image:: http://image.com/image.png</code>.</p>'
+                  }
+                ]
+    },
 
+    {
+      menuName: 'Miscellaneous',
+      content: [
+                  {
+                    menuName: 'Escaping',
+                    data: '<p>If you want to use a special Rest character in your document (such as displaying literal asterisks), you can escape the character with the backslash (<code>\\</code>). Rest will ignore the character directly after a backslash.'
+                  }
+                ]
+    }
+  ];
 
-$.GollumEditor.defineLanguage('rest', reStructuredText);
-$.GollumEditor.defineHelp('rest', reStructuredTextHelp);
+  $.GollumEditor.defineHelp('rest', reStructuredTextHelp);
 
 })(jQuery);

--- a/lib/gollum/public/gollum/javascript/editor/langs/textile.js
+++ b/lib/gollum/public/gollum/javascript/editor/langs/textile.js
@@ -6,152 +6,64 @@
 
 (function($) {
 
+// No need to set all the replacements, only those different from the default language (Markdown).
 var Textile = {
 
-  'function-bold' :         {         
-                              search: /([^\n]+)([\n\s]*)/g,
-                              replace: "*$1*$2"
-                            },
-
-  'function-italic' :       {
-                              search: /([^\n]+)([\n\s]*)/g,
-                              replace: "_$1_$2"
-                            },
-
-  'function-hr'     :       {
-                              append: "\n***\n"
-                            },
+  'function-hr'     :       undefined,
 
   'function-code'   :       {
-                              search: /([^\n]+)([\n\s]*)/g,
-                              replace: "<pre><code>$1</code></pre>$2"
-                            },
-
-  'function-ul'     :       {
-                              exec: function( txt, selText, $field ) {
-                                var repText = '';
-                                var lines = selText.split("\n");
-                                for ( var i = 0; i < lines.length; i++ ) {
-                                  repText += '* ' + lines[i] + "\n";
-                                }
-                                repText = repText.substring(0, repText.length-1)
-                                $.GollumEditor.replaceSelection( repText, true, true );
-                              },
+                              replace: "bc. $1$2",
+                              whole_line: true
                             },
 
   'function-ol'   :         {
-                              exec: function( txt, selText, $field ) {
-                                var repText = '';
-                                var lines = selText.split("\n");
-                                for ( var i = 0; i < lines.length; i++ ) {
-                                  repText += '# ' + lines[i] + "\n";
-                                }
-                                repText = repText.substring(0, repText.length-1)
-                                $.GollumEditor.replaceSelection( repText, true, true );
-                              },
+                              'line': function ( index, line) {
+                                return '# ' + line + "\n";
+                              } 
                             },
 
   'function-blockquote' :   {
-                              search: /(.+)([\n]?)/gi,
                               replace: "bq. $1$2",
-                              break_line: true,
+                            },
+
+  'function-h1'         :   {
+                              replace: "h1. $1$2"
+                            },
+
+  'function-h2'         :   {
+                              replace: "h2. $1$2"
+                            },
+
+  'function-h3'         :   {
+                              replace: "h3. $1$2"
                             },
 
   'function-link'       :   {
-                              exec: function( txt, selText, $field ) {
-                                var results = null;
-                                $.GollumEditor.Dialog.init({
-                                  title: 'Insert Link',
-                                  fields: [
-                                    {
-                                      id:   'text',
-                                      name: 'Link Text',
-                                      type: 'text',
-                                      help: 'The text to display to the user.',
-                                      defaultValue: selText
-                                    },
-                                    {
-                                      id:   'href',
-                                      name: 'URL',
-                                      type: 'text',
-                                      help: 'The URL to link to.'
-                                    }
-                                  ],
-                                  OK: function( res ) {
-                                   var h = '';
-                                   if ( res['text'] && res['href'] ) {
-                                      h = '"' + res['text'] + '":' +
-                                          res['href'];
-                                   }
-                                   $.GollumEditor.replaceSelection( h );
-                                  }
-                                });
-
-
+                              replace: function( res ) {
+                               var rep = '';
+                               if ( res['text'] && res['href'] ) {
+                                  rep = '"' + res['text'] + '":' + res['href'];
+                               }
+                               return rep;
                               }
                             },
 
   'function-image'      :   {
-                              exec: function( txt, selText, $field ) {
-                                var results = null;
-                                $.GollumEditor.Dialog.init({
-                                  title: 'Insert Image',
-                                  fields: [
-                                    {
-                                      id: 'url',
-                                      name: 'Image URL',
-                                      type: 'text'
-                                    },
-                                    {
-                                      id: 'alt',
-                                      name: 'Alt Text',
-                                      type: 'text'
-                                    }
-                                  ],
-                                  OK: function( res ) {
-                                    if ( res['url'] ) {
-                                      var h = '!' + res['url'];
-                                      if ( res['alt'] != '' ) {
-                                        h += '(' + res['alt'] + ')';
-                                      }
-                                      h += '!';
-                                      $.GollumEditor.replaceSelection( h );
-                                    }
+                              replace: function( res ) {
+                                var rep = '';
+                                if ( res['url'] ) {
+                                  var rep = '!' + res['url'];
+                                  if ( res['alt'] != '' ) {
+                                    rep += '(' + res['alt'] + ')';
                                   }
-                                });
-                              }
-                            },
-                            
-  'function-critic-accept' : {
-                              exec: function( txt, selText, $field) {
-                                var toReplace = selText.
-                                  replace(/\{\+\+(.*?)\+\+[ \t]*(\[(.*?)\])?[ \t]*\}/gm, "$1").
-                                  replace(/\{--(.*?)--[ \t]*(\[(.*?)\])?[ \t]*\}/gm, "").
-                                  replace(/\{~~(.*?)~>(.*?)~~\}/gm, "$2").
-                                  replace(/\{\=\=(.*?)[ \t]*(\[(.*?)\])?[ \t]*\=\=\}{>>(.*?)<<\}/gm, "$1").
-                                  replace(/\{>>(.*?)<<\}/gm, "")
-                                $.GollumEditor.replaceSelection( toReplace );
-                              }
-
-                          },
-
-    'function-critic-reject' : {
-                                exec: function( txt, selText, $field) {
-                                  var toReplace = selText.
-                                    replace(/\{\+\+(.*?)\+\+[ \t]*(\[(.*?)\])?[ \t]*\}/gm, "").
-                                    replace(/\{--(.*?)--[ \t]*(\[(.*?)\])?[ \t]*\}/gm, "$1").
-                                    replace(/\{~~(.*?)~>(.*?)~~\}/gm, "$1").
-                                    replace(/\{\=\=(.*?)[ \t]*(\[(.*?)\])?[ \t]*\=\=\}{>>(.*?)<<\}/gm, "$1").
-                                    replace(/\{>>(.*?)<<\}/gm, "")
-                                  $.GollumEditor.replaceSelection( toReplace );
+                                  rep += '!';
+                                  return rep;
                                 }
-
-                             }
-
-
+                              }
+                            }
 };
 
-$.GollumEditor.defineLanguage('textile', Textile);
+$.GollumEditor.defineLanguage('textile', $.constructLanguageDefinition(Textile));
 
 
 var TextileHelp = [

--- a/lib/gollum/public/gollum/javascript/editor/langs/textile.js
+++ b/lib/gollum/public/gollum/javascript/editor/langs/textile.js
@@ -1,6 +1,9 @@
 /**
  *  Textile Language Definition
+ *  See default.js for documentation
+ *
  */
+
 (function($) {
 
 var Textile = {


### PR DESCRIPTION
Also fixes two bugs:
  * `reStructuredText function buttons were not being activated because the language was called 'rest' rather than 'rst' (`rest.js`)
  * function buttons were not being reset on switching language because the buttons are `<button>` elements rather than `<a>` elements since the move to Primer (`gollum.editor.js`)