### PR TITLE
Editable sections

### DIFF
--- a/lib/gollum/public/gollum/javascript/app.js
+++ b/lib/gollum/public/gollum/javascript/app.js
@@ -6,6 +6,7 @@
 //= require gollum.dialog
 //= require gollum.placeholder
 //= require editor/gollum.editor
+//= require editor/sections
 //= require editor/langs/default
 //= require_tree ./editor/langs
 //= require ace/ace

--- a/lib/gollum/public/gollum/javascript/editor/gollum.editor.js
+++ b/lib/gollum/public/gollum/javascript/editor/gollum.editor.js
@@ -219,6 +219,15 @@
         }
       } // EditorHas.functionBar
 
+      if (ActiveOptions['section'] && $.markupSupportsEditableSections ( ActiveOptions.MarkupType )) {
+        var sectionLine = $.findSection(ActiveOptions['section'], LanguageDefinition.getDefinitionFor('gollum-helpers'));
+        if (sectionLine) {
+          window.ace_editor.gotoLine(sectionLine+1, 0, false);
+          window.ace_editor.scrollToLine(sectionLine, false, false);
+          window.ace_editor.focus();
+        }
+      }
+
       if ( EditorHas.dragDropUpload() ) {
         var $editorBody = $('#gollum-editor-body-ace');
         var editorBody = $('#gollum-editor-body-ace')[0];

--- a/lib/gollum/public/gollum/javascript/editor/langs/markdown.js
+++ b/lib/gollum/public/gollum/javascript/editor/langs/markdown.js
@@ -6,8 +6,35 @@
 
 (function($) {
 
-var MarkDown = $.extend(true, {}, $.DefaultLang); // The default language definition is markdown, so copy it into a new variable.
-$.GollumEditor.defineLanguage('markdown', MarkDown);
+// The default language definition (in default.js) is markdown, so we only need to set the special helper functions.
+var MarkDown = {
+
+  'gollum-helpers': {
+
+    'find-header-line': function (line, token) {
+      // For use in sections.js
+      // Checks if token matches alternative-syntax markdown headers. These are of the form '===' or '---'.
+      // If so, returns an array containing the text of the header and the previous line number.
+      // If not, returns null.
+      if ( token.match(/(^[=]+$)/) || token.match(/(^[-]+$)/) ){
+        var foundLine = line-1
+        var text = window.ace_editor.getSession().getLine(foundLine);
+        if (foundLine >= 0 && !/^\s+$/.test(text)) { // Sanity check
+          return [text, foundLine];
+        }
+        else {
+          return null;
+        }
+      } else {
+        return null;
+      }
+    }
+
+  }
+
+};
+
+$.GollumEditor.defineLanguage('markdown', $.constructLanguageDefinition(MarkDown));
 
 var MarkDownHelp = [
 

--- a/lib/gollum/public/gollum/javascript/editor/langs/rest.js
+++ b/lib/gollum/public/gollum/javascript/editor/langs/rest.js
@@ -83,6 +83,22 @@
                                   }
                                   return rep;
                                 }
+                              },
+
+    'gollum-helpers'      :   {
+
+                                'find-header-line': function (line, token) {
+                                  // For use in sections.js
+                                  // Return an array containing the text of the header and the previous line number.
+                                  var foundLine = line-1;
+                                  var text = window.ace_editor.getSession().getLine(foundLine);
+                                  if (foundLine >= 0 && !/^\s+$/.test(text)) { // Sanity check
+                                    return [text, foundLine];
+                                  }
+                                  else {
+                                    return null;
+                                  }
+                              }
                               }
 
   };

--- a/lib/gollum/public/gollum/javascript/editor/sections.js
+++ b/lib/gollum/public/gollum/javascript/editor/sections.js
@@ -1,0 +1,93 @@
+(function($) {
+
+  $.markupSupportsEditableSections = function ( markup ) {
+    var supportedFormats = ['markdown', 'textile', 'asciidoc', 'rst'];
+    return supportedFormats.includes(markup);
+  }
+
+  $.findSection = function ( anchor, languageHelpers ) {
+    var titles = {};
+
+    for (i = 0; i < window.ace_editor.getSession().getLength(); i++) {
+      var foundLine = null;
+
+      var results = getSectionTokens(i);
+      var section = results[0];
+      var header  = results[1];
+
+      if (!section) {
+        continue; // No section on this line, go to the next
+      }
+
+      if (header) {
+        header = header['value'];
+        foundLine = i; // Header text was found on this line
+      } else
+      {
+        // No header text found on this line. Perhaps the markup language puts section-defining syntax and the title of the section on different lines?
+        var header_and_line = getHeader(i, section['value'], languageHelpers);
+        if ( header_and_line.length ) {
+          header = header_and_line[0];
+          foundLine = header_and_line[1];        
+        } else {
+          continue; // No header text was found again. Skip this line.
+        }
+      }
+
+      // Now that we have the header text, compare it to the anchor we're looking for.
+      header = generateAnchor(header);
+
+      // If we've encountered this header before, add an index to it (e.g. 'bilbo-baggins-1'.
+      if (index = titles[header]) {
+        header = header + '-' + index.toString();
+        titles[header] = index+1;
+      } else {
+        titles[header] = 1;
+      }
+
+      // Compare the final header to the anchor we're looking for
+      if (header == anchor) {
+        return foundLine;
+      }
+    }
+    return null;  
+  }
+
+  function getSectionTokens ( line ) {
+    var session = window.ace_editor.getSession();
+    tokens = session.getTokens(line);
+
+    // Assume we can't have more than one section heading per line, so take the first section and the first header text
+    section = tokens.filter(function (el) {
+      return /markup.heading/.test(el.type);
+    })[0];
+
+    header = tokens.filter(function (el) {
+      return /^(heading)|(text)$/.test(el.type); 
+    })[0];
+
+    return [section, header];
+  }
+
+  function getHeader ( section_line, section_token, languageHelpers ) {
+    if (!languageHelpers || !languageHelpers['find-header-line']) {
+      return [];
+    }
+    var results  = languageHelpers['find-header-line'](section_line, section_token);
+    if ( results == null ) {
+      return [];
+    } else {
+      return [results[0], results[1]];
+    }
+  }
+
+  function generateAnchor ( header ) {
+    header = header.trim();
+    header = header.replace(/[^a-z0-9_\s]/gi, ' ');
+    header = header.replace(/\s\s+/g, ' ');
+    header = header.split(/\s/).join('-');
+    header = header.replace(/^-/,'');
+    header = header.toLowerCase();
+    return header;
+  }
+})(jQuery);

--- a/lib/gollum/public/gollum/javascript/gollum.js.erb
+++ b/lib/gollum/public/gollum/javascript/gollum.js.erb
@@ -340,7 +340,9 @@ $(document).ready(function() {
     $("#gollum-editor-body").one('change', function(){
       window.onbeforeunload = function(){ return "Leaving will discard all edits!" };
     });
-    $.GollumEditor();
+    $.GollumEditor({
+      section: window.location.hash.substr(1)
+    });
     $("#gollum-editor-submit").click( function(e) {
       e.preventDefault();
       // Prevent button from being clicked again
@@ -499,14 +501,16 @@ $(document).ready(function() {
     // Set text direction auto
     $('.markdown-body p, .markdown-body span, .markdown-body pre, .markdown-body table').attr('dir','auto');
 
-    // Copy anchors for each editable header and give the new anchor the 'edit' class, to display an "edit section" link
-    $('a.anchor').each(function (index, anchor) {
-      header = $(anchor).closest(':header');
-      if (header.hasClass('editable')){
-        var newUrl = routePath('edit') + '/' + pageName() + $(anchor).attr('href');
-        $(anchor).clone().addClass('edit').attr('href', newUrl).appendTo(header);
-      }
-    });
+    if ($.markupSupportsEditableSections(pageFormat)){
+      // Copy anchors for each editable header and give the new anchor the 'edit' class, to display an "edit section" link
+      $('a.anchor').each(function (index, anchor) {
+        header = $(anchor).closest(':header');
+        if (header.hasClass('editable')){
+          var newUrl = routePath('edit') + '/' + pageName() + $(anchor).attr('href');
+          $(anchor).clone().addClass('edit').attr('href', newUrl).appendTo(header);
+        }
+      });
+    }
   }
 
   if( $('#wiki-history').length || $('#page-history').length){

--- a/lib/gollum/templates/layout.mustache
+++ b/lib/gollum/templates/layout.mustache
@@ -22,6 +22,7 @@
 	}
 	{{#page}}
 	  var pageFullPath = '{{escaped_url_path}}';
+    var pageFormat   = '{{format}}';
 	{{/page}}
 
   </script>


### PR DESCRIPTION
When clicking the little edit anchor on a section header on a page, the user will be taken to `/gollum/edit/PageName#section`. In the edit view, we use ace to search through the document for section definitions. When we find one, we generate an anchor for it, and compare it to the anchor searched for (`#section`). When there's a match, the editor scrolls to the relevant line, and the cursor is place there.

Complications:
  * Not all markups have their own ace modes. If they don't, we can't apply the above procedure. Hence we test whether the markup supports editable sections before applying it, and also when determining whether to insert the clickable pencil/edit anchor next to the header in the first place (in `gollum.js`).
  * Some markups (markdown, rest) have syntax that puts the section definition and its title on different lines. Ace only finds the definition (e.g. in markdown `====`), and doesn't know about the title on the other line. I added a `'gollum-helpers'` field to the relevant language definitions, which provides a function for getting the title from the other line. (In both markdown and rest, this is the previous line, but since we can imagine a markup language which has first `====` and then the title on the next line, I've let this up for determination by the helper function.)

Todo: - [ ] extend the ace modes for the supported formats to recognize gollum-specific block-level. syntax, such as UML and backtick-style code blocks.
 * This is so ace correctly ignores what will look like section definitions within such blocks.