### PR TITLE
Solve minor issue involving Preview title

### DIFF
--- a/lib/gollum/app.rb
+++ b/lib/gollum/app.rb
@@ -382,7 +382,13 @@ module Precious
 
       post '/preview' do
         wiki           = wiki_new
-        @name          = params[:page] || "Preview"
+        if params[:page]
+        @name = CGI.unescape(params[:page])
+        # Check if the page name determined from the url already has a format extension, and if so, strip it.
+        @name = Gollum::Page.valid_extension?(@name) ? Gollum::Page.strip_filename(@name) : @name
+        else
+          @name = "Preview"
+        end
         @page          = wiki.preview_page(@name, params[:content], params[:format])
         ['sidebar', 'header', 'footer'].each do |subpage|
           @page.send("set_#{subpage}".to_sym, params[subpage]) if params[subpage]

--- a/lib/gollum/app.rb
+++ b/lib/gollum/app.rb
@@ -382,13 +382,7 @@ module Precious
 
       post '/preview' do
         wiki           = wiki_new
-        if params[:page]
-        @name = CGI.unescape(params[:page])
-        # Check if the page name determined from the url already has a format extension, and if so, strip it.
-        @name = Gollum::Page.valid_extension?(@name) ? Gollum::Page.strip_filename(@name) : @name
-        else
-          @name = "Preview"
-        end
+        @name          = params[:page] ? strip_page_name(CGI.unescape(params[:page])) : 'Preview'
         @page          = wiki.preview_page(@name, params[:content], params[:format])
         ['sidebar', 'header', 'footer'].each do |subpage|
           @page.send("set_#{subpage}".to_sym, params[subpage]) if params[subpage]
@@ -399,7 +393,7 @@ module Precious
         @h1_title      = wiki.h1_title
         @editable      = false
         @bar_side      = wiki.bar_side
-        @allow_uploads = wiki.allow_uploads
+        @allow_uploads = false
         @navbar        = false
         @preview       = true
         mustache :page

--- a/lib/gollum/helpers.rb
+++ b/lib/gollum/helpers.rb
@@ -10,6 +10,11 @@ module Precious
       [nil, ''].include?(param) ? nil : CGI.unescape(param)
     end
 
+    def strip_page_name(name)
+      # Check if name already has a format extension, and if so, strip it.
+      Gollum::Page.valid_extension?(name) ? Gollum::Page.strip_filename(name) : name
+    end
+
     # Remove all slashes from the start of string.
     # Remove all double slashes
     def clean_url url

--- a/test/test_app.rb
+++ b/test/test_app.rb
@@ -434,8 +434,9 @@ context "Frontend" do
   end
 
   test "previews content" do
-    post "/gollum/preview", :content => 'abc', :format => 'markdown'
+    post "/gollum/preview", :content => 'abc', :format => 'markdown', :page => 'Samewise%20Gamgee.mediawiki'
     assert last_response.ok?
+    assert last_response.body.include?('Samewise Gamgee</h1>')
   end
 
   test "previews content on the first page of an empty wiki" do


### PR DESCRIPTION
The title of a preview page:
* Was unescaped, so filenames containing spaces had title e.g. "Samwise%20Gamgee"
* Included the page extension even when the URL didn't.
Solved with a minor change to the route in `app.rb`