### PR TITLE
Add CSS for table.toc Fix #925

### DIFF
--- a/lib/gollum/public/gollum/stylesheets/template.scss.erb
+++ b/lib/gollum/public/gollum/stylesheets/template.scss.erb
@@ -79,6 +79,11 @@ a {
   overflow: hidden;
   word-wrap: break-word;
 
+  table.toc {
+    width: auto;
+    display: inline-table;
+  }
+
   .anchor {
     display: inline-block;
     position: absolute;

--- a/lib/gollum/public/gollum/stylesheets/template.scss.erb
+++ b/lib/gollum/public/gollum/stylesheets/template.scss.erb
@@ -79,6 +79,7 @@ a {
   overflow: hidden;
   word-wrap: break-word;
 
+  /* MediaWiki's TOC table -- this does not pertain to gollum's own TOC functionality */
   table.toc {
     width: auto;
     display: inline-table;

--- a/lib/gollum/public/gollum/stylesheets/template.scss.erb
+++ b/lib/gollum/public/gollum/stylesheets/template.scss.erb
@@ -82,6 +82,9 @@ a {
   table.toc {
     width: auto;
     display: inline-table;
+    .anchor {
+      display: none;
+    }
   }
 
   .anchor {


### PR DESCRIPTION
Result:
<img width="514" alt="Screenshot 2019-09-11 at 12 45 31" src="https://user-images.githubusercontent.com/147111/64691045-15595300-d492-11e9-8c55-520a09f73f07.png">
