### PR TITLE
Improve preview. Resolves #1414

### DIFF
--- a/lib/gollum/public/gollum/javascript/editor/gollum.editor.js
+++ b/lib/gollum/public/gollum/javascript/editor/gollum.editor.js
@@ -81,19 +81,12 @@
         }
       });
 
-      // Ace editor seems to capture all keyboard events so gollum's global
-      // shortcuts does not work in the editor area. So we add them back in
-      // the editor as commands. These commands are added back on-demand since
-      // not all gollum shortcuts are necessary in the presence of Ace editor.
-      editor.commands.addCommand({
-        name: "saveContents",
-        bindKey: {win: "Ctrl-s", mac: "Command-s"},
-        exec: function() {
-          $("#gollum-editor-submit").trigger("click");
-        }
-      });
-    });
-
+      if ( ActiveOptions.commands ) {
+        $.each(ActiveOptions.commands, function ( index, cmd ) {
+          editor.commands.addCommand(cmd);
+        });
+      }
+      
     $("#gollum-editor-body-ace").resize(function(){
       window.ace_editor.resize();
     });

--- a/lib/gollum/public/gollum/javascript/gollum.js.erb
+++ b/lib/gollum/public/gollum/javascript/gollum.js.erb
@@ -307,42 +307,58 @@ $(document).ready(function() {
     });
   }
 
+  // Called when clicking the 'Preview' tab in the editor view
+  function getPreview () {
+    var formData = new FormData($('#gollum-editor-form').get(0));
+    var paths = window.location.pathname.split('/');
+    var sectionAnchor = window.location.hash.substr(1);
+    formData.append('page', paths[ paths.length - 1 ] || '')
+    $.ajax({
+      url: routePath('preview'),
+      data: formData,
+      type: 'POST',
+      processData: false,
+      contentType: false,
+      success: function(data) {
+        var mainDiv = $('#wiki-wrapper', data);
+        $('.tabnav-div#preview-content').html(mainDiv);
+        setTextDirection();
+        if (sectionAnchor ) { 
+          if ( sectionHeading = $('a' + '#' + sectionAnchor+'.anchor')[0] ) {
+            sectionHeading.scrollIntoView();
+          }
+        }
+      },
+      error: function(data, textStatus, errorThrown) {
+        console.log('something went wrong: ' + textStatus + errorThrown);
+      }
+    });
+  }
+
+  function togglePreviewTab ( preview ) {
+    if (preview) {
+      active_div = '#preview-content'
+      active_tab = '#preview.tabnav-tab';
+    } else {
+      active_div = '#edit-content'
+      active_tab = '#edit.tabnav-tab';
+    }
+
+    $('.tabnav-tab.selected').removeClass('selected');
+    $(active_tab).addClass('selected');
+    $('.tabnav-div').hide();
+    $(active_div).show();
+  }
+
   if( $('.tabnav-tabs').length ){
     $(".tabnav-tab").click( function(e) {
       e.preventDefault();
-      if( ! $(this).hasClass('selected')) {
-        tab_id = $(this).attr('id');
-        if (tab_id == 'preview') {
-          var formData = new FormData($('#gollum-editor-form').get(0));
-          var paths = window.location.pathname.split('/');
-          var sectionAnchor = window.location.hash.substr(1);
-          formData.append('page', paths[ paths.length - 1 ] || '')
-          $.ajax({
-            url: routePath('preview'),
-            data: formData,
-            type: 'POST',
-            processData: false,
-            contentType: false,
-            success: function(data) {
-              var mainDiv = $('#wiki-wrapper', data);
-              $('.tabnav-div#preview-content').html(mainDiv);
-              setTextDirection();
-              if (sectionAnchor ) { 
-                if ( sectionHeading = $('a' + '#' + sectionAnchor+'.anchor')[0] ) {
-                  sectionHeading.scrollIntoView();
-                }
-              }
-            },
-            error: function(data, textStatus, errorThrown) {
-              console.log('something went wrong: ' + textStatus + errorThrown);
-            }
-          });
+      if( !$(this).hasClass('selected') ) {
+        preview = $(this).attr('id') == 'preview';
+        if (preview) {
+          getPreview();
         }
-        $('.tabnav-tab.selected').removeClass('selected');
-        $(this).addClass('selected');
-        active_div = '#' + tab_id + "-content";
-        $('.tabnav-div').hide();
-        $(active_div).show();
+        togglePreviewTab(preview);
       };
     });
   };
@@ -352,9 +368,32 @@ $(document).ready(function() {
     $("#gollum-editor-body").one('change', function(){
       window.onbeforeunload = function(){ return "Leaving will discard all edits!" };
     });
+
+    var previewHotkey = function () {
+      $('.tabnav-tab').not('.selected').click();
+      return false;
+    };
+
+    // Hotkey for moving between Edit and Preview tab
+    Mousetrap.bind(['ctrl+shift+p'], previewHotkey);
+
     $.GollumEditor({
-      section: window.location.hash.substr(1)
-    });
+      section: window.location.hash.substr(1),
+      commands: // Ace's keybindings overrule mousetrap, so add some of gollum's keyboard shortcuts to the editor, as well.
+      [{
+        name: "togglePreview",
+        bindKey: {win: "ctrl-shift-p", mac: "ctrl-shift-p"},
+        exec: previewHotkey
+      },
+      {
+        name: "saveContents",
+        bindKey: {win: "Ctrl-s", mac: "Command-s"},
+        exec: function() {
+          $("#gollum-editor-submit").trigger("click");
+        }
+      }]
+    }); 
+
     $("#gollum-editor-submit").click( function(e) {
       e.preventDefault();
       // Prevent button from being clicked again
@@ -510,8 +549,15 @@ $(document).ready(function() {
   }
 
   if($('.markdown-body').length ){
-    // Set text direction auto
+    // Set text direction (LTR or RTL)
     setTextDirection();
+
+    // Set the 'e' hotkey for editing pages.
+    Mousetrap.bind(['e'], function( e ) {
+      e.preventDefault();
+      window.location = routePath('edit') + '/' + pageFullPath;
+      return false;
+    });
 
     if ($.markupSupportsEditableSections(pageFormat)){
       // Copy anchors for each editable header and give the new anchor the 'edit' class, to display an "edit section" link

--- a/lib/gollum/public/gollum/stylesheets/editor.scss
+++ b/lib/gollum/public/gollum/stylesheets/editor.scss
@@ -21,6 +21,10 @@ a {
   color: lightgray;
 }
 
+a.tabnav-tab:focus {
+  outline: none;
+}
+
 #gollum-editor-body-ace {
   overflow: hidden;
   font-family: Consolas, "Liberation Mono", Courier, monospace;

--- a/lib/gollum/templates/page.mustache
+++ b/lib/gollum/templates/page.mustache
@@ -1,10 +1,3 @@
-<script>
-Mousetrap.bind(['e'], function( e ) {
-  e.preventDefault();
-  window.location = "{{edit_path}}" + '/' + pageFullPath;
-  return false;
-});
-</script>
 <div id="wiki-wrapper" class="page">
 <div id="head">
 	{{#navbar?}}{{>navbar}}{{/navbar?}}


### PR DESCRIPTION
* Fixes preview text direction
* Adds Ctrl-P hotkey for switching between editor/preview tab
* Removes a:focus css from tabs (this was the wird dotted square border around the 'Preview' and 'Edit' tab links)

I've decided not to add the 'e' key as a hotkey for moving back to the editor, thought that would be a bit overkill.

There was a minor problem: ace overrules Mousetrap's keybindings, so I had to add the toggle function to Ace's keybindings, too. The easiest thing was binding it only to `ctrl-shift-p`, and not also `cmd-shift-p`. I think this is alright as a) there is no `cmd` on windows and b) Firefox opens a new private browsing window with `cmd-shift-p`. Let me know if you think we should change the keys though.