### PR TITLE
5.x: Fix a couple of upload issues

### DIFF
--- a/lib/gollum/app.rb
+++ b/lib/gollum/app.rb
@@ -224,7 +224,7 @@ module Precious
         contents = ::File.read(tempfile)
         reponame = "#{dir}/#{filename}.#{format}"
 
-        options = { :message => "Uploaded file to #{dir}/#{reponame}" }
+        options = { :message => "Uploaded file to #{reponame}" }
         options[:parent] = wiki.repo.head.commit if wiki.repo.head
 
         author  = session['gollum.author']

--- a/lib/gollum/public/gollum/javascript/gollum.js.erb
+++ b/lib/gollum/public/gollum/javascript/gollum.js.erb
@@ -185,7 +185,7 @@ $(document).ready(function() {
             success: function(data) {
               // File successfully uploaded
               $('#wiki-content').removeClass('uploading');
-              flashNotice("success", "Your file was successfully uploaded.", "foobar", "alert('flash!')");
+              flashNotice("success", "Your file was successfully uploaded.");
             },
             error: function(data, textStatus, errorThrown) {
               $('#wiki-content').removeClass('uploading');


### PR DESCRIPTION
The flashed notice for successful uploads had some weird behaviour that looks like it was added for debugging.

Upload commits would have an incorrect path (e.g. "Uploaded file to uploads/uploads/52514235_365861454017357_1956855208312945998_n.jpg") because `reponame` already contains `dir`.