### PR TITLE
Use tmpdir instead of tempfile for creating temporary repos in the test suite.

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -6,6 +6,7 @@ require 'mocha/setup'
 require 'fileutils'
 require 'minitest/reporters'
 require 'twitter_cldr'
+require 'tmpdir'
 
 # Silence locale validation warning
 require 'i18n'
@@ -42,13 +43,11 @@ end
 
 def cloned_testpath(path, bare = false)
   repo   = File.expand_path(testpath(path))
-  tmp    = Tempfile.new(self.class.name)
-  path   = tmp.path
+  tmpdir = Dir.mktmpdir(self.class.name)
   bare   = bare ? "--bare" : ""
-  tmp.close(true)
   redirect = Gem.win_platform? ? '' : '2>/dev/null'
-  %x{git clone #{bare} #{repo} #{path} #{redirect}}
-  path
+  %x{git clone #{bare} '#{repo}' #{tmpdir} #{redirect}}
+  tmpdir
 end
 
 def commit_details


### PR DESCRIPTION
Previously, the test suite was broken for older git versions because git (e.g. version 2.14.3 (Apple Git-98)) could not clone to Tempfiles. This PR fixes the issue by cloning to a tmpdir instead of a Tempfile.