### PR TITLE
Update rake to mitigate CVE-2020-8130.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,4 +10,6 @@ end
 gem 'gollum-lib', :git => 'https://github.com/gollum/gollum-lib.git', :branch => 'gollum-lib-5.x' # For development purposes
 gem 'therubyrhino', :platforms => :jruby
 gemspec
-gem 'rake', '~> 11.2'
+gem "rake", ">= 12.3.3"
+
+


### PR DESCRIPTION
We may also want to fix this in master, depending on when we think the 5.x release will be out.