### PR TITLE
Restore functionality for determining the position of the sidebar (left or right).

### DIFF
--- a/lib/gollum/templates/wiki_content.mustache
+++ b/lib/gollum/templates/wiki_content.mustache
@@ -11,12 +11,12 @@
 	  {{/has_toc}}
 	  {{#has_sidebar}}
 	  <div id="wiki-sidebar" class="gollum-{{sidebar_format}}-content">
-	    <div id="sidebar-content" class="Box Box--condensed col-3 markdown-body pl-4 float-right">
+	    <div id="sidebar-content" class="Box Box--condensed col-3 markdown-body px-4 float-{{bar_side}}">
 	      {{{sidebar_content}}}
 	    </div>
 	  </div>
 	  {{/has_sidebar}}
-	  <div id="wiki-body" class="gollum-{{format}}-content">
+	  <div id="wiki-body" class="gollum-{{format}}-content overflow-hidden {{#left_bar}}pl-4{{/left_bar}}">
 	    {{#has_header}}
 	    <div id="wiki-header" class="gollum-{{header_format}}-content">
 	      <div id="header-content" class="markdown-body">

--- a/lib/gollum/views/page.rb
+++ b/lib/gollum/views/page.rb
@@ -122,6 +122,10 @@ module Precious
       def bar_side
         @bar_side.to_s
       end
+      
+      def left_bar
+        @bar_side == :left
+      end
 
       def has_sidebar
         if @sidebar


### PR DESCRIPTION
This PR restores the functionality for programmatically determining the position of the sidebar (left or right).

The default position is `:right`. To change, set `wiki_options['sidebar'] = :left`. Or in config.rb:
```ruby
wiki_options = {sidebar: :left}
Precious::App.set(:wiki_options, wiki_options)
 ```

![Screen Shot 2020-03-14 at 19 26 02](https://user-images.githubusercontent.com/571173/76688112-2db94e80-662a-11ea-93e1-55ea86518a05.png)

![Screen Shot 2020-03-14 at 19 25 40](https://user-images.githubusercontent.com/571173/76688114-33169900-662a-11ea-8214-1142717abc1d.png)
