### PR TITLE
Add adapters to the Gemfile again.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,11 +2,13 @@ source 'https://rubygems.org'
 
 if RUBY_PLATFORM == 'java'
   gem 'warbler'
+  gem 'gollum-rjgit_adapter'
+else
+  gem 'gollum-rugged_adapter'
 end
 
 gem 'gollum-lib', :git => 'https://github.com/gollum/gollum-lib.git', :branch => 'gollum-lib-5.x' # For development purposes
 gem 'therubyrhino', :platforms => :jruby
 gemspec
 gem "rake", ">= 12.3.3"
-
 


### PR DESCRIPTION
This PR adds the adapters back in the Gemfile, but uses normal releases instead of github branch. Relates to https://github.com/gollum/gollum/issues/1470 . 