### PR TITLE
Remove more references to grit and start updating readme

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,9 @@
+# 5.0 / 2020-03-17
+
+This is a major new release that substantially cleans up and improves the codebase. It also introduces many new features, bugfixes, and removing major limitations. See [here](https://github.com/gollum/gollum/wiki/5.0-release-notes) for a list of changes. Many thanks for all the users who have provided feedback, and everyone who has chipped in in the development process!
+
+Many of these changes have been made possible by removing the default grit adapter in favour of the new [rugged adapter](https://github.com/gollum/rugged_adapter).
+
 # 4.1.0 /2017-03-09
 
 * Added file deletion functionality to file view

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,10 @@
 # 5.0 / 2020-03-17
 
-This is a major new release that substantially cleans up and improves the codebase. It also introduces many new features, bugfixes, and removing major limitations. See [here](https://github.com/gollum/gollum/wiki/5.0-release-notes) for a list of changes. Many thanks for all the users who have provided feedback, and everyone who has chipped in in the development process!
+This is a major new release that substantially cleans up and improves the codebase. It also introduces many new features, bugfixes, and removing major limitations. See [here](https://github.com/gollum/gollum/wiki/5.0-release-notes) for a list of changes.
+
+**Note**: due to changes in the way in which Gollum handles filenames, you may have to change some links in your wiki when migrating from gollum 4.x. See the [release notes](https://github.com/gollum/gollum/wiki/5.0-release-notes) for more details.
+
+Many thanks to all the users who have provided feedback, and everyone who has chipped in in the development process!
 
 Many of these changes have been made possible by removing the default grit adapter in favour of the new [rugged adapter](https://github.com/gollum/rugged_adapter).
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ gollum -- A git-based Wiki
 [![Build Status](https://travis-ci.org/gollum/gollum.svg?branch=master)](https://travis-ci.org/gollum/gollum)
 [![Dependency Status](https://gemnasium.com/gollum/gollum.svg)](https://gemnasium.com/gollum/gollum)
 
-**Gollum version 5.0 is out!** See [here](https://github.com/gollum/gollum/wiki/5.0-release-notes) for a list of changes and new features compared to gollum version 4.x.
+**Gollum version 5.0 is out!** See [here](https://github.com/gollum/gollum/wiki/5.0-release-notes) for a list of changes and new features compared to Gollum version 4.x. See some [Screenshots](https://github.com/gollum/gollum/wiki/Screenshots) of Gollum's features.
 
 ## DESCRIPTION
 
@@ -36,18 +36,17 @@ Varies depending on operating system, package manager and Ruby installation. Gen
 	```
 	[sudo] gem install gollum
 	```
+	
+Installation examples for individual systems can be seen [here](https://github.com/gollum/gollum/wiki/Installation).
 
 To run, simply:
 
-1. Navigate to your git repository (wiki) via the command line.
-2. Run: `gollum`.
-3. Open `http://127.0.0.1:4567` in your browser.
-
-Of course, you can also run `gollum /path/to/wiki`. Installation examples for individual systems can be seen [here](https://github.com/gollum/gollum/wiki/Installation).
+1. Run: `gollum /path/to/wiki`.
+2. Open `http://localhost:4567` in your browser.
 
 ### Markups
 
-Gollum allows using different markup languages per page. It presently ships with support for the following markups:
+Gollum allows using different markup languages on different wiki pages. It presently ships with support for the following markups:
 * [Markdown](http://daringfireball.net/projects/markdown/syntax) (see [below](#Markdown-flavors) for more information on Markdown flavors)
 * [RDoc](http://rdoc.sourceforge.net/)
 
@@ -74,7 +73,7 @@ See [here](https://github.com/gollum/gollum/wiki/Custom-rendering-gems) for inst
 2. `cd gollum`
 3. `[sudo] bundle install`
 4. `bundle exec bin/gollum`
-5. Open `http://127.0.0.1:4567` in your browser.
+5. Open `http://localhost:4567` in your browser.
 
 ### Rack
 
@@ -131,7 +130,7 @@ Gollum comes with the following command line options:
 1. The `0.0.0.0` IP address allows remote access. Should you wish for Gollum to turn into a personal Wiki, use `127.0.0.1`.
 2. Before using `--adapter`, you should probably read [this](https://github.com/gollum/gollum/wiki/Git-adapters) first.
 3. When `--css` or `--js` is used, respective files must be committed to your git repository or you will get a 302 redirect to the create a page.
-4. Files can be uploaded simply by dragging and dropping them onto the editor's text area.
+4. Files can be uploaded simply by dragging and dropping them onto the editor's text area when `--allow-uploads` is used.
 
 ### Config file
 

--- a/README.md
+++ b/README.md
@@ -25,24 +25,9 @@ For more information on Gollum's capabilities and pitfalls:
 3. [Troubleshoot guide](https://github.com/gollum/gollum/wiki/Troubleshoot-guide).
 4. [Security overview](https://github.com/gollum/gollum/wiki/Security).
 
-### Videos
-
-* [Quick impression of gollum](https://www.youtube.com/watch?v=gj1qqK3Oku8)
-* [Gollum overview and simple markdown tutorial (german with english subtitles)](https://www.youtube.com/watch?v=wfWgDRmcbU4)
-* [Advanced features in action](https://www.youtube.com/watch?v=EauxgxsLDC4)
-
 ## SYSTEM REQUIREMENTS
 
-| Operating System | Ruby           | Adapters           | Supported |
-| ---------------- | -------------- | ------------------ | --------- |
-| Unix/Linux-like  | Ruby 1.9.3+    | all except [RJGit](https://github.com/repotag/rjgit) | yes |
-| Unix/Linux-like  | [JRuby](https://github.com/jruby/jruby) (1.9.3+ compatible) | [RJGit](https://github.com/repotag/rjgit) | yes |
-| Windows          | Ruby 1.9.3+    | all except [RJGit](https://github.com/repotag/rjgit) | no  |
-| Windows          | [JRuby](https://github.com/jruby/jruby) (1.9.3+ compatible) | [RJGit](https://github.com/repotag/rjgit) | almost<sup>1</sup> |
-
-**Notes:**
-
-1. You can track the progress at [Support Windows via JRuby - Meta Issue](https://github.com/gollum/gollum/issues/1044).
+Gollum runs on Unix-like systems using its [adapter](https://github.com/gollum/rugged_adapter) for [https://github.com/libgit2/rugged](rugged) by default. You can also run Gollum on [JRuby](https://github.com/jruby/jruby) via its [adapter](https://github.com/repotag/gollum-lib_rjgit_adapter) for [RJGit](https://github.com/repotag/rjgit/). On Windows, Gollum runs only on JRuby.
 
 ## INSTALLATION
 
@@ -124,8 +109,7 @@ Gollum comes with the following command line options:
 | --port            | [PORT]    | Specify the port to bind Gollum with. Default: `4567`. |
 | --config          | [FILE]  | Specify path to Gollum's configuration file. |
 | --ref             | [REF]     | Specify the git branch to serve. Default: `master`. |
-| --adapter         | [ADAPTER] | Launch Gollum using a specific git adapter. Default: `grit`.<sup>2</sup> |
-| --bare            | none      | Tell Gollum that the git repository should be treated as bare. This is only necessary when using the default grit adapter. |
+| --adapter         | [ADAPTER] | Launch Gollum using a specific git adapter. Default: `rugged`.<sup>2</sup> |
 | --base-path       | [PATH]    | Specify the leading portion of all Gollum URLs (path info). Setting this to `/wiki` will make the wiki accessible under `http://localhost:4567/wiki/`. Default: `/`. |
 | --page-file-dir   | [PATH]    | Specify the subdirectory for all pages. If set, Gollum will only serve pages from this directory and its subdirectories. Default: repository root. |
 | --css             | none      | Tell Gollum to inject custom CSS into each page. Uses `custom.css` from repository root.<sup>3,5</sup> |
@@ -153,8 +137,7 @@ Gollum comes with the following command line options:
 1. The `0.0.0.0` IP address allows remote access. Should you wish for Gollum to turn into a personal Wiki, use `127.0.0.1`.
 2. Before using `--adapter`, you should probably read [this](https://github.com/gollum/gollum/wiki/Git-adapters) first.
 3. When `--css` or `--js` is used, respective files must be committed to your git repository or you will get a 302 redirect to the create a page.
-4. Files can be uploaded simply by dragging and dropping them onto the editor's text area (this is, however exclusive to the default editor, not the live preview editor).
-5. Read the relevant [Security note](https://github.com/gollum/gollum/wiki/Security#custom-cssjs--mathjax-config) before using these.
+4. Files can be uploaded simply by dragging and dropping them onto the editor's text area.
 
 ### Config file
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ gollum -- A git-based Wiki
 [![Build Status](https://travis-ci.org/gollum/gollum.svg?branch=master)](https://travis-ci.org/gollum/gollum)
 [![Dependency Status](https://gemnasium.com/gollum/gollum.svg)](https://gemnasium.com/gollum/gollum)
 
-Note: this is the development branch for the next major release of Gollum, version 5.0. See [here](https://github.com/gollum/gollum/wiki/5.0-release-notes) for a list of changes and new features.
+Gollum version 5.0 is out! See [here](https://github.com/gollum/gollum/wiki/5.0-release-notes) for a list of changes and new features compared to the 4.x branch.
 
 ## DESCRIPTION
 
@@ -15,17 +15,17 @@ Gollum is a simple wiki system built on top of Git. A Gollum Wiki is simply a gi
 	* May be written in a variety of [markups](#markups).
 	* Can be edited with your favourite system editor or IDE (changes will be visible after committing) or with the built-in web interface.
 	* Can be displayed in all versions (commits).
+	* Can link to each other (and to files/images) via gollum's own [tags](https://github.com/gollum/gollum/wiki#tags), or via link syntax provided by your markup language of choice.
+* Gollum supports advanced functionality like:
+  * [UML diagrams](https://github.com/gollum/gollum/wiki#plantuml-diagrams)
+	* [BibTeX and Citation support](https://github.com/gollum/gollum/wiki/BibTeX-and-Citations)
+	* Annotations using [CriticMarkup](https://github.com/gollum/gollum/wiki#criticmarkup-annotations)
+	* Mathematics via [MathJax](https://github.com/gollum/gollum/wiki#mathematics)
+	* [Macros](https://github.com/gollum/gollum/wiki/Standard-Macros)
+	* [YAML frontmatter/metadata per page](https://github.com/gollum/gollum/wiki#metadata)
+	* ...and [more](https://github.com/gollum/gollum/wiki).
 
-Gollum can be launched either as a webserver (with the web interface) or in "console mode", where you can use a predefined API to query and manipulate the repository. For more information, see the [Running](#running) and [Configuration](#configuration) sections.
-
-For more information on Gollum's capabilities and pitfalls:
-
-1. [Syntax/capability overview for pages](https://github.com/gollum/gollum/wiki).
-2. [Known limitations](https://github.com/gollum/gollum/wiki/Known-limitations).
-3. [Troubleshoot guide](https://github.com/gollum/gollum/wiki/Troubleshoot-guide).
-4. [Security overview](https://github.com/gollum/gollum/wiki/Security).
-
-## SYSTEM REQUIREMENTS
+### SYSTEM REQUIREMENTS
 
 Gollum runs on Unix-like systems using its [adapter](https://github.com/gollum/rugged_adapter) for [https://github.com/libgit2/rugged](rugged) by default. You can also run Gollum on [JRuby](https://github.com/jruby/jruby) via its [adapter](https://github.com/repotag/gollum-lib_rjgit_adapter) for [RJGit](https://github.com/repotag/rjgit/). On Windows, Gollum runs only on JRuby.
 
@@ -41,9 +41,11 @@ Varies depending on operating system, package manager and Ruby installation. Gen
 
 Installation examples for individual systems can be seen [here](https://github.com/gollum/gollum/wiki/Installation).
 
+See [RUNNING](#running) for further instructions.
+
 ### Markups
 
-Gollum presently ships with support for the following markups:
+Gollum allows using different markup languages per page. It presently ships with support for the following markups:
 * [Markdown](http://daringfireball.net/projects/markdown/syntax) (see [below](#Markdown-flavors) for more information on Markdown flavors)
 * [RDoc](http://rdoc.sourceforge.net/)
 
@@ -70,9 +72,9 @@ Simply:
 
 1. Navigate to your git repository (wiki) via the command line.
 2. Run: `gollum`.
-3. Open `http://localhost:4567` in your browser.
+3. Open `http://127.0.0.1:4567` in your browser.
 
-This will start up a web server (WEBrick) running Gollum with a web interface, where you can view and edit your wiki.
+This will start up a web server (WEBrick) running Gollum with a web interface, where you can view and edit your wiki. Of course, you can also run `gollum /path/to/your/wiki`.
 
 ### Running from source
 
@@ -81,7 +83,7 @@ This will start up a web server (WEBrick) running Gollum with a web interface, w
 3. `[sudo] bundle install` (may not always be necessary).
 4. `bundle exec bin/gollum`
 	* Like that, gollum assumes the target wiki (git repository) is the project repository itself. If it's not, execute `bundle exec bin/gollum <path-to-wiki>` instead.
-5. Open `http://localhost:4567` in your browser.
+5. Open `http://127.0.0.1:4567` in your browser.
 
 ### Rack
 
@@ -105,32 +107,33 @@ Gollum comes with the following command line options:
 
 | Option            | Arguments | Description |
 | ----------------- | --------- | ----------- |
-| --host            | [HOST]    | Specify the hostname or IP address to listen on. Default: `0.0.0.0`.<sup>1</sup> |
+| --host            | [HOST]    | Specify the hostname or IP address to listen on. Default: '0.0.0.0'.<sup>1</sup> |
 | --port            | [PORT]    | Specify the port to bind Gollum with. Default: `4567`. |
-| --config          | [FILE]  | Specify path to Gollum's configuration file. |
+| --config          | [FILE]    | Specify path to Gollum's configuration file. |
 | --ref             | [REF]     | Specify the git branch to serve. Default: `master`. |
 | --adapter         | [ADAPTER] | Launch Gollum using a specific git adapter. Default: `rugged`.<sup>2</sup> |
 | --base-path       | [PATH]    | Specify the leading portion of all Gollum URLs (path info). Setting this to `/wiki` will make the wiki accessible under `http://localhost:4567/wiki/`. Default: `/`. |
 | --page-file-dir   | [PATH]    | Specify the subdirectory for all pages. If set, Gollum will only serve pages from this directory and its subdirectories. Default: repository root. |
+| --static, --no-static | none  | Use static assets. Defaults to false in development/test,  true in production/staging. |
+| --assets          |  [PATH]   | Set the path to look for static assets. |
 | --css             | none      | Tell Gollum to inject custom CSS into each page. Uses `custom.css` from repository root.<sup>3,5</sup> |
 | --js              | none      | Tell Gollum to inject custom JS into each page. Uses `custom.js` from repository root.<sup>3,5</sup> |
 | --emoji           | none      | Parse and interpret emoji tags (e.g. `:heart:`) except when the leading colon is backslashed (e.g. `\:heart:`). |
 | --no-edit         | none      | Disable the feature of editing pages. |
-| --live-preview    | none      | Enable the live preview feature in page editor. |
-| --no-live-preview | none      | Disable the live preview feature in page editor. |
+| --follow-renames, --no-follow-renames  | none      | Follow pages across renames in the History view. Default: true.
 | --allow-uploads   | [MODE]    | Enable file uploads. If set to `dir`, Gollum will store all uploads in the `/uploads/` directory in repository root. If set to `page`, Gollum will store each upload at the currently edited page.<sup>4</sup> |
 | --mathjax         | none      | Enables MathJax (renders mathematical equations). By default, uses the `TeX-AMS-MML_HTMLorMML` config with the `autoload-all` extension.<sup>5</sup> |
+| --critic-markup   | none      | Enable support for annotations using [CriticMarkup](http://criticmarkup.com/). |
 | --irb             | none      | Launch Gollum in "console mode", with a [predefined API](https://github.com/gollum/gollum-lib/). |
 | --h1-title        | none      | Tell Gollum to use the first `<h1>` as page title. |
 | --no-display-metadata | none  | Do not render metadata tables in pages. |
-| --show-all        | none      | Tell Gollum to also show files in the file view. By default, only valid pages are shown. |
-| --collapse-tree   | none      | Tell Gollum to collapse the file tree, when the file view is opened. By default, the tree is expanded. |
 | --user-icons      | [MODE]    | Tell Gollum to use specific user icons for history view. Can be set to `gravatar`, `identicon` or `none`. Default: `none`. |
 | --mathjax-config  | [FILE]    | Specify path to a custom MathJax configuration. If not specified, uses the `mathjax.config.js` file from repository root. |
 | --template-dir    | [PATH]    | Specify custom mustache template directory. |
+| --template-page   | none      | Use _Template in root as a template for new pages. Must be committed. |
 | --help            | none      | Display the list of options on the command line. |
 | --version         | none      | Display the current version of Gollum. |
-| --template-page   | none      | Tell Gollum to use /_Template as the default content for new pages. _Template must be git committed. |
+| --versions        | none      | Display the current version of Gollum and auxiliary gems. |
 
 **Notes:**
 
@@ -144,3 +147,7 @@ Gollum comes with the following command line options:
 When `--config` option is used, certain inner parts of Gollum can be customized. This is used throughout our wiki for certain user-level alterations, among which [customizing supported markups](https://github.com/gollum/gollum/wiki/Formats-and-extensions) will probably stand out.
 
 **All of the mentioned alterations work both for Gollum's config file (`config.rb`) and Rack's config file (`config.ru`).**
+
+## CONTRIBUTING
+
+See [CONTRIBUTING](CONTRIBUTING.md) for information on how to submit issues, and how to start hacking on gollum.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ gollum -- A git-based Wiki
 [![Build Status](https://travis-ci.org/gollum/gollum.svg?branch=master)](https://travis-ci.org/gollum/gollum)
 [![Dependency Status](https://gemnasium.com/gollum/gollum.svg)](https://gemnasium.com/gollum/gollum)
 
-**Gollum version 5.0 is out!** See [here](https://github.com/gollum/gollum/wiki/5.0-release-notes) for a list of changes and new features compared to the 4.x branch.
+**Gollum version 5.0 is out!** See [here](https://github.com/gollum/gollum/wiki/5.0-release-notes) for a list of changes and new features compared to gollum version 4.x.
 
 ## DESCRIPTION
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ gollum -- A git-based Wiki
 [![Build Status](https://travis-ci.org/gollum/gollum.svg?branch=master)](https://travis-ci.org/gollum/gollum)
 [![Dependency Status](https://gemnasium.com/gollum/gollum.svg)](https://gemnasium.com/gollum/gollum)
 
-Gollum version 5.0 is out! See [here](https://github.com/gollum/gollum/wiki/5.0-release-notes) for a list of changes and new features compared to the 4.x branch.
+**Gollum version 5.0 is out!** See [here](https://github.com/gollum/gollum/wiki/5.0-release-notes) for a list of changes and new features compared to the 4.x branch.
 
 ## DESCRIPTION
 
@@ -15,15 +15,13 @@ Gollum is a simple wiki system built on top of Git. A Gollum Wiki is simply a gi
 	* May be written in a variety of [markups](#markups).
 	* Can be edited with your favourite system editor or IDE (changes will be visible after committing) or with the built-in web interface.
 	* Can be displayed in all versions (commits).
-	* Can link to each other (and to files/images) via gollum's own [tags](https://github.com/gollum/gollum/wiki#tags), or via link syntax provided by your markup language of choice.
 * Gollum supports advanced functionality like:
   * [UML diagrams](https://github.com/gollum/gollum/wiki#plantuml-diagrams)
-	* [BibTeX and Citation support](https://github.com/gollum/gollum/wiki/BibTeX-and-Citations)
-	* Annotations using [CriticMarkup](https://github.com/gollum/gollum/wiki#criticmarkup-annotations)
-	* Mathematics via [MathJax](https://github.com/gollum/gollum/wiki#mathematics)
-	* [Macros](https://github.com/gollum/gollum/wiki/Standard-Macros)
-	* [YAML frontmatter/metadata per page](https://github.com/gollum/gollum/wiki#metadata)
-	* ...and [more](https://github.com/gollum/gollum/wiki).
+  * [BibTeX and Citation support](https://github.com/gollum/gollum/wiki/BibTeX-and-Citations)
+  * Annotations using [CriticMarkup](https://github.com/gollum/gollum/wiki#criticmarkup-annotations)
+  * Mathematics via [MathJax](https://github.com/gollum/gollum/wiki#mathematics)
+  * [Macros](https://github.com/gollum/gollum/wiki/Standard-Macros)
+  * ...and [more](https://github.com/gollum/gollum/wiki).
 
 ### SYSTEM REQUIREMENTS
 
@@ -39,9 +37,13 @@ Varies depending on operating system, package manager and Ruby installation. Gen
 	[sudo] gem install gollum
 	```
 
-Installation examples for individual systems can be seen [here](https://github.com/gollum/gollum/wiki/Installation).
+To run, simply:
 
-See [RUNNING](#running) for further instructions.
+1. Navigate to your git repository (wiki) via the command line.
+2. Run: `gollum`.
+3. Open `http://127.0.0.1:4567` in your browser.
+
+Of course, you can also run `gollum /path/to/wiki`. Installation examples for individual systems can be seen [here](https://github.com/gollum/gollum/wiki/Installation).
 
 ### Markups
 
@@ -66,23 +68,12 @@ By default, Gollum ships with the `kramdown` gem to render Markdown. However, yo
 
 See [here](https://github.com/gollum/gollum/wiki/Custom-rendering-gems) for instructions on how to use custom rendering gems and set custom options.
 
-## RUNNING
-
-Simply:
-
-1. Navigate to your git repository (wiki) via the command line.
-2. Run: `gollum`.
-3. Open `http://127.0.0.1:4567` in your browser.
-
-This will start up a web server (WEBrick) running Gollum with a web interface, where you can view and edit your wiki. Of course, you can also run `gollum /path/to/your/wiki`.
-
-### Running from source
+## RUNNING FROM SOURCE
 
 1. `git clone https://github.com/gollum/gollum`
 2. `cd gollum`
-3. `[sudo] bundle install` (may not always be necessary).
+3. `[sudo] bundle install`
 4. `bundle exec bin/gollum`
-	* Like that, gollum assumes the target wiki (git repository) is the project repository itself. If it's not, execute `bundle exec bin/gollum <path-to-wiki>` instead.
 5. Open `http://127.0.0.1:4567` in your browser.
 
 ### Rack

--- a/bin/gollum
+++ b/bin/gollum
@@ -113,7 +113,7 @@ MSG
   opts.on("--no-edit", "Disable the feature of editing pages.")  do
     wiki_options[:allow_editing] = false
   end
-  opts.on("--follow-renames", "Follow pages across renames in the History view. Default except on jruby.") do
+  opts.on("--follow-renames", "Follow pages across renames in the History view. Default: true.") do
     wiki_options[:follow_renames] = true
   end
   opts.on("--no-follow-renames", "Do not follow pages across renames in the History view.") do

--- a/bin/gollum
+++ b/bin/gollum
@@ -62,11 +62,8 @@ opts = OptionParser.new do |opts|
   opts.on("-r", "--ref [REF]", "Specify the branch to serve. Default: 'master'.") do |ref|
     wiki_options[:ref] = ref
   end
-  opts.on("-a", "--adapter [ADAPTER]", "Launch Gollum using a specific git adapter. Default: 'grit'.") do |adapter|
+  opts.on("-a", "--adapter [ADAPTER]", "Launch Gollum using a specific git adapter. Default: 'rugged'.") do |adapter|
     Gollum::GIT_ADAPTER = adapter
-  end
-  opts.on("--bare", "Declare '<git-repo>' to be bare. This is only necessary when using the grit adapter.") do
-    wiki_options[:repo_is_bare] = true
   end
   opts.on("-b", "--base-path [PATH]", "Specify the leading portion of all Gollum URLs (path info). Default: '/'.",
     "Example: setting this to '/wiki' will make the wiki accessible under 'http://localhost:4567/wiki/'.") do |base_path|
@@ -175,7 +172,7 @@ MSG
     puts "Running on: #{RUBY_PLATFORM} with Ruby version #{RUBY_VERSION}"
     puts "Using:"
     loaded_gemspecs =  Gem.loaded_specs
-    gollum_gems = ['gollum-lib', 'gollum-rjgit_adapter', 'rjgit', 'gollum-grit_adapter', 'grit', 'gollum-rugged_adapter', 'rugged']
+    gollum_gems = ['gollum-lib', 'gollum-rjgit_adapter', 'rjgit', 'gollum-rugged_adapter', 'rugged']
     puts Gem.loaded_specs.select{|name, spec| gollum_gems.include?(name)}.map {|name, spec| "#{name} #{spec.version}"}
     puts "Markdown rendering gem: #{GitHub::Markup::Markdown.implementation_name}"
     puts "Other renderering gems:"

--- a/test/test_unicode.rb
+++ b/test/test_unicode.rb
@@ -87,15 +87,6 @@ context "Frontend Unicode support" do
     assert_equal 'ghi', page.version.message
   end
 
-  test 'unicode filenames' do
-    # we transliterate only when adapter is grit
-    return if defined?(Gollum::GIT_ADAPTER) && Gollum::GIT_ADAPTER != 'grit'
-    
-    @wiki.write_page("ééééé", :markdown, '한글 text', { :name => '', :email => '' })
-    page = @wiki.page("eeeee")
-    assert_equal '한글 text', utf8(page.raw_data)
-  end
-
   def app
     Precious::App
   end


### PR DESCRIPTION
I removed the Videos section from the Readme because the videos are all based on 4.x. Or is it better to have something rather than nothing here?