### PR TITLE
Update migration script

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Gollum is a simple wiki system built on top of Git. A Gollum Wiki is simply a gi
 	* May be written in a variety of [markups](#markups).
 	* Can be edited with your favourite system editor or IDE (changes will be visible after committing) or with the built-in web interface.
 	* Can be displayed in all versions, reverted, etc.
+* Gollum strives to be compatible with GitHub wikis (see `--hyphened_tag_lookup`)
 * Gollum supports advanced functionality like:
   * [UML diagrams](https://github.com/gollum/gollum/wiki#plantuml-diagrams)
   * [BibTeX and Citation support](https://github.com/gollum/gollum/wiki/BibTeX-and-Citations)
@@ -124,6 +125,7 @@ Gollum comes with the following command line options:
 | --template-page   | none      | Use _Template in root as a template for new pages. Must be committed. |
 | --emoji           | none      | Parse and interpret emoji tags (e.g. `:heart:`) except when the leading colon is backslashed (e.g. `\:heart:`). |
 | --global-tag-lookup | none   |  Match an internal link to 'Foo' with the first page found with that filename, anywhere in the repository. Provides compatibility with Gollum 4.x. |
+| --hyphened-tag-lookup | none  | Match an internal link to 'Bilbo Baggins' with 'Bilbo-Baggins'. Provides compatibility with Gollum 4.x. |
 | --help            | none      | Display the list of options on the command line. |
 | --version         | none      | Display the current version of Gollum. |
 | --versions        | none      | Display the current version of Gollum and auxiliary gems. |

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Gollum is a simple wiki system built on top of Git. A Gollum Wiki is simply a gi
   * Annotations using [CriticMarkup](https://github.com/gollum/gollum/wiki#criticmarkup-annotations)
   * Mathematics via [MathJax](https://github.com/gollum/gollum/wiki#mathematics)
   * [Macros](https://github.com/gollum/gollum/wiki/Standard-Macros)
-	* [Redirects](https://github.com/gollum/gollum/wiki/5.0-release-notes#support-for-redirects)
+  * [Redirects](https://github.com/gollum/gollum/wiki/5.0-release-notes#support-for-redirects)
   * ...and [more](https://github.com/gollum/gollum/wiki)
 
 ### SYSTEM REQUIREMENTS
@@ -39,7 +39,7 @@ Gollum runs on Unix-like systems using its [adapter](https://github.com/gollum/r
 	[sudo] gem install gollum
 	```
 	
-Installation examples for individual systems can be seen [here](https://github.com/gollum/gollum/wiki/Installation). Alternatively, you can [run Gollum from source](#running-from-source)
+Installation examples for individual systems can be seen [here](https://github.com/gollum/gollum/wiki/Installation).
 
 To run, simply:
 

--- a/README.md
+++ b/README.md
@@ -17,13 +17,14 @@ Gollum is a simple wiki system built on top of Git. A Gollum Wiki is simply a gi
 	* May be written in a variety of [markups](#markups).
 	* Can be edited with your favourite system editor or IDE (changes will be visible after committing) or with the built-in web interface.
 	* Can be displayed in all versions, reverted, etc.
-* Gollum strives to be compatible with GitHub wikis (see `--hyphened_tag_lookup`)
+* Gollum strives to be compatible with GitHub wikis (see `--hyphened-tag-lookup`)
 * Gollum supports advanced functionality like:
   * [UML diagrams](https://github.com/gollum/gollum/wiki#plantuml-diagrams)
   * [BibTeX and Citation support](https://github.com/gollum/gollum/wiki/BibTeX-and-Citations)
   * Annotations using [CriticMarkup](https://github.com/gollum/gollum/wiki#criticmarkup-annotations)
   * Mathematics via [MathJax](https://github.com/gollum/gollum/wiki#mathematics)
   * [Macros](https://github.com/gollum/gollum/wiki/Standard-Macros)
+	* [Redirects](https://github.com/gollum/gollum/wiki/5.0-release-notes#support-for-redirects)
   * ...and [more](https://github.com/gollum/gollum/wiki)
 
 ### SYSTEM REQUIREMENTS
@@ -31,8 +32,6 @@ Gollum is a simple wiki system built on top of Git. A Gollum Wiki is simply a gi
 Gollum runs on Unix-like systems using its [adapter](https://github.com/gollum/rugged_adapter) for [rugged](https://github.com/libgit2/rugged) by default. You can also run Gollum on [JRuby](https://github.com/jruby/jruby) via its [adapter](https://github.com/repotag/gollum-lib_rjgit_adapter) for [RJGit](https://github.com/repotag/rjgit/). On Windows, Gollum runs only on JRuby.
 
 ## INSTALLATION
-
-Varies depending on operating system, package manager and Ruby installation. Generally, you should first install Ruby and then Gollum.
 
 1. Ruby is best installed either via [RVM](https://rvm.io/) or a package manager of choice.
 2. Gollum is best installed via RubyGems:  
@@ -46,6 +45,8 @@ To run, simply:
 
 1. Run: `gollum /path/to/wiki`.
 2. Open `http://localhost:4567` in your browser.
+
+See [below](#running-from-source) for information on running Gollum from source, as a Rack app, and more.
 
 ### Markups
 

--- a/bin/gollum
+++ b/bin/gollum
@@ -155,6 +155,9 @@ MSG
   opts.on('--global-tag-lookup', 'Match an internal link to \'Foo\' with the first page found with that filename, anywhere in the repository. Provides compatibility with Gollum 4.x.') do
     wiki_options[:global_tag_lookup] = true
   end
+  opts.on('--hyphened-tag-lookup', 'Match an internal link to \'Bilbo Baggins\' with \'Bilbo-Baggins\'. Provides compatibility with Gollum 4.x.') do
+    wiki_options[:hyphened_tag_lookup] = true
+  end
   opts.on('--emoji', 'Parse and interpret emoji tags (e.g. :heart:) except when the leading colon is backslashed (e.g. \\:heart:).') do
     wiki_options[:emoji] = true
   end

--- a/bin/gollum-migrate-tags
+++ b/bin/gollum-migrate-tags
@@ -82,7 +82,8 @@ end
 begin
   opts.parse!
   migrate_options.each do |setting, value|
-    Object.const_set(setting.to_s.upcase, value)
+    const = setting.to_s.upcase
+    Object.const_set(const, value) unless Object.const_defined?(const)
   end
 rescue OptionParser::InvalidOption
   puts "gollum-migrate-tags: #{$!.message}"

--- a/bin/gollum-migrate-tags
+++ b/bin/gollum-migrate-tags
@@ -33,6 +33,7 @@ Use this tool to migrate a wiki repository created under Gollum versions 4.x or 
 It finds and repairs Gollum link tags that no longer work under 5.x for two reasons:
 
 * 5.x wiki internal links may contain spaces. [[Bilbo Baggins]] and [[Bilbo-Baggins]] therefore link to distinct pages.
+    * NB: you can use the --hyphened_tag_lookup option in gollum >= 5.x to mimic the behavior from 4.x.
 * 5.x wiki internal links are case senitive
 * 5.x wiki internal links are no longer 'global'.
     * NB: you can use the --global-tag-lookup option in gollum >= 5.x to enable 4.x-style global tags.

--- a/bin/gollum-migrate-tags
+++ b/bin/gollum-migrate-tags
@@ -6,26 +6,16 @@ require 'rubygems'
 
 REPO = ARGV[0] || Dir.pwd
 
-def set_const(const, val)
-  already_defined = begin
-    Object.const_get(const)
-    true
-  rescue NameError
-    false
-  end
-  Object.const_set(const, val) unless already_defined
-end
-
-def const_true(const)
-  begin
-    Object.const_get(const)
-  rescue NameError
-    false
-  end
-end
-
 wiki_options = {}
 options = {}
+
+migrate_options = {
+  :hyphenate => true
+}
+
+def setting(const)
+  Object.const_defined?(const.upcase) && Object.const_get(const.upcase)
+end
 
 opts = OptionParser.new do |opts|
 opts.banner = <<EOF
@@ -68,30 +58,32 @@ EOF
   end
     
   opts.on('--prefer-relative-links', 'When specified, will try to replace broken links with relative links (\'[[Foo/Bar]]\' instead of \'[[/Subdir/Foo/Bar]]\') where possible.') do
-    set_const(:PREFER_RELATIVE, true)
-  end
-  
-  opts.on('--no-hyphenate', 'Turn off the --hyphenate option.') do
-    set_const(:HYPHENATE, false)
+    migrate_options[:prefer_relative] = true
   end
   
   opts.on('--hyphenate', 'Default. Repair links that use spaces instead of hyphens: [[Bilbo Baggins]] -> [[Bilbo-Baggins]]') do
-    set_const(:HYPHENATE, true)
+    migrate_options[:hyphenate] = true
+  end
+  
+  opts.on('--no-hyphenate', 'Turn off the --hyphenate option.') do
+    migrate_options[:hyphenate] = false
   end
   
   opts.on('--run-silent', 'Don\'t output anything.') do
-    set_const(:PREFER_RELATIVE, true)
+    migrate_options[:run_silent] = true
   end
   
   opts.on('--write', 'No dry run: actually perform the substitutions.') do
-    set_const(:NO_DRY_RUN, true)
+    migrate_options[:no_dry_run] = true
   end
 end
 
 # Read command line options into `options` hash
 begin
   opts.parse!
-  set_const(:HYPHENATE, true)
+  migrate_options.each do |setting, value|
+    Object.const_set(setting.to_s.upcase, value)
+  end
 rescue OptionParser::InvalidOption
   puts "gollum-migrate-tags: #{$!.message}"
   puts "gollum-migrate-tags: try 'gollum-migrate-tags --help' for more information"
@@ -172,9 +164,9 @@ class ::Gollum::Filter::TagMigrator < Gollum::Filter::Tags
       return orig_tag
     end
 
-    # It's an internal Page link tag. Try to find the file/page it links to
+    # Try to resolve it as an internal Page link tag.
     link = link_part
-    page = find_page_from_path(link)
+    page = find_page_or_file_from_path(link)
     anchor = nil
     
     if page.nil? # No match yet, now try finding the page with anchor removed
@@ -187,7 +179,7 @@ class ::Gollum::Filter::TagMigrator < Gollum::Filter::Tags
         return orig_tag
       end
 
-      page  = find_page_from_path(link)
+      page  = find_page_or_file_from_path(link)
     end
 
     if page
@@ -218,21 +210,17 @@ class ::Gollum::Filter::TagMigrator < Gollum::Filter::Tags
   private
   
   def tag_for_pick(pick, orig_tag, extra, anchor, linking_page_path)
-    pick = if const_true(:PREFER_RELATIVE)
+    pick = if setting(:prefer_relative)
       overlapping_path = Pathname.new(linking_page_path).dirname.to_s
-      if overlapping_path == '.'
-        overlapping_path = '' 
-      else
-        overlapping_path = ::File.join('/', overlapping_path)
-      end
+      overlapping_path = overlapping_path == '.' ? '' : ::File.join('/', overlapping_path)
       relative_path = pick.to_s.match(/^#{overlapping_path}\/(.+)/)
       relative_path ? relative_path[1] : pick
     else
       pick
     end
-    new_tag = extra.nil? ? %{[[#{pick}]]} : %{[[#{extra}|#{pick}#{anchor}]]}
+    new_tag = extra.nil? ? %{[[#{pick}#{anchor}]]} : %{[[#{extra}|#{pick}#{anchor}]]}
     log(:info, "#{@markup.page.path}: Changing #{orig_tag} -> #{new_tag}")
-    return const_true(:DRY_RUN) ? orig_tag : new_tag    
+    new_tag    
   end
 end
 
@@ -248,7 +236,7 @@ wiki = ::Gollum::Wiki.new(REPO, wiki_options.merge({:filter_chain => filter_chai
 TREE = wiki.tree_list(wiki.ref, true, true).map {|file| ::File.join('/', file.path)}
 
 def find_linked(link)
-  link.gsub!(' ', '-') if const_true(:HYPHENATE) # Match paths containing dashes instead of spaces
+  link.gsub!(' ', '-') if setting(:hyphenate) # Match paths containing dashes instead of spaces
   # If the link has no explicit file extension, test against the link + the '.' character.
   # This is to avoid that 'Samwi' matches 'Samwise.md'
   # If it has an explicit file extension ('Samwi.md'), just test against that.
@@ -259,7 +247,7 @@ def find_linked(link)
 end
 
 def log(kind, msg = nil)
-  unless const_true(:RUN_SILENT)
+  unless setting(:run_silent)
     if kind == :none
       puts msg
     elsif kind == :empty
@@ -273,7 +261,7 @@ end
 wiki.pages.each do |page|
   log(:info,"Page #{page.path}")
   new_data = page.formatted_data
-  if const_true(:NO_DRY_RUN)
+  if setting(:no_dry_run)
     path = ::File.join([wiki.path, wiki.page_file_dir, page.path].compact)
     f = File.new(path, 'w')
     f.write(new_data)

--- a/bin/gollum-migrate-tags
+++ b/bin/gollum-migrate-tags
@@ -245,9 +245,7 @@ end
 filter_chain = [:PlainTextMigrator, :CodeMigrator, :TagMigrator]
 
 wiki = ::Gollum::Wiki.new(REPO, wiki_options.merge({:filter_chain => filter_chain}))
-pages = wiki.tree_list(wiki.ref, true, false)
-files = wiki.files
-TREE = (pages + files).map {|file| ::File.join('/', file.path)}
+TREE = wiki.tree_list(wiki.ref, true, true).map {|file| ::File.join('/', file.path)}
 
 def find_linked(link)
   link.gsub!(' ', '-') if const_true(:HYPHENATE) # Match paths containing dashes instead of spaces

--- a/bin/gollum-migrate-tags
+++ b/bin/gollum-migrate-tags
@@ -6,6 +6,24 @@ require 'rubygems'
 
 REPO = ARGV[0] || Dir.pwd
 
+def set_const(const, val)
+  already_defined = begin
+    Object.const_get(const)
+    true
+  rescue NameError
+    false
+  end
+  Object.const_set(const, val) unless already_defined
+end
+
+def const_true(const)
+  begin
+    Object.const_get(const)
+  rescue NameError
+    false
+  end
+end
+
 wiki_options = {}
 options = {}
 
@@ -14,7 +32,7 @@ opts.banner = <<EOF
 Use this tool to migrate a wiki repository created under Gollum versions 4.x or earlier to a 5.x compatibile repo.
 It finds and repairs Gollum link tags that no longer work under 5.x for two reasons:
 
-* 5.x wiki internal links may contain spaces, [[Bilbo Baggins]] no longer resolves to [[Bilbo-Baggins]]
+* 5.x wiki internal links may contain spaces. [[Bilbo Baggins]] and [[Bilbo-Baggins]] therefore link to distinct pages.
 * 5.x wiki internal links are case senitive
 * 5.x wiki internal links are no longer 'global'.
     * NB: you can use the --global-tag-lookup option in gollum >= 5.x to enable 4.x-style global tags.
@@ -49,29 +67,30 @@ EOF
   end
     
   opts.on('--prefer-relative-links', 'When specified, will try to replace broken links with relative links (\'[[Foo/Bar]]\' instead of \'[[/Subdir/Foo/Bar]]\') where possible.') do
-    PREFER_RELATIVE = true
-  end
-  
-  HYPHENATE = true unless defined?(HYPHENATE)
-  opts.on('--hyphenate', 'Default. Repair links that use spaces instead of hyphens for pages that contain hyphens: [[Bilbo Baggins]] -> [[Bilbo-Baggins]]') do
+    set_const(:PREFER_RELATIVE, true)
   end
   
   opts.on('--no-hyphenate', 'Turn off the --hyphenate option.') do
-    HYPHENATE = false
+    set_const(:HYPHENATE, false)
+  end
+  
+  opts.on('--hyphenate', 'Default. Repair links that use spaces instead of hyphens: [[Bilbo Baggins]] -> [[Bilbo-Baggins]]') do
+    set_const(:HYPHENATE, true)
   end
   
   opts.on('--run-silent', 'Don\'t output anything.') do
-    PREFER_RELATIVE = true
+    set_const(:PREFER_RELATIVE, true)
   end
   
   opts.on('--write', 'No dry run: actually perform the substitutions.') do
-    NO_DRY_RUN = true
+    set_const(:NO_DRY_RUN, true)
   end
 end
 
 # Read command line options into `options` hash
 begin
   opts.parse!
+  set_const(:HYPHENATE, true)
 rescue OptionParser::InvalidOption
   puts "gollum-migrate-tags: #{$!.message}"
   puts "gollum-migrate-tags: try 'gollum-migrate-tags --help' for more information"
@@ -198,7 +217,7 @@ class ::Gollum::Filter::TagMigrator < Gollum::Filter::Tags
   private
   
   def tag_for_pick(pick, orig_tag, extra, anchor, linking_page_path)
-    pick = if defined?(PREFER_RELATIVE) && PREFER_RELATIVE
+    pick = if const_true(:PREFER_RELATIVE)
       overlapping_path = Pathname.new(linking_page_path).dirname.to_s
       if overlapping_path == '.'
         overlapping_path = '' 
@@ -212,7 +231,7 @@ class ::Gollum::Filter::TagMigrator < Gollum::Filter::Tags
     end
     new_tag = extra.nil? ? %{[[#{pick}]]} : %{[[#{extra}|#{pick}#{anchor}]]}
     log(:info, "#{@markup.page.path}: Changing #{orig_tag} -> #{new_tag}")
-    return (defined?(DRY_RUN) && DRY_RUN) ? orig_tag : new_tag    
+    return const_true(:DRY_RUN) ? orig_tag : new_tag    
   end
 end
 
@@ -230,7 +249,7 @@ files = wiki.files
 TREE = (pages + files).map {|file| ::File.join('/', file.path)}
 
 def find_linked(link)
-  link.gsub!(' ', '-') if defined?(HYPHENATE) && HYPHENATE # Match paths containing dashes instead of spaces
+  link.gsub!(' ', '-') if const_true(:HYPHENATE) # Match paths containing dashes instead of spaces
   # If the link has no explicit file extension, test against the link + the '.' character.
   # This is to avoid that 'Samwi' matches 'Samwise.md'
   # If it has an explicit file extension ('Samwi.md'), just test against that.
@@ -241,7 +260,7 @@ def find_linked(link)
 end
 
 def log(kind, msg = nil)
-  unless defined?(RUN_SILENT) && RUN_SILENT
+  unless const_true(:RUN_SILENT)
     if kind == :none
       puts msg
     elsif kind == :empty
@@ -255,7 +274,7 @@ end
 wiki.pages.each do |page|
   log(:info,"Page #{page.path}")
   new_data = page.formatted_data
-  if defined?(NO_DRY_RUN) && NO_DRY_RUN
+  if const_true(:NO_DRY_RUN)
     path = ::File.join([wiki.path, wiki.page_file_dir, page.path].compact)
     f = File.new(path, 'w')
     f.write(new_data)

--- a/bin/gollum-migrate-tags
+++ b/bin/gollum-migrate-tags
@@ -17,6 +17,8 @@ It finds and repairs Gollum link tags that no longer work under 5.x for two reas
 * 5.x wiki internal links are case senitive
 * 5.x wiki internal links are no longer 'global'.
     * NB: you can use the --global-tag-lookup option in gollum >= 5.x to enable 4.x-style global tags.
+  
+NB: you can also use this script to update links to filenames containing hyphens, see the --hyphenate option.
 
 See https://github.com/gollum/gollum/wiki/5.0-release-notes#filename-handling for more information.
 Usage of this script comes without any warranty.
@@ -46,9 +48,13 @@ EOF
   opts.on('--page-file-dir [PATH]', 'Specify the subdirectory for all pages. Default: repository root.') do |path|
     wiki_options[:page_file_dir] = path
   end
-  
+    
   opts.on('--prefer-relative-links', 'When specified, will try to replace broken links with relative links (\'[[Foo/Bar]]\' instead of \'[[/Subdir/Foo/Bar]]\') where possible.') do
     PREFER_RELATIVE = true
+  end
+  
+  opts.on('--hyphenate', 'Repair links that used spaces instead of hyphens for pages that contain hyphens: [[Bilbo Baggings]] -> [[Bilbo-Baggins]]') do
+    HYPHENATE = true
   end
   
   opts.on('--run-silent', 'Don\'t output anything.') do
@@ -189,16 +195,21 @@ class ::Gollum::Filter::TagMigrator < Gollum::Filter::Tags
   private
   
   def tag_for_pick(pick, orig_tag, extra, anchor, linking_page_path)
-    pick = if defined?(PREFER_RELATIVE)
+    pick = if defined?(PREFER_RELATIVE) && PREFER_RELATIVE
       overlapping_path = Pathname.new(linking_page_path).dirname.to_s
-      relative_path = pick.to_s.match(/^\/#{overlapping_path}\/(.+)/)
+      if overlapping_path == '.'
+        overlapping_path = '' 
+      else
+        overlapping_path = ::File.join('/', overlapping_path)
+      end
+      relative_path = pick.to_s.match(/^#{overlapping_path}\/(.+)/)
       relative_path ? relative_path[1] : pick
     else
       pick
     end
     new_tag = extra.nil? ? %{[[#{pick}]]} : %{[[#{extra}|#{pick}#{anchor}]]}
     log(:info, "#{@markup.page.path}: Changing #{orig_tag} -> #{new_tag}")
-    return defined?(DRY_RUN) ? orig_tag : new_tag    
+    return (defined?(DRY_RUN) && DRY_RUN) ? orig_tag : new_tag    
   end
 end
 
@@ -214,6 +225,7 @@ wiki = ::Gollum::Wiki.new(REPO, wiki_options.merge({:filter_chain => filter_chai
 TREE = wiki.tree_list(wiki.ref, true, false).map {|page| ::File.join('/', page.path)}
 
 def find_linked(link)
+  link.gsub!(' ', '-') if defined?(HYPHENATE) && HYPHENATE # Match paths containing dashes instead of spaces
   # If the link has no explicit file extension, test against the link + the '.' character.
   # This is to avoid that 'Samwi' matches 'Samwise.md'
   # If it has an explicit file extension ('Samwi.md'), just test against that.
@@ -224,7 +236,7 @@ def find_linked(link)
 end
 
 def log(kind, msg = nil)
-  unless defined?(RUN_SILENT)
+  unless defined?(RUN_SILENT) && RUN_SILENT
     if kind == :none
       puts msg
     elsif kind == :empty
@@ -238,7 +250,7 @@ end
 wiki.pages.each do |page|
   log(:info,"Page #{page.path}")
   new_data = page.formatted_data
-  if defined?(NO_DRY_RUN)
+  if defined?(NO_DRY_RUN) && NO_DRY_RUN
     path = ::File.join([wiki.path, wiki.page_file_dir, page.path].compact)
     f = File.new(path, 'w')
     f.write(new_data)

--- a/bin/gollum-migrate-tags
+++ b/bin/gollum-migrate-tags
@@ -14,12 +14,11 @@ opts.banner = <<EOF
 Use this tool to migrate a wiki repository created under Gollum versions 4.x or earlier to a 5.x compatibile repo.
 It finds and repairs Gollum link tags that no longer work under 5.x for two reasons:
 
+* 5.x wiki internal links may contain spaces, [[Bilbo Baggins]] no longer resolves to [[Bilbo-Baggins]]
 * 5.x wiki internal links are case senitive
 * 5.x wiki internal links are no longer 'global'.
     * NB: you can use the --global-tag-lookup option in gollum >= 5.x to enable 4.x-style global tags.
   
-NB: you can also use this script to update links to filenames containing hyphens, see the --hyphenate option.
-
 See https://github.com/gollum/gollum/wiki/5.0-release-notes#filename-handling for more information.
 Usage of this script comes without any warranty.
 

--- a/bin/gollum-migrate-tags
+++ b/bin/gollum-migrate-tags
@@ -53,8 +53,12 @@ EOF
     PREFER_RELATIVE = true
   end
   
-  opts.on('--hyphenate', 'Repair links that used spaces instead of hyphens for pages that contain hyphens: [[Bilbo Baggings]] -> [[Bilbo-Baggins]]') do
-    HYPHENATE = true
+  HYPHENATE = true unless defined?(HYPHENATE)
+  opts.on('--hyphenate', 'Default. Repair links that use spaces instead of hyphens for pages that contain hyphens: [[Bilbo Baggins]] -> [[Bilbo-Baggins]]') do
+  end
+  
+  opts.on('--no-hyphenate', 'Turn off the --hyphenate option.') do
+    HYPHENATE = false
   end
   
   opts.on('--run-silent', 'Don\'t output anything.') do
@@ -145,7 +149,7 @@ class ::Gollum::Filter::TagMigrator < Gollum::Filter::Tags
     mime = MIME::Types.type_for(::File.extname(img_args.first.to_s)).first
     
     # For any kind of tag other than an internal link: just return the tag.
-    if tag =~ /^_TOC_/ || link_part =~ /^_$/ || link_part =~ /^#{INCLUDE_TAG}/ || (mime && mime.content_type =~ /^image/) || process_external_link_tag(link_part, extra)# || process_file_link_tag(link_part, extra)
+    if tag =~ /^_TOC_/ || link_part =~ /^_$/ || link_part =~ /^#{INCLUDE_TAG}/ || (mime && mime.content_type =~ /^image/) || process_external_link_tag(link_part, extra) || process_file_link_tag(link_part, extra)
       return orig_tag
     end
 

--- a/bin/gollum-migrate-tags
+++ b/bin/gollum-migrate-tags
@@ -145,7 +145,7 @@ class ::Gollum::Filter::TagMigrator < Gollum::Filter::Tags
     mime = MIME::Types.type_for(::File.extname(img_args.first.to_s)).first
     
     # For any kind of tag other than an internal link: just return the tag.
-    if tag =~ /^_TOC_/ || link_part =~ /^_$/ || link_part =~ /^#{INCLUDE_TAG}/ || (mime && mime.content_type =~ /^image/) || process_external_link_tag(link_part, extra) || process_file_link_tag(link_part, extra)
+    if tag =~ /^_TOC_/ || link_part =~ /^_$/ || link_part =~ /^#{INCLUDE_TAG}/ || (mime && mime.content_type =~ /^image/) || process_external_link_tag(link_part, extra)# || process_file_link_tag(link_part, extra)
       return orig_tag
     end
 
@@ -222,7 +222,9 @@ end
 filter_chain = [:PlainTextMigrator, :CodeMigrator, :TagMigrator]
 
 wiki = ::Gollum::Wiki.new(REPO, wiki_options.merge({:filter_chain => filter_chain}))
-TREE = wiki.tree_list(wiki.ref, true, false).map {|page| ::File.join('/', page.path)}
+pages = wiki.tree_list(wiki.ref, true, false)
+files = wiki.files
+TREE = (pages + files).map {|file| ::File.join('/', file.path)}
 
 def find_linked(link)
   link.gsub!(' ', '-') if defined?(HYPHENATE) && HYPHENATE # Match paths containing dashes instead of spaces

--- a/test/test_migrate.rb
+++ b/test/test_migrate.rb
@@ -43,7 +43,7 @@ unless ENV['TRAVIS']
       Dir.chdir(@path) do
         load script_path
       end
-      f = File.new(::File.join(@path, 'Subdir/Foo.md'), 'r')
+      f = ::File.new(::File.join(@path, 'Subdir/Foo.md'), 'r')
       assert_equal result, f.read
     end
     
@@ -57,7 +57,7 @@ unless ENV['TRAVIS']
         load script_path
       end
     
-      f = File.new(::File.join(@path, 'Home.textile'), 'r')
+      f = ::File.new(::File.join(@path, 'Home.textile'), 'r')
       output = f.read
       assert_equal true, output.include?('[[Bilbo-Baggins.md]]')
       assert_equal true, output.include?('[[evil|Mordor/Eye-Of-Sauron.md]]')

--- a/test/test_migrate.rb
+++ b/test/test_migrate.rb
@@ -23,6 +23,8 @@ waa
 [[Subsub/Zaa.md]]
 EOF
 
+script_path = File.expand_path(File.join(File.dirname(__FILE__), '../', 'bin', 'gollum-migrate-tags'))
+
 unless ENV['TRAVIS']
 
   context '4.x -> 5.x tag migrator' do
@@ -36,12 +38,29 @@ unless ENV['TRAVIS']
       PREFER_RELATIVE = true
       RUN_SILENT = true
       NO_DRY_RUN = true
-      script_path = File.expand_path(File.join(File.dirname(__FILE__), '../', 'bin', 'gollum-migrate-tags'))
+      HYPHENATE = false
+      
       Dir.chdir(@path) do
         load script_path
       end
       f = File.new(::File.join(@path, 'Subdir/Foo.md'), 'r')
       assert_equal result, f.read
+    end
+    
+    test 'change spaced filenames to hyphenated filenames' do
+      RUN_SILENT = true
+      NO_DRY_RUN = true
+      PREFER_RELATIVE = true
+      HYPHENATE = true
+    
+      Dir.chdir(@path) do
+        load script_path
+      end
+    
+      f = File.new(::File.join(@path, 'Home.textile'), 'r')
+      output = f.read
+      assert_equal true, output.include?('[[Bilbo-Baggins.md]]')
+      assert_equal true, output.include?('[[evil|Mordor/Eye-Of-Sauron.md]]')
     end
 
     teardown do


### PR DESCRIPTION
Support the hyphenate option in the migration script, too. Will require minor changes after https://github.com/gollum/gollum-lib/pull/365 is merged.