### PR TITLE
Remove a tiny padding in the head div

### DIFF
--- a/lib/gollum/templates/navbar.mustache
+++ b/lib/gollum/templates/navbar.mustache
@@ -22,7 +22,7 @@
 		{{/history}}
 		
     {{#allow_editing}}
-		  <div class="TableObject-item px-1">
+		  <div class="TableObject-item pl-1">
 				{{#allow_uploads}}
 					<a class="btn" id="minibutton-upload-page" href="#">Upload</a>
 	    	{{/allow_uploads}}


### PR DESCRIPTION
`px-1` class has been replaced with `pl-1` so that the right edge of the `div#wiki-wrapper` is aligned.

Current:
<img width="327" alt="Screen Shot 2020-03-27 at 16 49 01" src="https://user-images.githubusercontent.com/1431267/77734349-db295a80-704b-11ea-8298-4d9e87d095fc.png">

This PR:
<img width="325" alt="Screen Shot 2020-03-27 at 16 49 44" src="https://user-images.githubusercontent.com/1431267/77734359-de244b00-704b-11ea-9c00-ce950f4dc563.png">
