### PR TITLE
Add --lenient-tag-lookup option

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,7 +2,7 @@
 
 This is a major new release that substantially cleans up and improves the codebase. It also introduces many new features, bugfixes, and removing major limitations. See [here](https://github.com/gollum/gollum/wiki/5.0-release-notes) for a list of changes.
 
-**Note**: due to changes to the way in which Gollum handles filenames, you may have to change some links in your wiki when migrating from gollum 4.x. See the [release notes](https://github.com/gollum/gollum/wiki/5.0-release-notes#migrating-your-wiki) for more details. You may be able to use the `bin/gollum-migrate-tags` script to accomplish this.
+**Note**: due to changes to the way in which Gollum handles filenames, you may have to change some links in your wiki when migrating from gollum 4.x. See the [release notes](https://github.com/gollum/gollum/wiki/5.0-release-notes#migrating-your-wiki) for more details. You may be able to use the `bin/gollum-migrate-tags` script to accomplish this. Also see the `--lenient-tag-lookup` option.
 
 Many thanks to all the users who have provided feedback, and everyone who has chipped in in the development process!
 

--- a/README.md
+++ b/README.md
@@ -126,8 +126,7 @@ Gollum comes with the following command line options:
 | --template-dir    | [PATH]    | Specify custom mustache template directory. |
 | --template-page   | none      | Use _Template in root as a template for new pages. Must be committed. |
 | --emoji           | none      | Parse and interpret emoji tags (e.g. `:heart:`) except when the leading colon is backslashed (e.g. `\:heart:`). |
-| --global-tag-lookup | none   |  Match an internal link to 'Foo' with the first page found with that filename, anywhere in the repository. Provides compatibility with Gollum 4.x. |
-| --hyphened-tag-lookup | none  | Match an internal link to 'Bilbo Baggins' with 'Bilbo-Baggins'. Provides compatibility with Gollum 4.x. |
+| --lenient-tag-lookup | none | Internal links resolve case-insensitively, will treat spaces as hyphens, and will match the first page found with a certain filename, anywhere in the repository. Provides compatibility with Gollum 4.x. |
 | --help            | none      | Display the list of options on the command line. |
 | --version         | none      | Display the current version of Gollum. |
 | --versions        | none      | Display the current version of Gollum and auxiliary gems. |

--- a/bin/gollum
+++ b/bin/gollum
@@ -152,19 +152,10 @@ MSG
   opts.on('--template-page', 'Use _Template in root as a template for new pages.') do
     wiki_options[:template_page] = true
   end
-  opts.on('--no-strict-tag-lookup', 'Conjunction of --global-tag-lookup, --hyphened-tag-lookup, and --case-insensitive-tag-lookup. Provides compatibility with Gollum 4.x.') do
+  opts.on('--lenient-tag-lookup', 'Internal links resolve case-insensitively, will treat spaces as hyphens, and will match the first page found with a certain filename, anywhere in the repository. Provides compatibility with Gollum 4.x.') do
     wiki_options[:case_insensitive_tag_lookup] = true
     wiki_options[:global_tag_lookup] = true
     wiki_options[:hyphened_tag_lookup] = true
-  end
-  opts.on('--global-tag-lookup', 'Match an internal link to \'Foo\' with the first page found with that filename, anywhere in the repository.') do
-    wiki_options[:global_tag_lookup] = true
-  end
-  opts.on('--hyphened-tag-lookup', 'Match an internal link to \'Bilbo Baggins\' with \'Bilbo-Baggins\'.') do
-    wiki_options[:hyphened_tag_lookup] = true
-  end
-  opts.on('--case-insensitive-tag-lookup', 'Match internal links case-insensitively.') do
-    wiki_options[:case_insensitive_tag_lookup] = true
   end
   opts.on('--emoji', 'Parse and interpret emoji tags (e.g. :heart:) except when the leading colon is backslashed (e.g. \\:heart:).') do
     wiki_options[:emoji] = true

--- a/bin/gollum
+++ b/bin/gollum
@@ -152,11 +152,19 @@ MSG
   opts.on('--template-page', 'Use _Template in root as a template for new pages.') do
     wiki_options[:template_page] = true
   end
-  opts.on('--global-tag-lookup', 'Match an internal link to \'Foo\' with the first page found with that filename, anywhere in the repository. Provides compatibility with Gollum 4.x.') do
+  opts.on('--no-strict-tag-lookup', 'Conjunction of --global-tag-lookup, --hyphened-tag-lookup, and --case-insensitive-tag-lookup. Provides compatibility with Gollum 4.x.') do
+    wiki_options[:case_insensitive_tag_lookup] = true
+    wiki_options[:global_tag_lookup] = true
+    wiki_options[:hyphened_tag_lookup] = true
+  end
+  opts.on('--global-tag-lookup', 'Match an internal link to \'Foo\' with the first page found with that filename, anywhere in the repository.') do
     wiki_options[:global_tag_lookup] = true
   end
-  opts.on('--hyphened-tag-lookup', 'Match an internal link to \'Bilbo Baggins\' with \'Bilbo-Baggins\'. Provides compatibility with Gollum 4.x.') do
+  opts.on('--hyphened-tag-lookup', 'Match an internal link to \'Bilbo Baggins\' with \'Bilbo-Baggins\'.') do
     wiki_options[:hyphened_tag_lookup] = true
+  end
+  opts.on('--case-insensitive-tag-lookup', 'Match internal links case-insensitively.') do
+    wiki_options[:case_insensitive_tag_lookup] = true
   end
   opts.on('--emoji', 'Parse and interpret emoji tags (e.g. :heart:) except when the leading colon is backslashed (e.g. \\:heart:).') do
     wiki_options[:emoji] = true


### PR DESCRIPTION
@bartkamphorst what do you think of adding the `--no-strict-tag-lookup` option as a combined option? We could also remove the individual options (they could still be set separately in a `config.rb`).

- [x] After settling on final options, update README and Wiki