### PR TITLE
Let Primer.CSS determine H1-H6 styling (fixes #1515).

### DIFF
--- a/lib/gollum/public/gollum/stylesheets/template.scss.erb
+++ b/lib/gollum/public/gollum/stylesheets/template.scss.erb
@@ -167,20 +167,15 @@ a {
   }
 
   h3 {
-    font-size: 1.5em;
   }
 
   h4 {
-    font-size: 1.2em;
   }
 
   h5 {
-    font-size: 1em;
   }
 
   h6 {
-    color: #777;
-    font-size: 1em;
   }
 
   p, blockquote, ul, ol, dl, table, pre {


### PR DESCRIPTION
We now use the same font sizes for H1-H6 as Github does:

![Screen Shot 2020-03-30 at 09 15 38](https://user-images.githubusercontent.com/571173/77888310-579a8400-726c-11ea-83f8-edd300d5d76b.png)
![Screen Shot 2020-03-30 at 09 15 20](https://user-images.githubusercontent.com/571173/77888312-58331a80-726c-11ea-8009-13b02711d1fc.png)
