### PR TITLE
Check page.nil? before page.wiki

### DIFF
--- a/lib/gollum/app.rb
+++ b/lib/gollum/app.rb
@@ -413,8 +413,8 @@ module Precious
         @page      = wikip.page
         @page_num  = [params[:page_num].to_i, 1].max
         @max_count = settings.wiki_options.fetch(:pagination_count, 10)
-        @wiki      = @page.wiki
         unless @page.nil?
+          @wiki      = @page.wiki
           @versions = @page.versions(
             per_page: @max_count,
             page_num: @page_num,

--- a/test/test_app.rb
+++ b/test/test_app.rb
@@ -647,6 +647,11 @@ EOF
     assert_match /meta name="robots" content="noindex, nofollow"/, last_response.body
   end
 
+  test 'history/NO-EXIST redirects to Home' do
+    get '/gollum/history/NO-EXIST'
+    assert_equal last_response.status, 302
+  end
+
   def app
     Precious::App
   end

--- a/test/test_app.rb
+++ b/test/test_app.rb
@@ -649,6 +649,9 @@ EOF
 
   test 'history/NO-EXIST redirects to Home' do
     get '/gollum/history/NO-EXIST'
+    follow_redirect!
+    assert_equal last_request.fullpath, '/'
+    # redirect again from / to /Home
     assert_equal last_response.status, 302
   end
 


### PR DESCRIPTION
So that /history/wrong-name gets redirected to / successfully.