### PR TITLE
Fix `data-file-path` in overview pages

### DIFF
--- a/lib/gollum/templates/overview.mustache
+++ b/lib/gollum/templates/overview.mustache
@@ -18,7 +18,7 @@
 						<span class="pr-2">{{{icon}}}</span>
 						<span><a href={{url}}>{{name}}</a></span>
 						{{#allow_editing}}
-							{{#is_file}}<button class="btn btn-sm float-right delete-file" data-file-path={{name}} data-confirm="Are you sure you want to delete {{name}}?">{{#octicon}}trashcan{{/octicon}}</button>{{/is_file}}
+							{{#is_file}}<button class="btn btn-sm float-right delete-file" data-file-path={{url}} data-confirm="Are you sure you want to delete {{name}}?">{{#octicon}}trashcan{{/octicon}}</button>{{/is_file}}
 						{{/allow_editing}}
 		      </li>
 				{{/files_folders}}


### PR DESCRIPTION
This correct the `data-file-path` attribute's value so that the value includes the ancestor directories to a file.

This is a fix for a bug that, for example, deleting `abc/def.md` actually deletes `def.md`.