### PR TITLE
Fix folder URL escaping in overview

### DIFF
--- a/lib/gollum/views/overview.rb
+++ b/lib/gollum/views/overview.rb
@@ -49,6 +49,7 @@ module Precious
               # result contains a folder
               folder_name = result_path.split('/').first
               folder_path = @path ? "#{@path}/#{folder_name}" : folder_name
+              folder_path = ERB::Util.url_encode(folder_path).gsub('%2F', '/').force_encoding('utf-8')
               folder_url  = "#{overview_path}/#{folder_path}/"
               files_and_folders << {name: folder_name, icon: rocticon('file-directory'), type: 'dir', url: folder_url, is_file: false}
             elsif result_path != '.gitkeep'


### PR DESCRIPTION
The overview currently doesn't do any escaping for folder URLs, which can result in incorrect HTML like ```<a href=/gollum/overview/Mail Routing/test subdirectory/>test subdirectory</a>```

This change escapes these URLs the same way file URLs are escaped, turning the above example into ```<a href=/gollum/overview/Mail%20Routing/test%20subdirectory/>test subdirectory</a>```