### PR TITLE
Don't uglify JS in development env

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -181,6 +181,7 @@ end
 
 desc 'Precompile assets'
 task :precompile do
+  require './lib/gollum/app.rb'
   require './lib/gollum/views/helpers.rb'
   require './lib/gollum/assets.rb'
   require 'sprockets'

--- a/lib/gollum/assets.rb
+++ b/lib/gollum/assets.rb
@@ -4,7 +4,7 @@ module Precious
   module Assets
     MANIFEST = %w(app.js editor.js app.css criticmarkup.css fileview.css ie7.css print.css *.png *.jpg *.svg *.eot *.ttf)
     ASSET_URL = 'gollum/assets'
-    
+
     def self.sprockets(dir = File.dirname(File.expand_path(__FILE__)))
       env = Sprockets::Environment.new
       env.append_path ::File.join(dir, 'public/gollum/stylesheets/')
@@ -12,7 +12,7 @@ module Precious
       env.append_path ::File.join(dir, 'public/gollum/images')
       env.append_path ::File.join(dir, 'public/gollum/fonts')
 
-      env.js_compressor  = :uglify
+      env.js_compressor  = :uglify unless Precious::App.development?
       env.css_compressor = :scss
 
       env.context_class.class_eval do


### PR DESCRIPTION
Leave JS human readable when running Gollum with `RACK_ENV=development`.