### PR TITLE
Let compare versions be used in no-edit mode 

### DIFF
--- a/lib/gollum/templates/history.mustache
+++ b/lib/gollum/templates/history.mustache
@@ -7,7 +7,7 @@
 
   {{>pagination}}
 
-    <form name="selection-form" id="selection-form" method="post" action="{{compare_path}}/{{escaped_url_path}}"></form>
+    <form name="selection-form" id="selection-form" method="get" action="{{compare_path}}/{{escaped_url_path}}"></form>
 
 	<div id="page-history-list" class="Box Box--condensed flex-auto">
 		<form id="version-form">

--- a/test/test_app.rb
+++ b/test/test_app.rb
@@ -957,17 +957,17 @@ context 'Frontend with base path' do
   end
   
   test 'compare view' do
-    post '/wiki/gollum/compare/Bilbo-Baggins.md', :versions => ['f25eccd98e9b667f9e22946f3e2f945378b8a72d', '5bc1aaec6149e854078f1d0f8b71933bbc6c2e43']
+    get '/wiki/gollum/compare/Bilbo-Baggins.md?versions[]=f25eccd98e9b667f9e22946f3e2f945378b8a72d&versions[]=5bc1aaec6149e854078f1d0f8b71933bbc6c2e43'
     follow_redirect!
     assert last_response.ok?
     assert_equal '/wiki/gollum/compare/Bilbo-Baggins.md/5bc1aaec6149e854078f1d0f8b71933bbc6c2e43...f25eccd98e9b667f9e22946f3e2f945378b8a72d', last_request.fullpath
     
-    post '/wiki/gollum/compare/Bilbo-Baggins.md', :versions => ['f25eccd98e9b667f9e22946f3e2f945378b8a72d']
+    get '/wiki/gollum/compare/Bilbo-Baggins.md?versions[]=f25eccd98e9b667f9e22946f3e2f945378b8a72d'
     follow_redirect!
     assert last_response.ok?
     assert_equal '/wiki/gollum/compare/Bilbo-Baggins.md/b0d108328459e44fff4a76cd19b10ddc34adce4b...f25eccd98e9b667f9e22946f3e2f945378b8a72d', last_request.fullpath
 
-    post '/wiki/gollum/compare/Bilbo-Baggins.md', :versions => []
+    get '/wiki/gollum/compare/Bilbo-Baggins.md'
     follow_redirect!
     assert last_response.ok?
     assert_equal '/wiki/gollum/history/Bilbo-Baggins.md', last_request.fullpath


### PR DESCRIPTION
First pass at letting compare work in non-edit mode - potential fix for #1546.

Based on comments in the issue, it made more sense for compare to be a get as nothing is changed on the server and this lets it past the forbidden check for POST requests. The routes have to be rearranged to allow the more specific regex to match the request before the general one accepts everything.