### PR TITLE
Reduce direct use of base_url

### DIFF
--- a/lib/gollum/helpers.rb
+++ b/lib/gollum/helpers.rb
@@ -19,7 +19,7 @@ module Precious
     # Remove all double slashes
     def clean_url(url)
       return url if url.nil?
-      url.gsub('%2F', '/').gsub(/^\/+/, '').gsub('//', '/')
+      url.gsub('%2F', '/').gsub(%r{/{2,}}, '/').gsub(%r{^/}, '')
     end
 
     def forbid(msg = "Forbidden. This wiki is set to no-edit mode.")

--- a/lib/gollum/templates/layout.mustache
+++ b/lib/gollum/templates/layout.mustache
@@ -14,7 +14,7 @@
 
   <script>
   var criticMarkup = '{{critic_markup}}';
-	var baseUrl = '{{base_url}}';
+	var baseUrl = '{{page_route}}';
 	var uploadDest = 'uploads';
 	var perPageUploads = '{{per_page_uploads}}';
 	if (perPageUploads == 'true') {

--- a/lib/gollum/templates/layout.mustache
+++ b/lib/gollum/templates/layout.mustache
@@ -8,7 +8,7 @@
   {{#sprockets_stylesheet_tag}}app{{/sprockets_stylesheet_tag}}
   {{#sprockets_stylesheet_tag}}print print{{/sprockets_stylesheet_tag}}
 
-  {{#css}}<link rel="stylesheet" type="text/css" href="{{custom_path}}/custom.css" media="all">{{/css}}
+  {{#css}}<link rel="stylesheet" type="text/css" href="{{custom_css}}" media="all">{{/css}}
   {{#noindex}}<meta name="robots" content="noindex, nofollow" />{{/noindex}}
 
 
@@ -49,11 +49,11 @@
     };
   </script>
   {{#mathjax_config}}
-  <script type="text/javascript" src="{{base_url}}/{{mathjax_config}}"></script>
+  <script type="text/javascript" src="{{mathjax_config}}"></script>
   {{/mathjax_config}}
-  <script defer src="{{base_url}}/gollum/assets/mathjax/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+  <script defer src="{{mathjax_js}}"></script>
   {{/mathjax}}
-  {{#js}}<script type="text/javascript" src="{{custom_path}}/custom.js"></script>{{/js}}
+  {{#js}}<script type="text/javascript" src="{{custom_js}}"></script>{{/js}}
 
   <title>{{title}}</title>
 </head>

--- a/lib/gollum/templates/layout.mustache
+++ b/lib/gollum/templates/layout.mustache
@@ -14,7 +14,7 @@
 
   <script>
   var criticMarkup = '{{critic_markup}}';
-	var baseUrl = '{{page_route}}';
+	var baseUrl = '{{base_url}}';
 	var uploadDest = 'uploads';
 	var perPageUploads = '{{per_page_uploads}}';
 	if (perPageUploads == 'true') {

--- a/lib/gollum/templates/navbar.mustache
+++ b/lib/gollum/templates/navbar.mustache
@@ -2,7 +2,7 @@
 	
 	<div class="TableObject">
 		<div class="TableObject-item">
-	    <a class="btn" id="minibutton-home" href="{{base_url}}/">Home</a>
+	    <a class="btn" id="minibutton-home" href="{{page_route}}">Home</a>
 	  </div>
 
 

--- a/lib/gollum/templates/search.mustache
+++ b/lib/gollum/templates/search.mustache
@@ -13,9 +13,8 @@
   <div class="Box-header border-bottom p-0"></div>
   {{#results}}
     <li class="Box-row Box-row--gray">
-            <span class="Counter Counter--gray tooltipped tooltipped-w" aria-label="{{filename_count}} hits in filename - {{count}} hits in content">{{filename_count}} - {{count}}</span>&nbsp;
-
-      <span class="text-bold"><a href="{{base_url}}/{{name}}">{{name}}</a></span>
+      <span class="Counter Counter--gray tooltipped tooltipped-w" aria-label="{{filename_count}} hits in filename - {{count}} hits in content">{{filename_count}} - {{count}}</span>&nbsp;
+      <span class="text-bold"><a href="{{href}}">{{name}}</a></span>
       <button class="btn-link tooltipped tooltipped-w float-right toggle-context" aria-label="Show all {{count}} hits in this page">{{#octicon}}search{{/octicon}}</button>
     </li>
 

--- a/lib/gollum/views/has_page.rb
+++ b/lib/gollum/views/has_page.rb
@@ -15,9 +15,5 @@ module Precious
     def id
       @page.sha
     end
-
-    def full_url_path
-      ::File.join(@base_url, escaped_url_path)
-    end
   end
 end

--- a/lib/gollum/views/helpers.rb
+++ b/lib/gollum/views/helpers.rb
@@ -39,7 +39,7 @@ module Precious
             route_path = "#{prefix}/#{path}"
             @@route_methods[name.to_s] = route_path
             define_method :"#{name.to_s}_path" do
-              "#{base_url}/#{route_path}".gsub(/\/{2,}/, '/') # remove double slashes
+              page_route(route_path)
             end
           end
         end
@@ -53,8 +53,15 @@ module Precious
         end
       end
 
-      def page_route(page)
-        "#{base_url}/#{page}".gsub(/\/{2,}/, '/') # remove double slashes
+      def page_route(page = nil)
+        clean_url(@base_url, page)
+      end
+
+      def clean_url(*url)
+        url.compact!
+        return url if url.nil?
+
+        ::File.join(*url).gsub(%r{/{2,}}, '/')
       end
     end
 

--- a/lib/gollum/views/helpers.rb
+++ b/lib/gollum/views/helpers.rb
@@ -59,7 +59,7 @@ module Precious
 
       def clean_url(*url)
         url.compact!
-        return url if url.nil?
+        return nil if url.empty?
 
         ::File.join(*url).gsub(%r{/{2,}}, '/')
       end

--- a/lib/gollum/views/layout.rb
+++ b/lib/gollum/views/layout.rb
@@ -26,12 +26,24 @@ module Precious
         !@path.nil?
       end
 
-      def base_url
+      def custom_path
         @base_url
       end
 
-      def custom_path
-        "#{@base_url}"
+      def custom_css
+        clean_url(custom_path, "custom.css")
+      end
+
+      def custom_js
+        clean_url(custom_path, "custom.js")
+      end
+
+      def mathjax_config
+        page_route(@mathjax_config)
+      end
+
+      def mathjax_js
+        page_route("gollum/assets/mathjax/MathJax.js?config=TeX-AMS-MML_HTMLorMML")
       end
 
       def css # custom css

--- a/lib/gollum/views/layout.rb
+++ b/lib/gollum/views/layout.rb
@@ -26,6 +26,10 @@ module Precious
         !@path.nil?
       end
 
+      def base_url
+        @base_url
+      end
+
       def custom_path
         @base_url
       end

--- a/lib/gollum/views/overview.rb
+++ b/lib/gollum/views/overview.rb
@@ -52,7 +52,7 @@ module Precious
               folder_url  = "#{overview_path}/#{folder_path}/"
               files_and_folders << {name: folder_name, icon: rocticon('file-directory'), type: 'dir', url: folder_url, is_file: false}
             elsif result_path != '.gitkeep'
-              file_url = "#{@base_url}/#{result.escaped_url_path}"
+              file_url = page_route(result.escaped_url_path)
               files_and_folders << {name: result.filename, icon: rocticon('file'), type: 'file', url: file_url, is_file: true}
             end
           end

--- a/lib/gollum/views/page.rb
+++ b/lib/gollum/views/page.rb
@@ -169,6 +169,10 @@ module Precious
         @navbar
       end
 
+      def full_url_path
+        page_route(@page.escaped_url_path)
+      end
+
       # Access to embedded metadata.
       #
       # Returns Hash.

--- a/lib/gollum/views/search.rb
+++ b/lib/gollum/views/search.rb
@@ -5,7 +5,7 @@ module Precious
       include Pagination
 
       def results
-        @results.sort do |a, b|
+        sorted = @results.sort do |a, b|
           if b.nil?
             b_filename_count = 0
             b_count          = 0
@@ -15,6 +15,7 @@ module Precious
           end
           [a[:filename_count], a[:count]] <=> [b_filename_count, b_count]
         end.reverse.slice((@page_num - 1) * @max_count, @max_count)
+        sorted.each {|x| x[:href] = page_route(x[:name])}
       end
 
       def query_string


### PR DESCRIPTION
As proposed in #1555, `page_route()` and `clean_url()` have been enhanced and applied to replace raw `base_url`s in mustache templates and ruby sources.

There may be some more places to be refactored, but I want somebody to review the changes before it gets too difficult to track.