### PR TITLE
Add rdoc dependency

### DIFF
--- a/gollum.gemspec
+++ b/gollum.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.rdoc_options = ['--charset=UTF-8']
   s.extra_rdoc_files = %w[README.md LICENSE]
 
+  s.add_dependency 'rdoc'
   s.add_dependency 'gollum-lib', '~> 5.0'
   s.add_dependency 'kramdown', '~> 2.1.0'
   s.add_dependency 'kramdown-parser-gfm', '~> 1.0.0'


### PR DESCRIPTION
Given
  I clone gollum from: https://github.com/gollum/gollum.git

Running
  ruby 2.7.1p83 (2020-03-31 revision a0c7c23c9c) [x86_64-linux]
  Fedora 32

When
  I follow the instructions at:
  https://github.com/gollum/gollum#running-from-source

Then
  It should Just Work

But
  $ bundle exec bin/gollum
  bundler: failed to load command: bin/gollum (bin/gollum)
  LoadError: cannot load such file -- rdoc

So
  I fixed it

But
  I don't know how to decide what version to put in the gemspec, so I didn't put any