### PR TITLE
Address home button issue #1590

### DIFF
--- a/lib/gollum/templates/navbar.mustache
+++ b/lib/gollum/templates/navbar.mustache
@@ -2,7 +2,7 @@
 	
 	<div class="TableObject">
 		<div class="TableObject-item">
-	    <a class="btn" id="minibutton-home" href="{{page_route}}">Home</a>
+	    <a class="btn" id="minibutton-home" href="{{page_route}}/">Home</a>
 	  </div>
 
 


### PR DESCRIPTION
A trailing slash is added. This fixes the behavior when `base_url` is `nil`.