### PR TITLE
Fix mathjax config path

### DIFF
--- a/lib/gollum/templates/layout.mustache
+++ b/lib/gollum/templates/layout.mustache
@@ -49,7 +49,7 @@
     };
   </script>
   {{#mathjax_config}}
-  <script type="text/javascript" src="{{mathjax_config}}"></script>
+  <script type="text/javascript" src="{{mathjax_config_path}}"></script>
   {{/mathjax_config}}
   <script defer src="{{mathjax_js}}"></script>
   {{/mathjax}}

--- a/lib/gollum/views/layout.rb
+++ b/lib/gollum/views/layout.rb
@@ -42,7 +42,7 @@ module Precious
         clean_url(custom_path, "custom.js")
       end
 
-      def mathjax_config
+      def mathjax_config_path
         page_route(@mathjax_config)
       end
 


### PR DESCRIPTION
Caught another issue related to https://github.com/gollum/gollum/issues/1602. The layouts referenced the `mathjax_config` method, but this was by default being interpreted as an attribute accessor for the `@mathjax_config` instance variable -- not the method in `layout.rb` which transforms `@mathjax_config` using `page_route`. Renamed the latter method, and referenced the new method name in the layout template.