### PR TITLE
Filter _Template content. Resolves #1603 and #1640.

### DIFF
--- a/bin/gollum
+++ b/bin/gollum
@@ -152,7 +152,7 @@ MSG
   opts.on('--template-dir [PATH]', 'Specify custom mustache template directory.') do |path|
     wiki_options[:template_dir] = path
   end
-  opts.on('--template-page', 'Use _Template in root as a template for new pages.') do
+  opts.on('--template-page', 'Use _Template.{ext} as a template for new pages.') do
     wiki_options[:template_page] = true
   end
   opts.on('--lenient-tag-lookup', 'Internal links resolve case-insensitively, will treat spaces as hyphens, and will match the first page found with a certain filename, anywhere in the repository. Provides compatibility with Gollum 4.x.') do

--- a/lib/gollum.rb
+++ b/lib/gollum.rb
@@ -33,4 +33,25 @@ module Gollum
       super(message || "Cannot write #{@dir}/#{@attempted_path}, found #{@dir}/#{@existing_path}.")
     end
   end
+  
+  class TemplateFilter
+    @@filters = {}
+
+    def self.filters
+      @@filters
+    end
+
+    def self.add_filter(pattern, &replacement)
+      @@filters[pattern] = replacement
+    end
+
+    def self.apply_filters(data)
+      template = data
+      @@filters.each do |pattern, replacement|
+        template = template.gsub(pattern, replacement.call)
+      end
+      template
+    end
+  end
+
 end

--- a/lib/gollum.rb
+++ b/lib/gollum.rb
@@ -46,11 +46,10 @@ module Gollum
     end
 
     def self.apply_filters(data)
-      template = data
       @@filters.each do |pattern, replacement|
-        template = template.gsub(pattern, replacement.call)
+        data.gsub!(pattern, replacement.call)
       end
-      template
+      data
     end
   end
 

--- a/lib/gollum.rb
+++ b/lib/gollum.rb
@@ -37,10 +37,6 @@ module Gollum
   class TemplateFilter
     @@filters = {}
 
-    def self.filters
-      @@filters
-    end
-
     def self.add_filter(pattern, &replacement)
       @@filters[pattern] = replacement
     end

--- a/lib/gollum/app.rb
+++ b/lib/gollum/app.rb
@@ -638,7 +638,7 @@ module Precious
 
     def load_template
       template_page = wiki_page('/_Template')
-      template_page = (templalate_page.page != nil) ? template_page.page.raw_data : 'Template page option is set, but no /_Template page is present or committed.'
+      template_page = (template_page.page != nil) ? template_page.page.raw_data : 'Template page option is set, but no /_Template page is present or committed.'
       template_page = Gollum::TemplateFilter.apply_filters(template_page) unless Gollum::TemplateFilter.filters.empty?
       template_page
     end

--- a/lib/gollum/app.rb
+++ b/lib/gollum/app.rb
@@ -352,11 +352,11 @@ module Precious
 
       get '/create/*' do
         forbid unless @allow_editing
-        @template_page = load_template if settings.wiki_options[:template_page]
         wikip = wiki_page(params[:splat].first)
         @name = wikip.name
         @ext  = wikip.ext
         @path = wikip.path
+        @template_page = load_template(@path) if settings.wiki_options[:template_page]
         @allow_uploads = wikip.wiki.allow_uploads
         @upload_dest   = find_upload_dest(wikip.fullpath)
 
@@ -636,11 +636,9 @@ module Precious
       end
     end
 
-    def load_template
-      template_page = wiki_page('/_Template')
-      template_page = (template_page.page != nil) ? template_page.page.raw_data : 'Template page option is set, but no /_Template page is present or committed.'
-      template_page = Gollum::TemplateFilter.apply_filters(template_page)
-      template_page
+    def load_template(path)
+      template_page = wiki_page(::File.join(path, '_Template')).page || wiki_page('/_Template').page
+      template_page.nil? ? nil : Gollum::TemplateFilter.apply_filters(template_page.raw_data)
     end
 
     def update_wiki_page(wiki, page, content, commit, name = nil, format = nil)

--- a/lib/gollum/app.rb
+++ b/lib/gollum/app.rb
@@ -639,7 +639,7 @@ module Precious
     def load_template
       template_page = wiki_page('/_Template')
       template_page = (template_page.page != nil) ? template_page.page.raw_data : 'Template page option is set, but no /_Template page is present or committed.'
-      template_page = Gollum::TemplateFilter.apply_filters(template_page) unless Gollum::TemplateFilter.filters.empty?
+      template_page = Gollum::TemplateFilter.apply_filters(template_page)
       template_page
     end
 

--- a/lib/gollum/app.rb
+++ b/lib/gollum/app.rb
@@ -352,13 +352,7 @@ module Precious
 
       get '/create/*' do
         forbid unless @allow_editing
-        if settings.wiki_options[:template_page] then
-          temppage = wiki_page('/_Template')
-          @template_page = (temppage.page != nil) ? temppage.page.raw_data : 'Template page option is set, but no /_Template page is present or committed.'
-          if defined?(Gollum::TemplateFilter)
-            @template_page = Gollum::TemplateFilter.filter(@template_page)
-          end
-        end
+        @template_page = load_template if settings.wiki_options[:template_page]
         wikip = wiki_page(params[:splat].first)
         @name = wikip.name
         @ext  = wikip.ext
@@ -640,6 +634,13 @@ module Precious
         content_type file.mime_type
         file.raw_data
       end
+    end
+
+    def load_template
+      template_page = wiki_page('/_Template')
+      template_page = (templalate_page.page != nil) ? template_page.page.raw_data : 'Template page option is set, but no /_Template page is present or committed.'
+      template_page = Gollum::TemplateFilter.apply_filters(template_page) unless Gollum::TemplateFilter.filters.empty?
+      template_page
     end
 
     def update_wiki_page(wiki, page, content, commit, name = nil, format = nil)

--- a/lib/gollum/app.rb
+++ b/lib/gollum/app.rb
@@ -638,7 +638,7 @@ module Precious
 
     def load_template(path)
       template_page = wiki_page(::File.join(path, '_Template')).page || wiki_page('/_Template').page
-      template_page.nil? ? nil : Gollum::TemplateFilter.apply_filters(template_page.raw_data)
+      template_page ? Gollum::TemplateFilter.apply_filters(template_page.raw_data) : nil
     end
 
     def update_wiki_page(wiki, page, content, commit, name = nil, format = nil)

--- a/lib/gollum/app.rb
+++ b/lib/gollum/app.rb
@@ -355,6 +355,9 @@ module Precious
         if settings.wiki_options[:template_page] then
           temppage = wiki_page('/_Template')
           @template_page = (temppage.page != nil) ? temppage.page.raw_data : 'Template page option is set, but no /_Template page is present or committed.'
+          if defined?(Gollum::TemplateFilter)
+            @template_page = Gollum::TemplateFilter.filter(@template_page)
+          end
         end
         wikip = wiki_page(params[:splat].first)
         @name = wikip.name


### PR DESCRIPTION
This is a proposed solution to the question in #1603 . Basically, we just allow users to create a `Gollum::TemplateFilter` in their `config.rb` and let them manipulate the contents of `_Template` however they want at runtime. What do you think about this approach @dometto? A very simple example of such a filter could be the following:
```ruby
module Gollum
  class TemplateFilter
    def self.filter(data)
      return data.gsub!('{{current_date}}', Time.now.strftime("%d/%m/%Y"))
    end
  end
end
```

(Where `_Template.md` would obviously need to include something like `Date: {{current_date}}`.)