### PR TITLE
Don't escape page path. Resolves #1615

### DIFF
--- a/lib/gollum/app.rb
+++ b/lib/gollum/app.rb
@@ -590,7 +590,6 @@ module Precious
     end
 
     get '/*' do
-      puts params.inspect
       show_page_or_file(params[:splat].first)
     end
 

--- a/lib/gollum/app.rb
+++ b/lib/gollum/app.rb
@@ -318,9 +318,8 @@ module Precious
       post '/edit/*' do
         etag      = params[:etag]        
         path      = "/#{clean_url(sanitize_empty_params(params[:path]))}"
-        page_name = CGI.unescape(params[:page])
         wiki      = wiki_new
-        page      = wiki.page(::File.join(path, page_name))
+        page      = wiki.page(::File.join(path, params[:page]))
 
         return if page.nil?
         if etag != page.sha
@@ -417,7 +416,7 @@ module Precious
 
       post '/preview' do
         wiki           = wiki_new
-        @name          = params[:page] ? strip_page_name(CGI.unescape(params[:page])) : 'Preview'
+        @name          = params[:page] ? strip_page_name(params[:page]) : 'Preview'
         @page          = wiki.preview_page(@name, params[:content], params[:format])
         ['sidebar', 'header', 'footer'].each do |subpage|
           @page.send("set_#{subpage}".to_sym, params[subpage]) if params[subpage]
@@ -591,6 +590,7 @@ module Precious
     end
 
     get '/*' do
+      puts params.inspect
       show_page_or_file(params[:splat].first)
     end
 

--- a/test/test_app.rb
+++ b/test/test_app.rb
@@ -474,7 +474,7 @@ EOF
   end
 
   test "previews content" do
-    post "/gollum/preview", :content => 'abc', :format => 'markdown', :page => 'Samewise%20Gamgee.mediawiki'
+    post "/gollum/preview", :content => 'abc', :format => 'markdown', :page => 'Samewise Gamgee.mediawiki'
     assert last_response.ok?
     assert last_response.body.include?('Samewise Gamgee</h1>')
   end


### PR DESCRIPTION
Strangely, it seems that `params[:page]` is already escaped -- perhaps by Sinatra? When you inspect `params` when you get the page `/Samwise%20Gamgee.md`, `params[:page]` will already be `Samwise Gamgee.md`. The fact that we were calling unescape on the already escaped string caused #1615: "C++.md" was being escaped into "C  .md".