### PR TITLE
Normalize preview data

### DIFF
--- a/lib/gollum/app.rb
+++ b/lib/gollum/app.rb
@@ -421,7 +421,7 @@ module Precious
       post '/preview' do
         wiki           = wiki_new
         @name          = params[:page] ? strip_page_name(CGI.unescape(params[:page])) : 'Preview'
-        @page          = wiki.preview_page(@name, params[:content], params[:format])
+        @page          = wiki.preview_page(@name, wiki.normalize(params[:content]), params[:format])
         ['sidebar', 'header', 'footer'].each do |subpage|
           @page.send("set_#{subpage}".to_sym, params[subpage]) if params[subpage]
         end

--- a/lib/gollum/app.rb
+++ b/lib/gollum/app.rb
@@ -355,6 +355,9 @@ module Precious
         if settings.wiki_options[:template_page] then
           temppage = wiki_page('/_Template')
           @template_page = (temppage.page != nil) ? temppage.page.raw_data : 'Template page option is set, but no /_Template page is present or committed.'
+          if defined?(Gollum::TemplateFilter)
+            @template_page = Gollum::TemplateFilter.filter(@template_page)
+          end
         end
         wikip = wiki_page(params[:splat].first)
         @name = wikip.name

--- a/lib/gollum/public/gollum/javascript/gollum.js.erb
+++ b/lib/gollum/public/gollum/javascript/gollum.js.erb
@@ -345,7 +345,8 @@ $(document).ready(function() {
     var formData = new FormData($('#gollum-editor-form').get(0));
     var paths = window.location.pathname.split('/');
     var sectionAnchor = window.location.hash.substr(1);
-    formData.append('page', paths[ paths.length - 1 ] || '')
+    formData.append('page', paths[ paths.length - 1 ] || '');
+
     $.ajax({
       url: routePath('preview'),
       data: formData,


### PR DESCRIPTION
This fixes #1617 by ensuring that the data passed into the PreviewPage is normalized (removing any `\r` occurrences). 

On second thought, this is a "gollum-only" fix; the alternative would be to call `normalize` from within `gollum-lib`. Alternative fix is [here](https://github.com/gollum/gollum-lib/pull/386).