### PR TITLE
Make sidebar layout mobile-friendly

### DIFF
--- a/lib/gollum/templates/wiki_content.mustache
+++ b/lib/gollum/templates/wiki_content.mustache
@@ -9,7 +9,7 @@
 	    {{{toc_content}}}
 	  </div>
 	  {{/has_toc}}
-	  <div id="wiki-body" class="gollum-{{format}}-content overflow-hidden {{#left_bar}}pl-4{{/left_bar}}">
+	  <div id="wiki-body" class="gollum-{{format}}-content overflow-hidden">
 	    {{#has_header}}
 	    <div id="wiki-header" class="gollum-{{header_format}}-content">
 	      <div id="header-content" class="markdown-body">
@@ -17,18 +17,20 @@
 	      </div>
 	    </div>
 	    {{/has_header}}
-	    <div class="markdown-body {{#header_enum?}}header-enum{{/header_enum?}}" {{#header_enum?}}style="--header-enum-style:{{header_enum_style}};"{{/header_enum?}}>
-	      {{{rendered_metadata}}}
-	      {{{content}}}
+	    <div class="main-content clearfix container-lg">
+	      <div class="markdown-body {{#header_enum?}}header-enum{{/header_enum?}} {{#has_sidebar}}col-md-9{{/has_sidebar}}" {{#header_enum?}}style="--header-enum-style:{{header_enum_style}};"{{/header_enum?}}>
+	        {{{rendered_metadata}}}
+	        {{{content}}}
+	      </div>
+	      {{#has_sidebar}}
+	      <div id="wiki-sidebar" class="Box Box--condensed col-md-3 px-4">
+	        <div id="sidebar-content" class="gollum-{{sidebar_format}}-content markdown-body">
+	          {{{sidebar_content}}}
+	        </div>
+	      </div>
+	      {{/has_sidebar}}
 	    </div>
 	  </div>
-	  {{#has_sidebar}}
-	  <div id="wiki-sidebar" class="gollum-{{sidebar_format}}-content">
-	    <div id="sidebar-content" class="Box Box--condensed col-3 markdown-body px-4 float-{{bar_side}}">
-	      {{{sidebar_content}}}
-	    </div>
-	  </div>
-	  {{/has_sidebar}}
 	  {{#has_footer}}
 	  <div id="wiki-footer" class="gollum-{{footer_format}}-content">
 	    <div id="footer-content" class="Box Box-condensed markdown-body pl-2">

--- a/lib/gollum/templates/wiki_content.mustache
+++ b/lib/gollum/templates/wiki_content.mustache
@@ -1,7 +1,7 @@
 <div id="wiki-content">
 	<h1 class="pt-4">{{page_header}}</h1>
 	<div class="breadcrumb">{{{breadcrumb}}}</div>
-	
+
 
 	<div class="{{#has_header}}has-header{{/has_header}}{{#has_footer}} has-footer{{/has_footer}}{{#has_sidebar}} has-sidebar has-{{bar_side}}bar{{/has_sidebar}}{{#has_toc}} has-toc{{/has_toc}}">
 	  {{#has_toc}}
@@ -9,13 +9,6 @@
 	    {{{toc_content}}}
 	  </div>
 	  {{/has_toc}}
-	  {{#has_sidebar}}
-	  <div id="wiki-sidebar" class="gollum-{{sidebar_format}}-content">
-	    <div id="sidebar-content" class="Box Box--condensed col-3 markdown-body px-4 float-{{bar_side}}">
-	      {{{sidebar_content}}}
-	    </div>
-	  </div>
-	  {{/has_sidebar}}
 	  <div id="wiki-body" class="gollum-{{format}}-content overflow-hidden {{#left_bar}}pl-4{{/left_bar}}">
 	    {{#has_header}}
 	    <div id="wiki-header" class="gollum-{{header_format}}-content">
@@ -29,6 +22,13 @@
 	      {{{content}}}
 	    </div>
 	  </div>
+	  {{#has_sidebar}}
+	  <div id="wiki-sidebar" class="gollum-{{sidebar_format}}-content">
+	    <div id="sidebar-content" class="Box Box--condensed col-3 markdown-body px-4 float-{{bar_side}}">
+	      {{{sidebar_content}}}
+	    </div>
+	  </div>
+	  {{/has_sidebar}}
 	  {{#has_footer}}
 	  <div id="wiki-footer" class="gollum-{{footer_format}}-content">
 	    <div id="footer-content" class="Box Box-condensed markdown-body pl-2">
@@ -57,5 +57,5 @@
 	  {{/historical}}
 	</div>
 
-	
+
 </div>

--- a/lib/gollum/templates/wiki_content.mustache
+++ b/lib/gollum/templates/wiki_content.mustache
@@ -18,12 +18,12 @@
 	    </div>
 	    {{/has_header}}
 	    <div class="main-content clearfix container-lg">
-	      <div class="markdown-body {{#header_enum?}}header-enum{{/header_enum?}} {{#has_sidebar}}col-md-9{{/has_sidebar}}" {{#header_enum?}}style="--header-enum-style:{{header_enum_style}};"{{/header_enum?}}>
+	      <div class="markdown-body {{#header_enum?}}header-enum{{/header_enum?}} {{#has_sidebar}}float-md-{{body_side}} col-md-9{{/has_sidebar}}" {{#header_enum?}}style="--header-enum-style:{{header_enum_style}};"{{/header_enum?}}>
 	        {{{rendered_metadata}}}
 	        {{{content}}}
 	      </div>
 	      {{#has_sidebar}}
-	      <div id="wiki-sidebar" class="Box Box--condensed col-md-3 px-4">
+          <div id="wiki-sidebar" class="Box Box--condensed float-md-{{body_side}} col-md-3 px-4">
 	        <div id="sidebar-content" class="gollum-{{sidebar_format}}-content markdown-body">
 	          {{{sidebar_content}}}
 	        </div>

--- a/lib/gollum/templates/wiki_content.mustache
+++ b/lib/gollum/templates/wiki_content.mustache
@@ -1,4 +1,4 @@
-<div id="wiki-content">
+<div id="wiki-content" class="px-4 px-md-0">
 	<h1 class="pt-4">{{page_header}}</h1>
 	<div class="breadcrumb">{{{breadcrumb}}}</div>
 
@@ -32,7 +32,7 @@
 	    </div>
 	  </div>
 	  {{#has_footer}}
-	  <div id="wiki-footer" class="gollum-{{footer_format}}-content">
+	  <div id="wiki-footer" class="gollum-{{footer_format}}-content my-2 my-md-0">
 	    <div id="footer-content" class="Box Box-condensed markdown-body pl-2">
 	      {{{footer_content}}}
 	    </div>

--- a/lib/gollum/views/page.rb
+++ b/lib/gollum/views/page.rb
@@ -123,7 +123,11 @@ module Precious
       def bar_side
         @bar_side.to_s
       end
-      
+
+      def body_side
+        @bar_side == :right ? "left" : "right"
+      end
+
       def left_bar
         @bar_side == :left
       end

--- a/test/test_page_view.rb
+++ b/test/test_page_view.rb
@@ -139,6 +139,17 @@ EOS
     assert_equal @view.breadcrumb, ''
   end
 
+  test "body_side is 'right' by default" do
+    @view = Precious::Views::Page.new
+    assert_equal @view.body_side, "right"
+  end
+
+  test "body_side is 'left' if bar_side side is 'right'" do
+    @view = Precious::Views::Page.new
+    @view.instance_variable_set :@bar_side, :right
+    assert_equal @view.body_side, "left"
+  end
+
   test "links to pages containing ?" do
     @view = Precious::Views::Page.new
     assert_equal @view.page_route("Page?"), '/Page%3F'


### PR DESCRIPTION
Gollum's sidebar did not render very well for me on my mobile device. Using Primer CSS utilities, I was able to make a mobile-friendly grid with minimal changes.

Please see the individual commit messages for more details rationale for each change.

Here's a screenshot of the (unchanged) desktop layout resulting from these commits:

![Screenshot from 2021-01-20 21-31-54](https://user-images.githubusercontent.com/883581/105285917-2fb53d80-5b6a-11eb-9f8c-9f05ffb987f7.png)

And here's a screenshot of the mobile layout with a sidebar and footer enabled:

<img width="350" src="https://user-images.githubusercontent.com/883581/105285938-3774e200-5b6a-11eb-94b1-a74cd44a2970.png" alt="mobile view of Gollum wiki content" />
