### PR TITLE
Fix sidebar and footer padding

### DIFF
--- a/lib/gollum/templates/wiki_content.mustache
+++ b/lib/gollum/templates/wiki_content.mustache
@@ -22,8 +22,8 @@
 	        {{{content}}}
 	      </div>
 	      {{#has_sidebar}}
-          <div id="wiki-sidebar" class="Box Box--condensed float-md-{{body_side}} col-md-3 px-4">
-	        <div id="sidebar-content" class="gollum-{{sidebar_format}}-content markdown-body">
+          <div id="wiki-sidebar" class="Box Box--condensed float-md-{{body_side}} col-md-3">
+	        <div id="sidebar-content" class="gollum-{{sidebar_format}}-content markdown-body px-4">
 	          {{{sidebar_content}}}
 	        </div>
 	      </div>

--- a/lib/gollum/templates/wiki_content.mustache
+++ b/lib/gollum/templates/wiki_content.mustache
@@ -31,8 +31,8 @@
 	    </div>
 	  </div>
 	  {{#has_footer}}
-	  <div id="wiki-footer" class="gollum-{{footer_format}}-content my-2 my-md-0">
-	    <div id="footer-content" class="Box Box-condensed markdown-body pl-2">
+	  <div id="wiki-footer" class="gollum-{{footer_format}}-content my-2">
+	    <div id="footer-content" class="Box Box-condensed markdown-body px-4">
 	      {{{footer_content}}}
 	    </div>
 	  </div>


### PR DESCRIPTION
Resolves #1674.

### Padding between sidebar and footer containers

@dometto reported that there was no spacing between the optional sidebar and footer containers. This would look a bit funny in edge cases, specifically if the sidebar was longer than the main wiki content or both the main wiki content and the sidebar were empty.

After:

![Screenshot from 2021-02-20 18-26-57](https://user-images.githubusercontent.com/883581/108614094-99647980-73ac-11eb-91f4-1de9a0dd85a4.png)

### Padding inside of sidebar and footer containers

While investigating the above issue, I noticed that the footer and sidebar also had very different content padding definitions, which looked off on mobile devices--though I think it is technically off on all devices.

You can see the padding change in the above screenshot, but it's much clearer on mobile:

Before:

![Screenshot from 2021-02-20 18-43-54](https://user-images.githubusercontent.com/883581/108614099-ada87680-73ac-11eb-976a-940c1b824afe.png)

After:

![Screenshot from 2021-02-20 18-30-25](https://user-images.githubusercontent.com/883581/108614101-b5681b00-73ac-11eb-9949-a406cb76d3cd.png)
