### PR TITLE
Make Keybinding and Markup selects smaller

### DIFF
--- a/lib/gollum/templates/editor.mustache
+++ b/lib/gollum/templates/editor.mustache
@@ -50,13 +50,13 @@
 
     <div id="gollum-editor-format-selector">
       <label for="format">Keybinding</label>
-      <select id="keybinding" name="keybinding" class="form-select">
+      <select id="keybinding" name="keybinding" class="form-select input-sm">
         <option selected="selected">default</option>
         <option>vim</option>
         <option>emacs</option>
       </select>
       <label for="format">Markup</label>
-      <select id="wiki_format" name="format" class="form-select">
+      <select id="wiki_format" name="format" class="form-select input-sm">
       {{#formats}}
       {{#enabled}}
       <option {{#selected}}selected="selected" {{/selected}}value="{{id}}" data-ext="{{ext}}">


### PR DESCRIPTION
**EDIT**: oops, accidentally included the same screenshot twice. Now fixed!

Looks like the update to Primer caused the Markup and Keybinding select elements in the editor view to become larger than they were:

<img width="1062" alt="Screenshot 2021-02-22 at 17 21 03" src="https://user-images.githubusercontent.com/147111/108737018-74017800-7532-11eb-810c-38703f684c67.png">

This PR makes them smaller again so they fit on the same row:

<img width="1053" alt="Screenshot 2021-02-22 at 17 19 42" src="https://user-images.githubusercontent.com/147111/108738663-284fce00-7534-11eb-9343-321a95972e0e.png">

But as you can see there is not much space between these fields and the buttons to the left. Is this acceptable styling, or should we e.g. move the selects down a row?