### PR TITLE
Fix jruby compare rename

### DIFF
--- a/lib/gollum/views/compare.rb
+++ b/lib/gollum/views/compare.rb
@@ -20,7 +20,7 @@ module Precious
       def lines(diff = @diff)
         lines = []
         lines_to_parse = diff.split("\n")[3..-1]
-        lines_to_parse = lines_to_parse[2..-1] if lines_to_parse[0].start_with?('---')
+        lines_to_parse = lines_to_parse[2..-1] if lines_to_parse[0] =~ /^(---|rename to )/
 
         if lines_to_parse.nil? || lines_to_parse.empty?
           lines_to_parse = []  # File is created without content

--- a/test/test_compare.rb
+++ b/test/test_compare.rb
@@ -13,6 +13,18 @@ context "Precious::Views::Compare" do
     # Precious::App.set(:gollum_path, @path)
     @wiki = Gollum::Wiki.new(@path)
   end
+  
+  test 'rename diff' do
+    # JGit returns differenly formatted diffs for rename commits. Support both kinds of diff.
+    jgit_diff = "diff --git a/Foo.md b/Bar.md\nsimilarity index 100%\nrename from Foo.md\nrename to Bar.md"
+    rugged_diff = "diff --git a/Bar.md b/Bar.md\nnew file mode 100644\nindex 0000000..e69de29\n--- /dev/null\n+++ b/Bar.md\n"
+  
+    [jgit_diff, rugged_diff].each do |diff|
+      view = Precious::Views::Compare.new
+      view.instance_variable_set(:@diff, diff)
+      assert_equal [], view.lines
+    end
+  end
 
   test 'file addition diff' do
     view = Precious::Views::Compare.new


### PR DESCRIPTION
Was getting an error on JRuby when comparing a rename commit in the Latest Changes or Page History views. It turns out JGit handles rename commits slightly differently from Rugged.

Here's `diff` and `lines_to_compare` on MRI:

```ruby
"diff --git a/Bar.md b/Bar.md\nnew file mode 100644\nindex 0000000..e69de29\n--- /dev/null\n+++ b/Bar.md\n"
["--- /dev/null", "+++ b/Bar.md"]
"diff --git a/Foo.md b/Foo.md\ndeleted file mode 100644\nindex e69de29..0000000\n--- a/Foo.md\n+++ /dev/null"
["--- a/Foo.md", "+++ /dev/null"]
```

And here on JRuby:

```ruby
"diff --git a/Foo.md b/Bar.md\nsimilarity index 100%\nrename from Foo.md\nrename to Bar.md"
["rename to Bar.md"]
```

This PR makes sure diffs consisting of JGit-style rename lines are appropriately skipped by the `compare.rb` view. @bartkamphorst is this an acceptable way of handling the edge case?