### PR TITLE
Fix styling for Latest Changes flexbox

### DIFF
--- a/lib/gollum/templates/latest_changes.mustache
+++ b/lib/gollum/templates/latest_changes.mustache
@@ -13,7 +13,7 @@
 		<li class="Box-row Box-row--hover-gray border-top d-flex flex-items-center">
 			<span class="float-left col-2" id="user-icons">{{>author_template}}</span>
 			<span class="flex-auto col-1 text-gray-light">{{date}}</span>
-			<span class="flex-auto col-7">{{message}}<br/>
+			<span class="flex-auto col-5">{{message}}<br/>
 			{{#files}}
 			  <span class="flex-auto col-2">{{#renamed}}{{renamed}} -> {{/renamed}}<a href="{{link}}">{{file}}</a></span><br/>
 			{{/files}}


### PR DESCRIPTION
This brings the flexbox on the latest changes view in line with that on the page history view, which also has `col-5` rather than `col-7`.

Before:

<img width="1061" alt="Screenshot 2021-02-23 at 14 28 53" src="https://user-images.githubusercontent.com/147111/108850370-9901f380-75e3-11eb-8f11-8454f594e898.png">

After:

<img width="1097" alt="Screenshot 2021-02-23 at 14 27 50" src="https://user-images.githubusercontent.com/147111/108850388-9c957a80-75e3-11eb-94fb-b129a43baf9b.png">
