### PR TITLE
Update image icon in editor

### DIFF
--- a/lib/gollum/templates/editor.mustache
+++ b/lib/gollum/templates/editor.mustache
@@ -37,7 +37,7 @@
 			<button class="btn btn-sm function-button" id="function-h3" title="Heading 3">h3</button>
 			<span class="pr-2"></span>
 			<button class="btn btn-sm function-button" id="function-link" title="Link">{{#octicon}}link{{/octicon}}</button>
-			<button class="btn btn-sm function-button" id="function-image" title="Image">{{#octicon}}file-media{{/octicon}}</button>
+			<button class="btn btn-sm function-button" id="function-image" title="Image">{{#octicon}}image{{/octicon}}</button>
 			<span class="pr-2"></span>
 			{{#critic_markup}}
 			<button class="btn btn-sm function-button" id="function-critic-accept" title="Accept Selected CriticMarkup">{{#octicon}}plus{{/octicon}}</button>


### PR DESCRIPTION
Noticed the image button icon was weirdly out of style compared to the other editor buttons! Using a different octicon helped.

Before:

<img width="701" alt="Screenshot 2021-02-26 at 13 53 07" src="https://user-images.githubusercontent.com/147111/109303233-cc8a8b00-783a-11eb-8fd3-837d4041aca9.png">

After:

<img width="680" alt="Screenshot 2021-02-26 at 13 58 53" src="https://user-images.githubusercontent.com/147111/109303243-d14f3f00-783a-11eb-99cd-96a8d2eab9f4.png">
