### PR TITLE
Fix nav outline styles

### DIFF
--- a/lib/gollum/templates/navbar.mustache
+++ b/lib/gollum/templates/navbar.mustache
@@ -54,21 +54,21 @@
 
       {{#allow_editing}}
         {{#allow_uploads}}
-          <a
+          <button
             class="btn BtnGroup-item btn-sm hide-sm hide-md
               minibutton-upload-page"
           >
             Upload
-          </a>
+          </button>
         {{/allow_uploads}}
 
         {{#editable}}
-          <a
+          <button
             class="btn BtnGroup-item btn-sm hide-sm hide-md
               minibutton-rename-page"
           >
             Rename
-          </a>
+          </button>
           <a
             class="btn BtnGroup-item btn-sm hide-sm hide-md"
             href="{{edit_path}}/{{escaped_url_path}}"
@@ -80,7 +80,6 @@
       {{/allow_editing}}
     </div>
   </div>
-
 
   {{#allow_editing}}
     {{#editable}}

--- a/lib/gollum/templates/navbar.mustache
+++ b/lib/gollum/templates/navbar.mustache
@@ -1,104 +1,104 @@
 <nav class="TableObject actions pt-4 px-2 px-lg-0 overflow-x-scroll">
-    <div class="TableObject-item hide-lg hide-xl">
-      {{>mobilenav}}
-    </div>
+  <div class="TableObject-item hide-lg hide-xl">
+    {{>mobilenav}}
+  </div>
 
-    <div class="TableObject-item hide-sm hide-md">
-      <a class="btn btn-sm" id="minibutton-home" href="{{page_route}}">
-        Home
-      </a>
-    </div>
+  <div class="TableObject-item hide-sm hide-md">
+    <a class="btn btn-sm" id="minibutton-home" href="{{page_route}}">
+      Home
+    </a>
+  </div>
 
-    <div
-      class="TableObject-item TableObject-item--primary px-2"
-      {{^search}}style="visibility:hidden"{{/search}}
-    >
-      {{>searchbar}}
-    </div>
+  <div
+    class="TableObject-item TableObject-item--primary px-2"
+    {{^search}}style="visibility:hidden"{{/search}}
+  >
+    {{>searchbar}}
+  </div>
 
-    <div class="TableObject-item hide-sm hide-md">
-      <div class="BtnGroup d-flex">
-        {{#overview}}
+  <div class="TableObject-item hide-sm hide-md">
+    <div class="BtnGroup d-flex">
+      {{#overview}}
+        <a
+          class="btn BtnGroup-item btn-sm"
+          href="{{overview_path}}"
+          id="minibutton-overview"
+        >
+          Overview
+        </a>
+      {{/overview}}
+
+      {{#latest_changes}}
+        <a
+          class="btn BtnGroup-item btn-sm"
+          href="{{latest_changes_path}}"
+          id="minibutton-latest-changes"
+        >
+          Latest Changes
+        </a>
+      {{/latest_changes}}
+    </div>
+  </div>
+
+  <div class="TableObject-item px-2">
+    <div class="BtnGroup d-flex">
+      {{#history}}
+        <a
+          class="btn BtnGroup-item btn-sm hide-sm hide-md"
+          href="{{history_path}}/{{escaped_url_path}}"
+          id="minibutton-history"
+        >
+          History
+        </a>
+      {{/history}}
+
+      {{#allow_editing}}
+        {{#allow_uploads}}
           <a
-            class="btn BtnGroup-item btn-sm"
-            href="{{overview_path}}"
-            id="minibutton-overview"
+            class="btn BtnGroup-item btn-sm hide-sm hide-md
+              minibutton-upload-page"
           >
-            Overview
+            Upload
           </a>
-        {{/overview}}
+        {{/allow_uploads}}
 
-        {{#latest_changes}}
+        {{#editable}}
           <a
-            class="btn BtnGroup-item btn-sm"
-            href="{{latest_changes_path}}"
-            id="minibutton-latest-changes"
+            class="btn BtnGroup-item btn-sm hide-sm hide-md
+              minibutton-rename-page"
           >
-            Latest Changes
+            Rename
           </a>
-        {{/latest_changes}}
-      </div>
-    </div>
-
-    <div class="TableObject-item px-2">
-      <div class="BtnGroup d-flex">
-        {{#history}}
           <a
             class="btn BtnGroup-item btn-sm hide-sm hide-md"
-            href="{{history_path}}/{{escaped_url_path}}"
-            id="minibutton-history"
+            href="{{edit_path}}/{{escaped_url_path}}"
+            id="minibutton-edit-page"
           >
-            History
+            Edit
           </a>
-        {{/history}}
-
-        {{#allow_editing}}
-          {{#allow_uploads}}
-            <a
-              class="btn BtnGroup-item btn-sm hide-sm hide-md
-                minibutton-upload-page"
-            >
-              Upload
-            </a>
-          {{/allow_uploads}}
-
-          {{#editable}}
-            <a
-              class="btn BtnGroup-item btn-sm hide-sm hide-md
-                minibutton-rename-page"
-            >
-              Rename
-            </a>
-            <a
-              class="btn BtnGroup-item btn-sm hide-sm hide-md"
-              href="{{edit_path}}/{{escaped_url_path}}"
-              id="minibutton-edit-page"
-            >
-              Edit
-            </a>
-          {{/editable}}
-        {{/allow_editing}}
-      </div>
+        {{/editable}}
+      {{/allow_editing}}
     </div>
+  </div>
 
 
-    {{#allow_editing}}
-      {{#editable}}
+  {{#allow_editing}}
+    {{#editable}}
+      <div class="TableObject-item">
+        <a class="btn btn-primary btn-sm minibutton-new-page" href="#">
+          New
+        </a>
+      </div>
+    {{/editable}}
+
+    {{^editable}}
+      {{#newable}}
         <div class="TableObject-item">
           <a class="btn btn-primary btn-sm minibutton-new-page" href="#">
             New
           </a>
         </div>
-      {{/editable}}
-
-      {{^editable}}
-        {{#newable}}
-          <div class="TableObject-item">
-            <a class="btn btn-primary btn-sm minibutton-new-page" href="#">
-              New
-            </a>
-          </div>
-        {{/newable}}
-      {{/editable}}
-    {{/allow_editing}}
+      {{/newable}}
+    {{/editable}}
+  {{/allow_editing}}
 </nav>

--- a/lib/gollum/templates/navbar.mustache
+++ b/lib/gollum/templates/navbar.mustache
@@ -1,5 +1,4 @@
-<nav class="actions pt-4 px-2 px-lg-0 overflow-x-scroll">
-  <div class="TableObject">
+<nav class="TableObject actions pt-4 px-2 px-lg-0 overflow-x-scroll">
     <div class="TableObject-item hide-lg hide-xl">
       {{>mobilenav}}
     </div>
@@ -102,5 +101,4 @@
         {{/newable}}
       {{/editable}}
     {{/allow_editing}}
-  </div>
 </nav>


### PR DESCRIPTION
Fixes #1692.

There was a display issue, where navbar items's outline styles were being cut off due to the parent `<nav>` element's margin and padding.

Fortunately, we can do away with the navbar wrapper div entirely. It was not doing anything important except defining its children as `TableObject` items. But we can just do this on the `<nav>` itself.