### PR TITLE
Add integration tests with capybara

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,11 @@ gem 'warbler', platforms: :jruby
 # current CI workflows pass, we should only try to install this version of
 # Nokogiri for newer Ruby versions.
 
+group :test do
+  gem 'selenium-webdriver', require: false
+  gem 'capybara', require: false
+end
+
 gemspec
 
 gem 'rake', '~> 13.0'

--- a/Rakefile
+++ b/Rakefile
@@ -84,7 +84,9 @@ end
 
 Rake::TestTask.new(:test) do |test|
   test.libs << 'lib' << 'test' << '.'
-  test.pattern = 'test/**/test_*.rb'
+  test.test_files = FileList.new('test/**/test_*.rb') do |fl|
+    fl.exclude('test/integration/**/test_*.rb')
+  end
   test.verbose = true
   test.warning = false
 end

--- a/Rakefile
+++ b/Rakefile
@@ -72,6 +72,16 @@ end
 task :default => :test
 
 require 'rake/testtask'
+
+namespace :test do
+  Rake::TestTask.new('capybara') do |test|
+    test.libs << 'lib' << 'test' << '.'
+    test.pattern = 'test/integration/**/test_*.rb'
+    test.verbose = true
+    test.warning = false
+  end
+end
+
 Rake::TestTask.new(:test) do |test|
   test.libs << 'lib' << 'test' << '.'
   test.pattern = 'test/**/test_*.rb'

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -32,7 +32,7 @@ ENV['RACK_ENV'] = 'test'
 require 'gollum'
 require 'gollum/app'
 
-CAPYBARA_DRIVER = ENV.fetch('CAPYBARA_DRIVER', :selenium_chrome).to_sym
+CAPYBARA_DRIVER = ENV['CI'] ? :selenium_chrome_headless : ENV.fetch('CAPYBARA_DRIVER', :selenium_chrome).to_sym
 
 # Disable the metadata feature
 $METADATA = false

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -32,6 +32,8 @@ ENV['RACK_ENV'] = 'test'
 require 'gollum'
 require 'gollum/app'
 
+CAPYBARA_DRIVER = ENV.fetch('CAPYBARA_DRIVER', :selenium_chrome).to_sym
+
 # Disable the metadata feature
 $METADATA = false
 

--- a/test/integration/test_js_errors.rb
+++ b/test/integration/test_js_errors.rb
@@ -1,0 +1,43 @@
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'helper'))
+require 'selenium-webdriver'
+require 'capybara'
+require 'capybara/dsl'
+
+def console_logs(page, level = :severe, &block)
+  yield page.driver.browser.manage.logs.get(:browser).select{|log| log.level == level.to_s.upcase }
+end
+
+def expected_errors
+  [
+    %r{Refused to apply style from 'http:.*/gollum/create/custom.css'}
+  ]
+end
+
+context 'Frontend with matjax' do
+  include Capybara::DSL
+  
+  setup do
+    @path = cloned_testpath("examples/lotr.git")
+    @wiki = Gollum::Wiki.new(@path)
+    Precious::App.set(:gollum_path, @path)
+    Precious::App.set(:wiki_options, {mathjax: true})
+    Capybara.app = Precious::App
+    Capybara.default_driver = :selenium_chrome
+    Capybara.server = :webrick
+  end
+  
+  test 'expected asset errors' do
+    visit '/'
+    console_logs(page) do |logs|
+      expected_errors.each do |error|
+        assert logs.find {|log| log.message.match?(error) }
+      end
+      assert logs.size == expected_errors.size # No other errors
+    end
+  end
+  
+  teardown do
+    Capybara.reset_sessions!
+    Capybara.use_default_driver
+  end
+end

--- a/test/integration/test_js_errors.rb
+++ b/test/integration/test_js_errors.rb
@@ -3,7 +3,7 @@ if ENV['CI'] || ENV['CAPYBARA'] then
   require 'selenium-webdriver'
   require 'capybara/dsl'
 
-  Capybara.default_driver = :selenium_headless
+  Capybara.default_driver = :selenium_chrome_headless
   Capybara.server = :webrick
 
   def console_log(page, level = :severe)

--- a/test/integration/test_js_errors.rb
+++ b/test/integration/test_js_errors.rb
@@ -1,51 +1,49 @@
-if ENV['CI'] || ENV['CAPYBARA'] then
-  require File.expand_path(File.join(File.dirname(__FILE__), '..', 'helper'))
-  require 'selenium-webdriver'
-  require 'capybara/dsl'
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'helper'))
+require 'selenium-webdriver'
+require 'capybara/dsl'
 
-  Capybara.default_driver = :selenium_chrome_headless
-  Capybara.server = :webrick
+Capybara.default_driver = ::CAPYBARA_DRIVER
+Capybara.server = :webrick
 
-  def console_log(page, level = :severe)
-    page.driver.browser.logs.get(:browser).select{|log| log.level == level.to_s.upcase }
+def console_log(page, level = :severe)
+  page.driver.browser.logs.get(:browser).select{|log| log.level == level.to_s.upcase }
+end
+
+def expected_errors
+  Regexp.union([
+    %r{Refused to apply style from 'http:.*/gollum/create/custom.css'}
+  ])
+end
+
+def assert_only_expected_errors(log)
+  assert_equal [], log.reject {|err| err.message.match?(expected_errors) }
+end
+
+context 'Frontend with mathjax' do
+  include Capybara::DSL
+  
+  setup do
+    @path = cloned_testpath("examples/lotr.git")
+    @wiki = Gollum::Wiki.new(@path)
+    Precious::App.set(:gollum_path, @path)
+    Precious::App.set(:wiki_options, {mathjax: true})
+    Capybara.app = Precious::App
   end
-
-  def expected_errors
-    Regexp.union([
-      %r{Refused to apply style from 'http:.*/gollum/create/custom.css'}
-    ])
+  
+  test 'no unexpected errors on /' do
+    visit '/'
+    log = console_log(page)
+    assert_only_expected_errors(log)
   end
-
-  def assert_only_expected_errors(log)
-    assert_equal [], log.reject {|err| err.message.match?(expected_errors) }
+  
+  test 'no unexpected errors on /create/' do
+    visit '/create/Foobar'
+    log = console_log(page)
+    assert_only_expected_errors(log)
   end
-
-  context 'Frontend with mathjax' do
-    include Capybara::DSL
-    
-    setup do
-      @path = cloned_testpath("examples/lotr.git")
-      @wiki = Gollum::Wiki.new(@path)
-      Precious::App.set(:gollum_path, @path)
-      Precious::App.set(:wiki_options, {mathjax: true})
-      Capybara.app = Precious::App
-    end
-    
-    test 'no unexpected errors on /' do
-      visit '/'
-      log = console_log(page)
-      assert_only_expected_errors(log)
-    end
-    
-    test 'no unexpected errors on /create/' do
-      visit '/create/Foobar'
-      log = console_log(page)
-      assert_only_expected_errors(log)
-    end
-    
-    teardown do
-      Capybara.reset_sessions!
-      Capybara.use_default_driver
-    end
+  
+  teardown do
+    Capybara.reset_sessions!
+    Capybara.use_default_driver
   end
 end

--- a/test/integration/test_js_errors.rb
+++ b/test/integration/test_js_errors.rb
@@ -13,7 +13,7 @@ def expected_errors
   ]
 end
 
-context 'Frontend with matjax' do
+context 'Frontend with mathjax' do
   include Capybara::DSL
   
   setup do
@@ -27,12 +27,15 @@ context 'Frontend with matjax' do
   end
   
   test 'expected asset errors' do
-    visit '/'
-    console_logs(page) do |logs|
-      expected_errors.each do |error|
-        assert logs.find {|log| log.message.match?(error) }
+    test_routes = ['/', '/create/Foobar.rst']
+    test_routes.each do |route|
+      visit route
+      console_logs(page) do |logs|
+        expected_errors.each do |error|
+          assert logs.find {|log| log.message.match?(error) }
+        end
+        assert logs.size == expected_errors.size # No other errors
       end
-      assert logs.size == expected_errors.size # No other errors
     end
   end
   

--- a/test/integration/test_js_errors.rb
+++ b/test/integration/test_js_errors.rb
@@ -1,48 +1,51 @@
-require File.expand_path(File.join(File.dirname(__FILE__), '..', 'helper'))
-require 'selenium-webdriver'
-require 'capybara/dsl'
+if ENV['CI'] || ENV['CAPYBARA'] then
+  require File.expand_path(File.join(File.dirname(__FILE__), '..', 'helper'))
+  require 'selenium-webdriver'
+  require 'capybara/dsl'
 
-def console_log(page, level = :severe)
-  page.driver.browser.manage.logs.get(:browser).select{|log| log.level == level.to_s.upcase }
-end
+  Capybara.default_driver = ::CAPYBARA_DRIVER
+  Capybara.server = :webrick
 
-def expected_errors
-  Regexp.union([
-    %r{Refused to apply style from 'http:.*/gollum/create/custom.css'}
-  ])
-end
-
-def assert_only_expected_errors(log)
-  assert_equal [], log.reject {|err| err.message.match?(expected_errors) }
-end
-
-context 'Frontend with mathjax' do
-  include Capybara::DSL
-  
-  setup do
-    @path = cloned_testpath("examples/lotr.git")
-    @wiki = Gollum::Wiki.new(@path)
-    Precious::App.set(:gollum_path, @path)
-    Precious::App.set(:wiki_options, {mathjax: true})
-    Capybara.app = Precious::App
-    Capybara.default_driver = :selenium_chrome
-    Capybara.server = :webrick
+  def console_log(page, level = :severe)
+    page.driver.browser.logs.get(:browser).select{|log| log.level == level.to_s.upcase }
   end
-  
-  test 'no unexpected errors on /' do
-    visit '/'
-    log = console_log(page)
-    assert_only_expected_errors(log)
+
+  def expected_errors
+    Regexp.union([
+      %r{Refused to apply style from 'http:.*/gollum/create/custom.css'}
+    ])
   end
-  
-  test 'no unexpected errors on /create/' do
-    visit '/create/Foobar'
-    log = console_log(page)
-    assert_only_expected_errors(log)
+
+  def assert_only_expected_errors(log)
+    assert_equal [], log.reject {|err| err.message.match?(expected_errors) }
   end
-  
-  teardown do
-    Capybara.reset_sessions!
-    Capybara.use_default_driver
+
+  context 'Frontend with mathjax' do
+    include Capybara::DSL
+    
+    setup do
+      @path = cloned_testpath("examples/lotr.git")
+      @wiki = Gollum::Wiki.new(@path)
+      Precious::App.set(:gollum_path, @path)
+      Precious::App.set(:wiki_options, {mathjax: true})
+      Capybara.app = Precious::App
+    end
+    
+    test 'no unexpected errors on /' do
+      visit '/'
+      log = console_log(page)
+      assert_only_expected_errors(log)
+    end
+    
+    test 'no unexpected errors on /create/' do
+      visit '/create/Foobar'
+      log = console_log(page)
+      assert_only_expected_errors(log)
+    end
+    
+    teardown do
+      Capybara.reset_sessions!
+      Capybara.use_default_driver
+    end
   end
 end

--- a/test/integration/test_js_errors.rb
+++ b/test/integration/test_js_errors.rb
@@ -3,7 +3,7 @@ if ENV['CI'] || ENV['CAPYBARA'] then
   require 'selenium-webdriver'
   require 'capybara/dsl'
 
-  Capybara.default_driver = ::CAPYBARA_DRIVER
+  Capybara.default_driver = :selenium_headless
   Capybara.server = :webrick
 
   def console_log(page, level = :severe)


### PR DESCRIPTION
Thought it might be desirable to have integretion/acceptance tests to prevent bugs like #1704. This uses capybara to make sure no JS errors (or actually: no unexpected errors) are thrown. In the future, we could also add more demanding tests for gollum's frontend (e.g. to make sure an update to ACE or other JS assets don't break the editor).

@benjaminwil @bartkamphorst do you think tests like these are desirable? If so, do we want to get them to work on travis, or just run them locally?