### PR TITLE
Ensure <title> is rendered for pages

### DIFF
--- a/lib/gollum/views/page.rb
+++ b/lib/gollum/views/page.rb
@@ -16,6 +16,11 @@ module Precious
       DEFAULT_AUTHOR = 'you'
       @@to_xml       = { :save_with => Nokogiri::XML::Node::SaveOptions::DEFAULT_XHTML ^ 1, :indent => 0, :encoding => 'UTF-8' }
 
+      def title
+        h1 = @h1_title ? page_header_from_content(@content) : false
+        h1 || @page.url_path_title # url_path_title is the metadata title if present, otherwise the filename-based title
+      end
+
       def page_header
         title
       end
@@ -262,11 +267,6 @@ module Precious
             result << "<td>" << (value.respond_to?(:each) ? table(value) : CGI.escapeHTML(value.to_s)) << "</td>\n"
           end
         result << "</tr>\n</table>\n"
-      end
-
-      def title
-        h1 = @h1_title ? page_header_from_content(@content) : false
-        h1 || @page.url_path_title # url_path_title is the metadata title if present, otherwise the filename-based title
       end
     end
   end

--- a/test/test_page_view.rb
+++ b/test/test_page_view.rb
@@ -38,7 +38,31 @@ context "Precious::Views::Page" do
     assert_include @view.breadcrumb, "数学 📘"
   end
 
-  test "page header retains unicde and ASCII characters" do
+  test 'page <title> is the page header from content, if present' do
+    page_title = 'Page header from content'
+    @wiki.write_page(page_title, :markdown, 'Contents', commit_details)
+
+    @view = Precious::Views::Page.new.tap do |view|
+      view.instance_variable_set :@page, @wiki.page(page_title)
+      view.instance_variable_set :@h1_title, true
+    end
+
+    assert_equal @view.title, 'Page header from content'
+  end
+
+  test 'page <title> is URL path title if no h1 present' do
+    @wiki.write_page('dir/My path title', :markdown, 'Contents', commit_details)
+    page = @wiki.page('dir/My path title')
+
+    @view = Precious::Views::Page.new.tap do |view|
+      view.instance_variable_set :@page, page
+      view.instance_variable_set :@h1_title, false
+    end
+
+    assert_equal @view.title, 'My path title'
+  end
+
+  test "page header retains unicode and ASCII characters" do
     title = "数学 📘"
     @wiki.write_page(title, :markdown, "How old is Bilbo?")
     page = @wiki.page(title)


### PR DESCRIPTION
Fixes #1709.

I made a mistake when I made `#title` a private method. I did not see
that it was being called from `layout.mustache` to generate the
`<title></title>` tag in the `<head></head>` of each page.

This fixes my error, and adds tests so the behaviour is more explicit.
