### PR TITLE
Use ranked search

### DIFF
--- a/lib/gollum/templates/search.mustache
+++ b/lib/gollum/templates/search.mustache
@@ -13,7 +13,7 @@
   <div class="Box-header border-bottom p-0"></div>
   {{#results}}
     <li class="Box-row Box-row--gray">
-      <span class="Counter Counter--gray tooltipped tooltipped-w" aria-label="{{filename_count}} hits in filename - {{count}} hits in content">{{filename_count}} - {{count}}</span>&nbsp;
+      <span class="Counter Counter--gray tooltipped tooltipped-w" aria-label="rank {{rank}} - {{filename_count}} hits in filename - {{count}} hits in content">{{rank}} - {{filename_count}} - {{count}}</span>&nbsp;
       <span class="text-bold"><a href="{{href}}">{{name}}</a></span>
       <button class="btn-link tooltipped tooltipped-w float-right toggle-context" aria-label="Show all {{count}} hits in this page">{{#octicon}}search{{/octicon}}</button>
     </li>

--- a/lib/gollum/views/search.rb
+++ b/lib/gollum/views/search.rb
@@ -9,11 +9,13 @@ module Precious
           if b.nil?
             b_filename_count = 0
             b_count          = 0
+            b_rank           = 0
           else
             b_filename_count = b[:filename_count]
             b_count          = b[:count]
+            b_rank           = b[:rank]
           end
-          [a[:filename_count], a[:count]] <=> [b_filename_count, b_count]
+          [a[:rank], a[:filename_count], a[:count]] <=> [b_rank, b_filename_count, b_count]
         end.reverse.slice((@page_num - 1) * @max_count, @max_count)
         sorted.each {|x| x[:href] = page_route(x[:name])}
       end


### PR DESCRIPTION
In a project using gollum for documentation it came up that the search was not as helpful as it could be.
One has to search for "relevant" results in the result list.

The request came up to improve the search by implementing a rank.

The "main" change of this is to gollum-lib. A separate pull request was created in the gollum-lib Repository.

To actually use the rank of gollum-lib, adaptions must be made to the search.mustache template to actually display the rank and to the search.rb view to sort the result based on the rank.