### PR TITLE
fixes #1723: Github Actions Supported

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,9 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [2.4.0, 2.6.0, 3.0.0]
-        # https://github.com/jruby/jruby/issues/4834
-        # Not including jruby due to issue above
+        ruby: [2.4.0, 2.6.0, 3.0.0, jruby-9.2.18.0]
     steps:
       - run: echo "The job was automatically triggered by a ${{ github.event_name }} event."
       - run: echo "This job is now running on a ${{ runner.os }} server hosted by GitHub!"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,31 @@
+name: Ruby Build
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby: [2.4.0, 2.6.0, 3.0.0]
+        # https://github.com/jruby/jruby/issues/4834
+        # Not including jruby due to issue above
+    steps:
+      - run: echo "The job was automatically triggered by a ${{ github.event_name }} event."
+      - run: echo "This job is now running on a ${{ runner.os }} server hosted by GitHub!"
+      - run: echo "The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - run: echo "The ${{ github.repository }} repository has been cloned to the runner."
+      - run: echo "The workflow is now ready to test your code on the runner."
+      - name: List files in the repository
+        run: |
+          ls ${{ github.workspace }}
+      - uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: '9'
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - name: exec rake
+        run: bundle exec rake

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ Gemfile.lock
 .*
 !.sprockets*
 !lib/gollum/public/gollum/stylesheets/_styles.css
+!.github*

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ rvm:
   - 2.4.0
   - 2.6.0
   - 3.0.0
-  - jruby-9.2.9.0
 jdk:
   - oraclejdk9
 before_install:

--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@ gollum -- A git-based Wiki
 ====================================
 
 [![Gem Version](https://badge.fury.io/rb/gollum.svg)](http://badge.fury.io/rb/gollum)
-[![Build Status](https://travis-ci.org/gollum/gollum.svg?branch=master)](https://travis-ci.org/gollum/gollum)
+![Build Status](https://github.com/gollum/gollum/actions/workflows/test.yaml/badge.svg)
 [![Open Source Helpers](https://www.codetriage.com/gollum/gollum/badges/users.svg)](https://www.codetriage.com/gollum/gollum)
 [![Cutting Edge Dependency Status](https://dometto-cuttingedge.herokuapp.com/github/gollum/gollum/svg 'Cutting Edge Dependency Status')](https://dometto-cuttingedge.herokuapp.com/github/gollum/gollum/info)
+
 
 **Gollum version 5.0 is out!** See [here](https://github.com/gollum/gollum/wiki/5.0-release-notes) for a list of changes and new features compared to Gollum version 4.x, and see some [Screenshots](https://github.com/gollum/gollum/wiki/Screenshots) of Gollum's features.
 

--- a/test/test_migrate.rb
+++ b/test/test_migrate.rb
@@ -44,7 +44,7 @@ def load_script(**args)
   end  
 end
 
-unless ENV['TRAVIS']
+unless ENV['CI']
 
   context '4.x -> 5.x tag migrator' do
     include Rack::Test::Methods


### PR DESCRIPTION
- This is to switch from Travis CI which is shutting down the org version,
  and the .com version, a free account is limited.
- Switch test environment variable from TRAVIS to CI to be more generic.