### PR TITLE
Use recent JRuby release for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ rvm:
   - 2.4.0
   - 2.6.0
   - 3.0.0
-  - jruby-9.2.9.0
+  - jruby-9.2.18.0
 jdk:
   - oraclejdk9
 before_install:


### PR DESCRIPTION
Our JRuby CI runs have been errorring due to what I think is an issue with an older `jruby-openssl` version.