### PR TITLE
Force utf8 encoding for diffs

### DIFF
--- a/lib/gollum/app.rb
+++ b/lib/gollum/app.rb
@@ -410,7 +410,7 @@ module Precious
         else
           sha2, sha1 = sha1, "#{sha1}^" if !sha2
           @versions  = [sha1, sha2]
-          @diff      = wiki.repo.diff(@versions.first, @versions.last, @page.path)
+          @diff      = wiki.repo.diff(@versions.first, @versions.last, @page.path).force_encoding('utf-8')
           @message   = 'The patch does not apply.'
           mustache :compare
         end
@@ -475,7 +475,7 @@ module Precious
         @versions = [start_version, end_version]
         wiki      = wikip.wiki
         @page     = wikip.page
-        @diff     = wiki.repo.diff(@versions.first, @versions.last, @page.path)
+        @diff     = wiki.repo.diff(@versions.first, @versions.last, @page.path).force_encoding('utf-8')
         if @diff.empty?
           @message = 'Could not compare these two revisions, no differences were found.'
           mustache :error
@@ -519,7 +519,7 @@ module Precious
           @commit = wiki.repo.commit(version)
           parent = @commit.parent
           parent_id = parent.nil? ? nil : parent.id
-          @diff = wiki.repo.diff(parent_id, version)
+          @diff = wiki.repo.diff(parent_id, version).force_encoding('utf-8')
           mustache :commit
         rescue Gollum::Git::NoSuchShaFound
           @message = "Invalid commit: #{@version}"

--- a/test/test_app.rb
+++ b/test/test_app.rb
@@ -47,6 +47,15 @@ context "Frontend" do
     get '/gollum/assets/mathjax/MathJax.js'
     assert last_response.ok?
   end
+  
+  test 'compare with utf8' do
+    commit = { :name => 'user1', :email => 'user1' }
+    @wiki.write_page('Utf8', :markdown, '\n中文', commit)
+    page = @wiki.page('Utf8')
+    @wiki.update_page(page, nil, nil, "No utf-8", commit)
+    get "/gollum/compare/Utf8.md/#{page.versions.first.id}..#{page.versions.last.id}"
+    assert last_response.body.include?('<div class="gi pl-2">+\n中文</div>')
+  end
 
   test "UTF-8 headers href preserved" do
     page = 'utfh1'


### PR DESCRIPTION
This PR fixes #1747. I've included a regression test.

The problem turns out to be with the `@diff` variable used by the `Compare` view. This is the result of a more or less direct git operation, for which `rugged` was apparently returning non-utf8 formatted data. I am wondering about where best to do the required `force_encoding`, though:

1. In `gollum-lib`?
2. In the adapter?
3. In the view?