### PR TITLE
Reduce size of container image

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -34,5 +34,5 @@ jobs:
         run: echo ${{ steps.docker_build.outputs.digest }}
       - name: docker state
         run: docker image ls
-      - name: Run tests
+      - name: Run gollum as test
         run: docker run -e CI=true -w /app ${{ env.CI_IMAGE }} --versions

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -35,4 +35,4 @@ jobs:
       - name: docker state
         run: docker image ls
       - name: Run gollum as test
-        run: echo "exit" | docker run -e CI=true ${{ env.CI_IMAGE }} --irb
+        run: docker run -e CI=true ${{ env.CI_IMAGE }} --irb

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -35,4 +35,4 @@ jobs:
       - name: docker state
         run: docker image ls
       - name: Run gollum as test
-        run: docker run -e CI=true ${{ env.CI_IMAGE }} --h1-title
+        run: echo "exit" | docker run -a stdin -e CI=true ${{ env.CI_IMAGE }} --irb

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -35,6 +35,4 @@ jobs:
       - name: docker state
         run: docker image ls
       - name: Run gollum as test
-        run: docker run -e CI=true ${{ env.CI_IMAGE }} --versions
-      - name: Check git repo present
-        run: docker run -e CI=true --entrypoint git ${{ env.CI_IMAGE }} -C /wiki rev-parse
+        run: docker run -e CI=true ${{ env.CI_IMAGE }} --h1-title

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -34,7 +34,7 @@ jobs:
         run: echo ${{ steps.docker_build.outputs.digest }}
       - name: docker state
         run: docker image ls
-      - name: Check git repo present
-        run: docker run -e CI=true --entrypoint git ${{ env.CI_IMAGE }} -C /wiki rev-parse
       - name: Run gollum as test
         run: docker run -e CI=true ${{ env.CI_IMAGE }} --versions
+      - name: Check git repo present
+        run: docker run -e CI=true --entrypoint git ${{ env.CI_IMAGE }} -C /wiki rev-parse

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -34,5 +34,7 @@ jobs:
         run: echo ${{ steps.docker_build.outputs.digest }}
       - name: docker state
         run: docker image ls
+      - name: Check git repo present
+        run: docker run -e CI=true --entryrpoint git ${{ env.CI_IMAGE }} -C /app rev-parse
       - name: Run gollum as test
         run: docker run -e CI=true -w /app ${{ env.CI_IMAGE }} --versions

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -35,6 +35,6 @@ jobs:
       - name: docker state
         run: docker image ls
       - name: Check git repo present
-        run: docker run -e CI=true --entryrpoint git ${{ env.CI_IMAGE }} -C /app rev-parse
+        run: docker run -e CI=true --entrypoint git ${{ env.CI_IMAGE }} -C /app rev-parse
       - name: Run gollum as test
         run: docker run -e CI=true -w /app ${{ env.CI_IMAGE }} --versions

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -35,6 +35,6 @@ jobs:
       - name: docker state
         run: docker image ls
       - name: Check git repo present
-        run: docker run -e CI=true --entrypoint git ${{ env.CI_IMAGE }} -C /app rev-parse
+        run: docker run -e CI=true --entrypoint git ${{ env.CI_IMAGE }} -C /wiki rev-parse
       - name: Run gollum as test
-        run: docker run -e CI=true -w /app ${{ env.CI_IMAGE }} --versions
+        run: docker run -e CI=true ${{ env.CI_IMAGE }} --versions

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -35,4 +35,4 @@ jobs:
       - name: docker state
         run: docker image ls
       - name: Run gollum as test
-        run: echo "exit" | docker run -a stdin -e CI=true ${{ env.CI_IMAGE }} --irb
+        run: echo "exit" | docker run -e CI=true ${{ env.CI_IMAGE }} --irb

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -35,4 +35,4 @@ jobs:
       - name: docker state
         run: docker image ls
       - name: Run tests
-        run: docker run -e CI=true -w /app --entrypoint bundle ${{ env.CI_IMAGE }} exec rake
+        run: docker run -e CI=true -w /app ${{ env.CI_IMAGE }} --versions

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
-FROM ruby:2.7
-ENV DEBIAN_FRONTEND="noninteractive"
+FROM ruby:2.7-alpine AS builder
 
-RUN apt-get update && apt-get install -y \
-    libicu-dev \
-    cmake
+RUN apk add \
+    build-base \
+    cmake \
+    git \
+    icu-dev \
+    openssl-dev
 
 COPY Gemfile* /tmp/
 COPY gollum.gemspec* /tmp/
@@ -22,6 +24,15 @@ RUN gem install \
 WORKDIR /app
 COPY . /app
 RUN bundle exec rake install
+
+
+FROM ruby:2.7-alpine
+
+COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
+
+RUN apk add \
+    bash \
+    git
 
 VOLUME /wiki
 WORKDIR /wiki

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -7,4 +7,4 @@ fi
 
 # Start gollum service
 [[ "$@" != *--mathjax* ]] && echo "WARNING: Mathjax will soon be disabled by default. To explicitly enable it, use --mathjax" >&2
-exec gollum "$@" --mathjax
+exec gollum "$@ --mathjax"

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -7,4 +7,4 @@ fi
 
 # Start gollum service
 [[ "$@" != *--mathjax* ]] && echo "WARNING: Mathjax will soon be disabled by default. To explicitly enable it, use --mathjax" >&2
-exec gollum "$@ --mathjax"
+exec gollum $@ --mathjax

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -6,4 +6,5 @@ if [ ! -d .git ]; then
 fi
 
 # Start gollum service
-exec gollum "$@"
+[[ "$@" != *--mathjax* ]] && echo "WARNING: Mathjax will soon be disabled by default. To explicitly enable it, use --mathjax" >&2
+exec gollum "$@" --mathjax

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -6,5 +6,4 @@ if [ ! -d .git ]; then
 fi
 
 # Start gollum service
-[[ "$@" != *--mathjax* ]] && echo "WARNING: Mathjax will soon be disabled by default. To explicitly enable it, use --mathjax" >&2
-exec gollum "$@ --ajax"
+exec gollum "$@"

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -6,4 +6,4 @@ if [ ! -d .git ]; then
 fi
 
 # Start gollum service
-gollum --mathjax
+exec gollum "$@"

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -6,4 +6,5 @@ if [ ! -d .git ]; then
 fi
 
 # Start gollum service
-exec gollum "$@"
+[[ "$@" != *--mathjax* ]] && echo "WARNING: Mathjax will soon be disabled by default. To explicitly enable it, use --mathjax" >&2
+exec gollum "$@ --ajax"


### PR DESCRIPTION
This change reduces the size of the Docker image from 446 MB to 126 MB (-71%). This can be tested using the public [`rgov/gollum`](https://hub.docker.com/repository/docker/rgov/gollum) image.

The new image also makes it possible to pass arguments to the `gollum` process (e.g., `docker run gollumorg/gollum --config=...`). Previously the image only passed `--mathjax`. (**Note:** After applying this change, users will have to explicitly pass `--mathjax`.)

The smaller image image is based on Alpine Linux instead of Debian Bullseye. It also uses a separate build stage for compiling and installing the gem dependencies, which are then copied over to the final image.

I tested the new image by browsing an existing wiki, creating a new page, editing it, previewing the edits, and uploading a file.

Note that `libicu` and `openssl` are both build-time dependencies that do not appear to be needed at runtime so they are no longer in the final image.