### PR TITLE
Added docker environment variables for cmdline options, author, and email. Resolves #702

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ Gemfile.lock
 !.sprockets*
 !lib/gollum/public/gollum/stylesheets/_styles.css
 !.github*
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,4 +26,4 @@ RUN bundle exec rake install
 VOLUME /wiki
 WORKDIR /wiki
 COPY docker-run.rb /docker-run.rb
-ENTRYPOINT ["/docker-run.rb"]
+ENTRYPOINT "/docker-run.rb" $GOLLUM_OPTIONS

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,5 +25,5 @@ RUN bundle exec rake install
 
 VOLUME /wiki
 WORKDIR /wiki
-COPY docker-run.sh /docker-run.sh
-ENTRYPOINT ["/docker-run.sh"]
+COPY docker-run.rb /docker-run.rb
+ENTRYPOINT ["/docker-run.rb"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "3"
+services:
+  gollum:
+    image: "gollum"
+    build:
+      context: ./
+    ports:
+      - "4567:4567"
+    volumes:
+      - "./wiki:/wiki"
+    environment:
+      GOLLUM_AUTHOR_USERNAME: "${GOLLUM_AUTHOR_USERNAME}"
+      GOLLUM_AUTHOR_EMAIL: "${GOLLUM_AUTHOR_EMAIL}"
+      GOLLUM_OPTIONS: "${GOLLUM_OPTIONS}"

--- a/docker-run.rb
+++ b/docker-run.rb
@@ -1,0 +1,21 @@
+#!/usr/bin/env ruby
+require 'rubygems'
+require 'gollum/app'
+
+# Initialize the wiki
+if !File.directory?('.git')
+  `git init`
+end
+
+# Add in commit user/email
+class Precious::App
+  before do
+    session['gollum.author'] = {
+      :name => ENV['GOLLUM_AUTHOR_USERNAME'].to_s != '' ? ENV['GOLLUM_AUTHOR_USERNAME'] : 'Anonymous',
+      :email => ENV['GOLLUM_AUTHOR_EMAIL'].to_s != '' ? ENV['GOLLUM_AUTHOR_EMAIL'] : 'anon@anon.com',
+    }
+  end
+end
+
+# Start gollum service
+load '/usr/local/bundle/bin/gollum'

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-# Initialize the wiki
-if [ ! -d .git ]; then
-    git init
-fi
-
-# Start gollum service
-gollum --mathjax


### PR DESCRIPTION
This PR adds docker support for several things.

- docker-compose file (easier to start a container with this)
- added environment variable for git author
- added environment variable for git email
- added environment variable for gollum cmdline options, e.g. "--h1-title --allow-uploads"

This was all adapted from https://github.com/pjeby/gollum-portable except this PR changes the existing setup very little.

To use the environment variables rename .env_example to .env and edit the variables. The docker-compose.yml file can also be edited but that is less desirable then editing .env.

I believe I've dotted all the i's and crossed all the t's. Please let me know if there's more I can do to get this PR accepted.