### PR TITLE
Update gollum launch script

### DIFF
--- a/bin/gollum
+++ b/bin/gollum
@@ -206,7 +206,7 @@ begin
 rescue OptionParser::InvalidOption => e
   puts "gollum: #{e.message}"
   puts 'gollum: try \'gollum --help\' for more information'
-  exit
+  exit 1
 end
 
 # --gollum-path wins over ARGV[0]


### PR DESCRIPTION
Exit with code 1 (error) when invalid option is given (as is standard for unix programs).