### PR TITLE
Remove explicit nokogori version requirement. Resolves #1779

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [jruby-9.2.18]
+        ruby: [jruby-9.3.2.0]
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2

--- a/Gemfile
+++ b/Gemfile
@@ -17,9 +17,6 @@ gem 'warbler', platforms: :jruby
 # Note that Nokogiri 1.11+ does not support Ruby v2.4.x anymore. So to make our
 # current CI workflows pass, we should only try to install this version of
 # Nokogiri for newer Ruby versions.
-#
-# [1]: https://github.com/gollum/gollum/issues/1779
-gem 'nokogiri', '1.12.4' unless RUBY_VERSION.include? '2.4'
 
 gemspec
 

--- a/gollum.gemspec
+++ b/gollum.gemspec
@@ -2,7 +2,7 @@ Gem::Specification.new do |s|
   s.specification_version = 2 if s.respond_to? :specification_version=
   s.required_rubygems_version = Gem::Requirement.new('>= 0') if s.respond_to? :required_rubygems_version=
   s.rubygems_version = '1.3.5'
-  s.required_ruby_version = '>= 1.9'
+  s.required_ruby_version = '>= 2.6'
 
   s.name              = 'gollum'
   s.version           = '5.2.3'


### PR DESCRIPTION
No longer needed after nokogiri's recent release, see https://github.com/gollum/gollum/issues/1779