### PR TITLE
Support versioned Docker builds

### DIFF
--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -1,12 +1,20 @@
 name: Deploy docker
-on: [push]
-env:
-  DEPLOY_NAME: gollumwiki/gollum:latest
+on:
+  push:
+    branches:
+      - master
+  release:
+      types: [published]
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: ${{ github.ref == 'refs/heads/master' }}
     steps:
+      - name: Set deploy name to master
+        if: github.ref == 'refs/heads/master'
+        run: | echo "DEPLOY_NAME=gollumwiki/gollum:master"
+      - name: Set deploy name to release version
+        if: startsWith(github.ref, 'refs/tags/')
+        run: | echo "DEPLOY_NAME=gollumwiki/gollum:${{ github.ref_name }}"
       - name: Check Out Repo
         uses: actions/checkout@v2
       - name: Login

--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -11,10 +11,12 @@ jobs:
     steps:
       - name: Set deploy name to master
         if: github.ref == 'refs/heads/master'
-        run: | echo "DEPLOY_NAME=gollumwiki/gollum:master"
+        run: |
+          echo "DEPLOY_NAME=gollumwiki/gollum:master"
       - name: Set deploy name to release version
         if: startsWith(github.ref, 'refs/tags/')
-        run: | echo "DEPLOY_NAME=gollumwiki/gollum:${{ github.ref_name }}"
+        run: |
+          echo "DEPLOY_NAME=gollumwiki/gollum:${{ github.ref_name }}"
       - name: Check Out Repo
         uses: actions/checkout@v2
       - name: Login


### PR DESCRIPTION
This PR

1. Also builds/deploys the Docker image on new releases, not just on pushes
2. Conditionally sets the DockerHub tag to either `master` in case of a push or the tag name (e.g. `v5.2.3`) in case of a release

I have stopped using the label `latest` because many seem to recommend against using that label, since it is confusing: https://vsupalov.com/docker-latest-tag/

Specifically, in our case, it could be understood to refer to the lastest *stable* version. But `master` is sometimes not stable (for instance when we add features that also require changes to gollum-lib). I think using the tag `master` for the Docker image is more descriptive, but open to other suggestions! (Could also be e.g. `nightly-2021-01-11`, etc.)