### PR TITLE
Restore the normalize check that appears to be inadvertantly removed

### DIFF
--- a/lib/gollum/app.rb
+++ b/lib/gollum/app.rb
@@ -274,7 +274,7 @@ module Precious
           options.merge! author
         end
 
-        normalize = Gollum::Page.valid_extension?(fullname)
+        options[:normalize] = Gollum::Page.valid_extension?(fullname)
 
         begin
           wiki.write_file(reponame, contents, options)


### PR DESCRIPTION
Originally there was a problem #1306 for image uploads. I installed the latest version of gollum and noticed that this was still a problem, although....

@bartkamphorst had provided a fix #1353

But it appears that this was inadvertently destroyed by @dometto in #1369 (I don't think he intended to remove this, because he didn't remove the variable `normalize` which was created, but rather when he consolidated the code to `write_file` he just accidentally removed the option that was inline, as he'd created a new one with large scope, but didn't populate it with the `normalize` variable)

So this is a very trivial PR, it's just adding the normalize variable into the options.

So compare the commits: https://github.com/gollum/gollum/commit/ca9702088f2c5cec86d99f9c4fe019dccc2bd637 and https://github.com/gollum/gollum/commit/b40a344c495c4317b2aadc32cdf7a5358c3d5ef7