### PR TITLE
Switch from TestUnit to Minitest

### DIFF
--- a/bin/gollum-migrate-tags
+++ b/bin/gollum-migrate-tags
@@ -11,8 +11,11 @@ migrate_options = {
   :hyphenate => true
 }
 
-def setting(const)
-  Object.const_defined?(const.upcase) && Object.const_get(const.upcase)
+def setting(variable_name)
+  class_variable_name = :"@@#{variable_name.to_s}"
+
+  Object.class_variable_defined?(class_variable_name) &&
+    Object.class_variable_get(class_variable_name)
 end
 
 opts = OptionParser.new do |opts|
@@ -25,7 +28,7 @@ It finds and repairs Gollum link tags that no longer work under 5.x for three re
 * 5.x wiki internal links are no longer 'global'.
 
 * NB: you can use the --lenient-tag-lookup option in gollum >= 5.x to enable 4.x-backwards compatible tags.
-  
+
 See https://github.com/gollum/gollum/wiki/5.0-release-notes#filename-handling for more information.
 Usage of this script comes without any warranty.
 
@@ -38,7 +41,7 @@ You can use the --page-file-dir and --config options as you would normally with 
 Requires a non-bare repository. Recommended usage:
 
 1. Clone your wiki's repository to create a backup.
-2. Run this script on your cloned repo. 
+2. Run this script on your cloned repo.
 3. If all looks sane, run the script with the --write option. This will overwrite files in your working directory, but not commit the changes, so you have time to review them.
 4. Do a 'git diff' to inspect the changes.
 5. Commit the changes if all looks sane, and push/pull them back into your original repo.
@@ -52,23 +55,23 @@ EOF
   opts.on('--page-file-dir [PATH]', 'Specify the subdirectory for all pages. Default: repository root.') do |path|
     wiki_options[:page_file_dir] = path
   end
-    
+
   opts.on('--prefer-relative-links', 'When specified, will try to replace broken links with relative links (\'[[Foo/Bar]]\' instead of \'[[/Subdir/Foo/Bar]]\') where possible.') do
     migrate_options[:prefer_relative] = true
   end
-  
+
   opts.on('--hyphenate', 'Default. Repair links that use spaces instead of hyphens: [[Bilbo Baggins]] -> [[Bilbo-Baggins]]') do
     migrate_options[:hyphenate] = true
   end
-  
+
   opts.on('--no-hyphenate', 'Turn off the --hyphenate option.') do
     migrate_options[:hyphenate] = false
   end
-  
+
   opts.on('--run-silent', 'Don\'t output anything.') do
     migrate_options[:run_silent] = true
   end
-  
+
   opts.on('--write', 'No dry run: actually perform the substitutions.') do
     migrate_options[:no_dry_run] = true
   end
@@ -78,8 +81,11 @@ end
 begin
   opts.parse!
   migrate_options.each do |setting, value|
-    const = setting.to_s.upcase
-    Object.const_set(const, value) unless Object.const_defined?(const)
+    variable_name = :"@@#{setting.to_s}"
+
+    unless Object.class_variable_defined?(variable_name)
+      Object.class_variable_set(variable_name, value)
+    end
   end
   wiki_options[:page_file_dir] = setting(:page_file_dir) ? setting(:page_file_dir) : wiki_options[:page_file_dir] # Allow settings :page_file_dir through PAGE_FILE_DIR constant.
 rescue OptionParser::InvalidOption
@@ -88,7 +94,7 @@ rescue OptionParser::InvalidOption
   exit
 end
 
-REPO = ARGV[0] || Dir.pwd
+wiki_directory = ARGV[0] || Dir.pwd
 
 require 'gollum-lib'
 
@@ -98,7 +104,7 @@ if cfg = options[:config]
   cfg = File.join(Dir.getwd, cfg) unless cfg.slice(0) == File::SEPARATOR
   require cfg
 end
-  
+
 class Gollum::Filter::CodeMigrator < Gollum::Filter::Code
   def extract(data)
     case @markup.format
@@ -126,7 +132,7 @@ class Gollum::Filter::CodeMigrator < Gollum::Filter::Code
         next '' if m_end.length < m_start.length
         lang = m_lang ? m_lang.strip.split.first : nil
         cache_codeblock($~.to_s)
-      end  
+      end
     end
 
     data.gsub!(/^([ ]{0,3})``` ?([^\r\n]+)?\r?\n(.+?)\r?\n[ ]{0,3}```[ \t]*\r?$/m) do
@@ -134,7 +140,7 @@ class Gollum::Filter::CodeMigrator < Gollum::Filter::Code
     end
     data
   end
-  
+
   def process(data)
     return data if data.nil? || data.size.zero? || @map.size.zero?
     @map.each do |id, block| ## Just put the code blocks back in verbatim
@@ -142,23 +148,23 @@ class Gollum::Filter::CodeMigrator < Gollum::Filter::Code
     end
     data
   end
-  
+
   def cache_codeblock(block)
     id = "#{open_pattern}#{Digest::SHA1.hexdigest(block)}#{close_pattern}"
     @map[id] = block
     id
   end
 end
-  
+
 class ::Gollum::Filter::TagMigrator < Gollum::Filter::Tags
   def process_tag(tag)
     link_part, extra = parse_tag_parts(tag)
     orig_tag = %{[[#{tag}]]}
     return orig_tag if link_part.nil?
-    
+
     img_args = extra ? [extra, link_part] : [link_part]
     mime = MIME::Types.type_for(::File.extname(img_args.first.to_s)).first
-    
+
     # For any kind of tag other than an internal link: just return the tag.
     if tag =~ /^_TOC_/ || link_part =~ /^_$/ || link_part =~ /^#{INCLUDE_TAG}/ || (mime && mime.content_type =~ /^image/) || process_external_link_tag(link_part, extra) || process_file_link_tag(link_part, extra)
       return orig_tag
@@ -168,7 +174,7 @@ class ::Gollum::Filter::TagMigrator < Gollum::Filter::Tags
     link = link_part
     page = find_page_or_file_from_path(link)
     anchor = nil
-    
+
     if page.nil? # No match yet, now try finding the page with anchor removed
       if pos = link.rindex('#')
         anchor = link[pos..-1]
@@ -203,12 +209,12 @@ class ::Gollum::Filter::TagMigrator < Gollum::Filter::Tags
         pick = possibles.first
         return tag_for_pick(pick, orig_tag, extra, anchor, @markup.page.path)
       end
-        
+
     end
   end
-  
+
   private
-  
+
   def tag_for_pick(pick, orig_tag, extra, anchor, linking_page_path)
     pick = if setting(:prefer_relative)
       overlapping_path = Pathname.new(linking_page_path).dirname.to_s
@@ -220,7 +226,7 @@ class ::Gollum::Filter::TagMigrator < Gollum::Filter::Tags
     end
     new_tag = extra.nil? ? %{[[#{pick}#{anchor}]]} : %{[[#{extra}|#{pick}#{anchor}]]}
     log(:info, "#{@markup.page.path}: Changing #{orig_tag} -> #{new_tag}")
-    new_tag    
+    new_tag
   end
 end
 
@@ -232,8 +238,12 @@ end
 
 filter_chain = [:PlainTextMigrator, :CodeMigrator, :TagMigrator]
 
-wiki = ::Gollum::Wiki.new(REPO, wiki_options.merge({:filter_chain => filter_chain}))
-TREE = wiki.tree_list(wiki.ref, true, true).map {|file| ::File.join('/', file.path)}
+wiki = ::Gollum::Wiki.new(wiki_directory, wiki_options.merge({:filter_chain => filter_chain}))
+
+Object.class_variable_set(
+  :"@@wiki_tree",
+  wiki.tree_list(wiki.ref, true, true).map {|file| ::File.join('/', file.path)}
+)
 
 def find_linked(link)
   link.gsub!(' ', '-') if setting(:hyphenate) # Match paths containing dashes instead of spaces
@@ -243,7 +253,9 @@ def find_linked(link)
   test_path = ::File.extname(link).empty? ? /#{link}\..+/ : link
   # Select pages from the wiki whose path =~ 'Foo/Bar/Samwi.*'
   # Match case-insenstively to mimic 4.x behavior!
-  TREE.select {|path| path =~ /^\/(.*\/)?#{test_path}/i}
+  Object.class_variable_get(:"@@wiki_tree").select { |path|
+    path =~ /^\/(.*\/)?#{test_path}/i
+  }
 end
 
 def log(kind, msg = nil)

--- a/lib/gollum/app.rb
+++ b/lib/gollum/app.rb
@@ -103,16 +103,13 @@ module Precious
     end
 
     before do
-      settings.wiki_options[:allow_editing] = settings.wiki_options.fetch(:allow_editing, true)
-      @allow_editing = settings.wiki_options[:allow_editing]
+      @allow_editing = settings.wiki_options.fetch(:allow_editing, true)
       @critic_markup = settings.wiki_options[:critic_markup]
       @redirects_enabled = settings.wiki_options.fetch(:redirects_enabled, true)
       @per_page_uploads = settings.wiki_options[:per_page_uploads]
       @show_local_time = settings.wiki_options.fetch(:show_local_time, false)
       
       @wiki_title = settings.wiki_options.fetch(:title, 'Gollum Wiki')
-
-      forbid unless @allow_editing || request.request_method == 'GET'
 
       if settings.wiki_options[:template_dir]
         Precious::Views::Layout.extend Precious::Views::TemplateCascade
@@ -143,6 +140,8 @@ module Precious
           config.manifest = Sprockets::Manifest.new(settings.sprockets, @static_assets_path)
         end
       end
+
+      forbid unless @allow_editing || request.request_method == 'GET'
     end
 
     get '/' do

--- a/lib/gollum/views/helpers/locale_helpers.rb
+++ b/lib/gollum/views/helpers/locale_helpers.rb
@@ -42,7 +42,7 @@ module Precious
       end
 
       def fill_argument_content(i18n_key, i18n_value)
-        i18n_value.gsub!(YAML_VARIABLE_REGEXP) do |argument|
+        i18n_value = i18n_value.gsub(YAML_VARIABLE_REGEXP) do |argument|
           method_name = argument.gsub(/[^\w]/, '')
 
           next if method_name.nil?

--- a/lib/gollum/views/template_cascade.rb
+++ b/lib/gollum/views/template_cascade.rb
@@ -11,9 +11,13 @@ module Precious
       end
 
       def first_path_available(name)
-        priority = File.join(template_priority_path, "#{name}.#{template_extension}")
         default = File.join(template_path, "#{name}.#{template_extension}")
-        File.exists?(priority) ? priority : default
+        priority =
+          if template_priority_path
+            File.join(template_priority_path, "#{name}.#{template_extension}")
+          end
+
+        priority && File.exists?(priority) ? priority : default
       end
 
       # Method should track lib/mustache/settings.rb from Mustache project.

--- a/lib/gollum/views/template_cascade.rb
+++ b/lib/gollum/views/template_cascade.rb
@@ -17,7 +17,7 @@ module Precious
             File.join(template_priority_path, "#{name}.#{template_extension}")
           end
 
-        priority && File.exists?(priority) ? priority : default
+        priority && File.exist?(priority) ? priority : default
       end
 
       # Method should track lib/mustache/settings.rb from Mustache project.

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -12,7 +12,9 @@ require 'tmpdir'
 require 'i18n'
 I18n.enforce_available_locales = false
 
-MiniTest::Reporters.use!
+Minitest::Reporters.use! [
+  Minitest::Reporters::DefaultReporter.new({color: true})
+]
 
 dir = File.dirname(File.expand_path(__FILE__))
 $LOAD_PATH.unshift(File.join(dir, '..', 'lib'))

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,11 +1,11 @@
 require 'rubygems'
 require 'rack/test'
-require 'test/unit'
 require 'shoulda'
-require 'mocha/setup'
-require 'fileutils'
+require 'minitest/autorun'
 require 'minitest/reporters'
 require 'minitest/spec'
+require 'mocha/setup'
+require 'fileutils'
 require 'tmpdir'
 
 # Silence locale validation warning
@@ -62,14 +62,29 @@ def normal(text)
   text
 end
 
-# test/spec/mini 3
-# http://gist.github.com/25455
-# chris@ozmm.org
-# file:lib/test/spec/mini.rb
+# The following configuration originates from this gist:
+
+#     http://gist.github.com/25455
+#
+# But it has been modified since it was first committed. It allows you to
+# write tests with an RSpec-like DSL:
+#
+#    context "my test context" do
+#      setup do
+#        # My test setup
+#      end
+#
+#      teardown do
+#        # My test teardown
+#      end
+#
+#      test "some functionality" do
+#        assert true
+#      end
+#    end
 def context(*args, &block)
   return super unless (name = args.first) && block
-  require 'test/unit'
-  klass = Class.new(defined?(ActiveSupport::TestCase) ? ActiveSupport::TestCase : Test::Unit::TestCase) do
+  klass = Class.new(Minitest::Test) do
     def self.test(name, &block)
       define_method("test_#{name.gsub(/\W/, '_')}", &block) if block
     end
@@ -85,10 +100,13 @@ def context(*args, &block)
       define_method(:teardown, &block)
     end
   end
+
   (
-  class << klass;
-    self
-  end).send(:define_method, :name) { name.gsub(/\W/, '_') }
+    class << klass;
+      self
+    end
+  ).send(:define_method, :name) { name.gsub(/\W/, '_') }
+
   $contexts << klass
   klass.class_eval &block
 end

--- a/test/test_allow_editing.rb
+++ b/test/test_allow_editing.rb
@@ -51,11 +51,11 @@ context "Precious::Views::Editing" do
 
     get '/gollum/history/A'
 
-    assert_no_match /Edit/, last_response.body, "'Edit' link is not blocked in history template"
+    refute_match /Edit/, last_response.body, "'Edit' link is not blocked in history template"
 
     get '/gollum/compare/A/fc66539528eb96f21b2bbdbf557788fe8a1196ac..b26b791cb7917c4f37dd9cb4d1e0efb24ac4d26f'
 
-    assert_no_match /Edit Page/,             last_response.body, "'Edit Page' link is not blocked in compare template"
+    refute_match /Edit Page/,             last_response.body, "'Edit Page' link is not blocked in compare template"
     assert_match /Revert Changes/,        last_response.body, "'Revert Changes' link is blocked in compare template"
   end
 
@@ -63,24 +63,24 @@ context "Precious::Views::Editing" do
     Precious::App.set(:wiki_options, { allow_editing: false })
     get '/A'
 
-    assert_no_match /Delete this Page/, last_response.body, "'Delete this Page' link not blocked in page template"
-    assert_no_match /New/,              last_response.body, "'New' button not blocked in page template"
-    assert_no_match /Upload\b/,         last_response.body, "'Upload' link not blocked in page template"
-    assert_no_match /Rename/,           last_response.body, "'Rename' link not blocked in page template"
-    assert_no_match /Edit/,             last_response.body, "'Edit' link not blocked in page template"
+    refute_match /Delete this Page/, last_response.body, "'Delete this Page' link not blocked in page template"
+    refute_match /New/,              last_response.body, "'New' button not blocked in page template"
+    refute_match /Upload\b/,         last_response.body, "'Upload' link not blocked in page template"
+    refute_match /Rename/,           last_response.body, "'Rename' link not blocked in page template"
+    refute_match /Edit/,             last_response.body, "'Edit' link not blocked in page template"
 
     get '/gollum/overview'
 
-    assert_no_match /New/, last_response.body, "'New' link not blocked in pages template"
+    refute_match /New/, last_response.body, "'New' link not blocked in pages template"
 
     get '/gollum/history/A'
 
-    assert_no_match /Edit/, last_response.body, "'Edit' link not blocked in history template"
+    refute_match /Edit/, last_response.body, "'Edit' link not blocked in history template"
 
     get '/gollum/compare/A/fc66539528eb96f21b2bbdbf557788fe8a1196ac..b26b791cb7917c4f37dd9cb4d1e0efb24ac4d26f'
 
-    assert_no_match /Edit Page/,             last_response.body, "'Edit Page' link not blocked in compare template"
-    assert_no_match /Revert Changes/,        last_response.body, "'Revert Changes' link not blocked in compare template"
+    refute_match /Edit Page/,             last_response.body, "'Edit Page' link not blocked in compare template"
+    refute_match /Revert Changes/,        last_response.body, "'Revert Changes' link not blocked in compare template"
   end
 
   def app

--- a/test/test_allow_editing.rb
+++ b/test/test_allow_editing.rb
@@ -7,15 +7,29 @@ context "Precious::Views::Editing" do
   setup do
     @path = cloned_testpath('examples/revert.git')
     Precious::App.set(:gollum_path, @path)
+    Precious::App.set(:wiki_options, {allow_editing: true, allow_uploads: true})
     @wiki = Gollum::Wiki.new(@path)
   end
 
   teardown do
+    Precious::App.set(:wiki_options, {allow_editing: true, allow_uploads: true})
     FileUtils.rm_rf(@path)
   end
 
+  test 'creating pages is not blocked' do
+    post '/gollum/create',
+      content: 'abc',
+      format: 'markdown',
+      message: 'def',
+      page: 'D'
+
+    assert_equal last_response.status, 302
+
+    refute_nil @wiki.page('D')
+  end
+
   test 'creating pages is blocked' do
-    Precious::App.set(:wiki_options, {allow_editing: false})
+    Precious::App.set(:wiki_options, {allow_editing: false, allow_uploads: false})
 
     post '/gollum/create',
       content: 'abc',
@@ -31,63 +45,62 @@ context "Precious::Views::Editing" do
   end
 
   test ".redirects.gollum file should not be accessible" do
-    Precious::App.set(:wiki_options, { allow_editing: true, allow_uploads: true })
     get '/.redirects.gollum'
     assert_match /Accessing this resource is not allowed/, last_response.body
   end
 
   test ".redirects.gollum file should not be editable" do
-    Precious::App.set(:wiki_options, { allow_editing: true, allow_uploads: true })
     get '/gollum/edit/.redirects.gollum'
     assert_match /Changing this resource is not allowed/, last_response.body
   end
 
   test "frontend links for editing are not blocked" do
-    Precious::App.set(:wiki_options, { allow_editing: true, allow_uploads: true })
     get '/A'
 
-    assert_match /Delete this Page/, last_response.body, "'Delete this Page' link is blocked in page template"
-    assert_match /New/,              last_response.body, "'New' button is blocked in page template"
-    assert_match /Upload\b/,         last_response.body, "'Upload' link is blocked in page template"
-    assert_match /Rename/,           last_response.body, "'Rename' link is blocked in page template"
-    assert_match /Edit/,             last_response.body, "'Edit' link is blocked in page template"
+    assert last_response.body.include? "Delete this Page"
+    assert last_response.body.include? "New"
+    assert last_response.body.include? "<span>Upload</span>"
+    assert last_response.body.include? "Rename"
+    assert last_response.body.include? "Edit"
 
     get '/gollum/overview'
 
-    assert_match /New/, last_response.body, "'New' link is blocked in pages template"
+    assert last_response.body.include? "New"
 
     get '/gollum/history/A'
 
-    refute_match /Edit/, last_response.body, "'Edit' link is not blocked in history template"
+    refute last_response.body.include? "Edit"
 
-    get '/gollum/compare/A/fc66539528eb96f21b2bbdbf557788fe8a1196ac..b26b791cb7917c4f37dd9cb4d1e0efb24ac4d26f'
+    get '/gollum/compare/A/fc665395..b26b791c'
 
-    refute_match /Edit Page/,             last_response.body, "'Edit Page' link is not blocked in compare template"
-    assert_match /Revert Changes/,        last_response.body, "'Revert Changes' link is blocked in compare template"
+    refute last_response.body.include? "Edit Page"
+
+    assert last_response.body.include? "Revert Changes"
   end
 
   test "frontend links for editing blocked" do
-    Precious::App.set(:wiki_options, { allow_editing: false })
+    Precious::App.set(:wiki_options, {allow_editing: false, allow_uploads: false})
+
     get '/A'
 
-    refute_match /Delete this Page/, last_response.body, "'Delete this Page' link not blocked in page template"
-    refute_match /New/,              last_response.body, "'New' button not blocked in page template"
-    refute_match /Upload\b/,         last_response.body, "'Upload' link not blocked in page template"
-    refute_match /Rename/,           last_response.body, "'Rename' link not blocked in page template"
-    refute_match /Edit/,             last_response.body, "'Edit' link not blocked in page template"
+    refute last_response.body.include? "Delete this Page"
+    refute last_response.body.include? "<span>Upload</span>"
+    refute last_response.body.include? "Rename"
+    refute last_response.body.include? "Edit"
+    refute last_response.body.include? "New"
 
     get '/gollum/overview'
 
-    refute_match /New/, last_response.body, "'New' link not blocked in pages template"
+    refute last_response.body.include? "New"
 
     get '/gollum/history/A'
 
-    refute_match /Edit/, last_response.body, "'Edit' link not blocked in history template"
+    refute last_response.body.include? "Edit"
 
-    get '/gollum/compare/A/fc66539528eb96f21b2bbdbf557788fe8a1196ac..b26b791cb7917c4f37dd9cb4d1e0efb24ac4d26f'
+    get '/gollum/compare/A/fc665395..b26b791c'
 
-    refute_match /Edit Page/,             last_response.body, "'Edit Page' link not blocked in compare template"
-    refute_match /Revert Changes/,        last_response.body, "'Revert Changes' link not blocked in compare template"
+    refute last_response.body.include? "Edit Page"
+    refute last_response.body.include? "Revert Changes"
   end
 
   def app

--- a/test/test_allow_editing.rb
+++ b/test/test_allow_editing.rb
@@ -3,8 +3,9 @@ require File.expand_path(File.join(File.dirname(__FILE__), 'helper'))
 
 context "Precious::Views::Editing" do
   include Rack::Test::Methods
+
   setup do
-    @path    = cloned_testpath('examples/revert.git')
+    @path = cloned_testpath('examples/revert.git')
     Precious::App.set(:gollum_path, @path)
     @wiki = Gollum::Wiki.new(@path)
   end
@@ -13,14 +14,20 @@ context "Precious::Views::Editing" do
     FileUtils.rm_rf(@path)
   end
 
-  test "creating page is blocked" do
-    Precious::App.set(:wiki_options, { allow_editing: false})
-    post "/gollum/create", :content => 'abc', :page => "D",
-         :format             => 'markdown', :message => 'def'
-    assert !last_response.ok?
+  test 'creating pages is blocked' do
+    Precious::App.set(:wiki_options, {allow_editing: false})
 
-    page = @wiki.page('D')
-    assert page.nil?
+    post '/gollum/create',
+      content: 'abc',
+      format: 'markdown',
+      message: 'def',
+      page: 'D'
+
+    assert last_response.body.include? 'Forbidden. This wiki is set to no-edit mode.'
+
+    refute last_response.ok?
+
+    assert_nil @wiki.page('D')
   end
 
   test ".redirects.gollum file should not be accessible" do
@@ -28,7 +35,7 @@ context "Precious::Views::Editing" do
     get '/.redirects.gollum'
     assert_match /Accessing this resource is not allowed/, last_response.body
   end
-  
+
   test ".redirects.gollum file should not be editable" do
     Precious::App.set(:wiki_options, { allow_editing: true, allow_uploads: true })
     get '/gollum/edit/.redirects.gollum'

--- a/test/test_app.rb
+++ b/test/test_app.rb
@@ -14,7 +14,7 @@ context "Frontend" do
   teardown do
     FileUtils.rm_rf(@path)
   end
-  
+
   test "utf-8 kcode" do
     assert_equal 'μ†ℱ'.scan(/./), ["μ", "†", "ℱ"]
   end
@@ -104,21 +104,21 @@ EOF
     page_2 = @wiki.page(page_1.name)
     assert_equal 'abc', page_2.raw_data
     assert_equal 'def', page_2.version.message
-    assert_not_equal page_1.version.sha, page_2.version.sha
+    refute_equal page_1.version.sha, page_2.version.sha
   end
-  
+
   test "edit page fails when page is outdated (edit collision)" do
     page = @wiki.page('A')
     old_sha = page.sha
     post "/gollum/edit/A", :content => 'abc', :page => 'A',
          :format => page.format, :message => 'def', :etag => old_sha
     assert last_response.ok?
-    
+
     @wiki.clear_cache
     page = @wiki.page('A')
     new_sha = page.sha
-    assert_not_equal old_sha, new_sha
-    
+    refute_equal old_sha, new_sha
+
     post "/gollum/edit/A", :content => 'def', :page => 'A',
          :format => page.format, :message => 'def', :etag => old_sha
     assert_equal last_response.status, 412
@@ -134,7 +134,7 @@ EOF
     page_2 = @wiki.page(page_1.name)
     assert_equal 'abc', page_2.raw_data
     assert_equal '[no message]', page_2.version.message
-    assert_not_equal page_1.version.sha, page_2.version.sha
+    refute_equal page_1.version.sha, page_2.version.sha
   end
 
   test "edit page with slash" do
@@ -165,12 +165,12 @@ EOF
     assert_equal 'header', header_2.raw_data
     assert_equal 'footer', foot_2.raw_data
     assert_equal 'def', foot_2.version.message
-    assert_not_equal foot_1.version.sha, foot_2.version.sha
-    assert_not_equal header_1.version.sha, header_2.version.sha
+    refute_equal foot_1.version.sha, foot_2.version.sha
+    refute_equal header_1.version.sha, header_2.version.sha
 
     assert_equal 'sidebar', side_2.raw_data
     assert_equal 'def', side_2.version.message
-    assert_not_equal side_1.version.sha, side_2.version.sha
+    refute_equal side_1.version.sha, side_2.version.sha
     assert_equal commits, @wiki.repo.commits('master').size
   end
 
@@ -187,7 +187,7 @@ EOF
     page_2 = @wiki.page('C')
     assert_equal "INITIAL\n\nSPAM2\n", page_2.raw_data
     assert_equal 'def', page_2.last_version.message
-    assert_not_equal page_1.version.sha, page_2.version.sha
+    refute_equal page_1.version.sha, page_2.version.sha
   end
 
   test "rename preserves format" do
@@ -222,7 +222,7 @@ EOF
 
   test "renames page in subdirectory" do
     page_1 = @wiki.page("G/H")
-    assert_not_equal page_1, nil
+    refute_equal page_1, nil
     post "/gollum/rename/G/H", :rename => "/I/C", :message => 'def'
 
     follow_redirect!
@@ -234,12 +234,12 @@ EOF
     page_2 = @wiki.page('I/C')
     assert_equal "INITIAL\n\nSPAM2\n", page_2.raw_data
     assert_equal 'def', page_2.last_version.message
-    assert_not_equal page_1.version.sha, page_2.version.sha
+    refute_equal page_1.version.sha, page_2.version.sha
   end
 
   test "renames page relative in subdirectory" do
     page_1 = @wiki.page("G/H")
-    assert_not_equal page_1, nil
+    refute_equal page_1, nil
     post "/gollum/rename/G/H", :rename => "K/C", :message => 'def'
 
     follow_redirect!
@@ -251,7 +251,7 @@ EOF
     page_2 = @wiki.page('G/K/C')
     assert_equal "INITIAL\n\nSPAM2\n", page_2.raw_data
     assert_equal 'def', page_2.last_version.message
-    assert_not_equal page_1.version.sha, page_2.version.sha
+    refute_equal page_1.version.sha, page_2.version.sha
   end
 
   test "creates page" do
@@ -320,7 +320,7 @@ EOF
     name = "#{dir}/bar"
     get "/gollum/create/#{name}"
     assert_match(/\/#{dir}/, last_response.body)
-    assert_no_match(/[^\/]#{dir}/, last_response.body)
+    refute_match(/[^\/]#{dir}/, last_response.body)
   end
 
   test "create with template succeed if template exists" do
@@ -351,7 +351,7 @@ EOF
     post '/gollum/edit/', :content => 'edit_msg',
          :page              => page, :path => path, :message => ''
     page_e = @wiki.page(::File.join(path,page))
-    assert_equal nil, page_e
+    assert_nil page_e
   end
 
   test "edit allows changing format" do
@@ -407,23 +407,23 @@ EOF
 
     @wiki.clear_cache
     page = @wiki.page(name)
-    assert_not_equal 'abc', page.raw_data
+    refute_equal 'abc', page.raw_data
   end
-  
+
   test "uploading is not allowed unless explicitly enabled" do
     temp_upload_file = Tempfile.new(['upload', '.file']) << 'abc'
     temp_upload_file.close
     post "/gollum/upload_file", :file => Rack::Test::UploadedFile.new(::File.open(temp_upload_file))
     assert_equal 405, last_response.status
   end
-  
+
   test "upload a file with mode dir" do
     temp_upload_file = Tempfile.new(['upload', '.file']) << 'abc'
     temp_upload_file.close
     Precious::App.set(:wiki_options, {allow_uploads: true})
-  
+
     post "/gollum/upload_file", :file => Rack::Test::UploadedFile.new(::File.open(temp_upload_file))
-  
+
     assert_equal 302, last_response.status # redirect is expected
     @wiki.clear_cache
     file = @wiki.file("uploads/#{::File.basename(temp_upload_file.path)}")
@@ -436,7 +436,7 @@ EOF
     temp_upload_file.close
     Precious::App.set(:wiki_options, {allow_uploads: true, per_page_uploads: true})
     post "/gollum/upload_file", {:file => Rack::Test::UploadedFile.new(::File.open(temp_upload_file))}, {'HTTP_REFERER' => 'http://localhost:4567/Home.md', 'HTTP_HOST' => 'localhost:4567'}
-    
+
     assert_equal 302, last_response.status # redirect is expected
     @wiki.clear_cache
     # Find the file in a page-specific subdir (here: Home), based on referer
@@ -444,13 +444,13 @@ EOF
     assert_equal 'abc', file.raw_data
     Precious::App.set(:wiki_options, {allow_uploads: false, per_page_uploads: false})
   end
-  
+
   test "upload a file with https referer" do
     temp_upload_file = Tempfile.new(['https_upload', '.file']) << 'abc'
     temp_upload_file.close
     Precious::App.set(:wiki_options, {allow_uploads: true, per_page_uploads: true})
     post "/gollum/upload_file", {:file => Rack::Test::UploadedFile.new(::File.open(temp_upload_file))}, {'HTTP_REFERER' => 'https://localhost:4567/Home.md', 'HTTP_HOST' => 'localhost:4567'}
-    
+
     assert_equal 302, last_response.status # redirect is expected
     @wiki.clear_cache
     # Find the file in a page-specific subdir (here: Home), based on referer
@@ -458,8 +458,8 @@ EOF
     assert_equal 'abc', file.raw_data
     Precious::App.set(:wiki_options, {allow_uploads: false, per_page_uploads: false})
   end
-  
-  
+
+
   test "guard against uploading an existing file" do
     temp_upload_file = Tempfile.new(['upload', '.file']) << 'abc'
     temp_upload_file.close
@@ -471,7 +471,7 @@ EOF
     assert_equal 409, last_response.status
     Precious::App.set(:wiki_options, {allow_uploads: false})
   end
-  
+
   test "delete a page" do
     name = "deleteme"
     post "/gollum/create", :content => 'abc', :page => name,
@@ -483,7 +483,7 @@ EOF
 
     @wiki.clear_cache
     page = @wiki.page(name)
-    assert_equal nil, page
+    assert_nil page
   end
 
   test "previews content" do
@@ -507,7 +507,7 @@ EOF
 
     @wiki.clear_cache
     page2 = @wiki.page('B')
-    assert_not_equal page1.version.sha, page2.version.sha
+    refute_equal page1.version.sha, page2.version.sha
     assert_equal "INITIAL", page2.raw_data.strip
     assert_equal "Revert commit 7c45b5f", page2.version.message
   end
@@ -521,7 +521,7 @@ EOF
 
     @wiki.clear_cache
     page2 = @wiki.page('A')
-    assert_not_equal page1.version.sha, page2.version.sha
+    refute_equal page1.version.sha, page2.version.sha
     assert_equal "INITIAL", page2.raw_data.strip
   end
 
@@ -535,7 +535,7 @@ EOF
     page2 = @wiki.page('A')
     assert_equal page1.version.sha, page2.version.sha
   end
-  
+
 =begin
   # redirects are now handled by class MapGollum in bin/gollum
   # they should be set in config.ru
@@ -583,7 +583,7 @@ EOF
                      { :name => 'user1', :email => 'user1' });
 
     get page
-    assert_no_match /custom.js/, last_response.body
+    refute_match /custom.js/, last_response.body
   end
 
   test "add custom.js if setting" do
@@ -601,7 +601,7 @@ EOF
 
   test "don't allow changing custom js or css" do
     Precious::App.set(:wiki_options, { :js => true, :css => true })
-  
+
     ['create', 'edit'].each do |route|
       ['.css', '.js'].each do |ext|
         get "/gollum/#{route}/custom#{ext}"
@@ -634,7 +634,7 @@ EOF
          :page    => 'Multibyte', :format => :markdown, :message => 'mesg'
 
     page = @wiki.page('Multibyte')
-    
+
     post "/gollum/edit/Multibyte",
          :content => 'りんご', :header => 'みかん', :footer => 'バナナ', :sidebar => 'スイカ',
          :page    => 'Multibyte', :format => :markdown, :message => 'mesg', :etag => page.sha
@@ -652,7 +652,7 @@ EOF
     get "A"
 
     assert last_response.ok?
-    assert_no_match /meta name="robots" content="noindex, nofollow"/, last_response.body
+    refute_match /meta name="robots" content="noindex, nofollow"/, last_response.body
 
     get "A/fc66539528eb96f21b2bbdbf557788fe8a1196ac"
 
@@ -831,10 +831,10 @@ context "Frontend with lotr" do
   test "show revision of specific file" do
     old_sha = "df26e61e707116f81ebc6b935ec6d1676b7e96c4"
     update_sha = "f803c64d11407b23797325e3843f3f378b78f611"
-    
+
     get "Data.csv/#{old_sha}"
     assert last_response.ok?
-    assert_no_match /Samwise,Gamgee/, last_response.body
+    refute_match /Samwise,Gamgee/, last_response.body
 
     get "Data.csv/#{update_sha}"
     assert last_response.ok?
@@ -879,7 +879,7 @@ context "Frontend with page-file-dir" do
     name = "#{dir}/baz"
     get "/gollum/create/#{name}"
     assert_match(/\/#{dir}/, last_response.body)
-    assert_no_match(/[^\/]#{dir}/, last_response.body)
+    refute_match(/[^\/]#{dir}/, last_response.body)
   end
 
   test "use custom.css from page-file-dir path if page-file-dir is set" do
@@ -920,7 +920,7 @@ end
 
 context "Frontend with empty repo" do
   include Rack::Test::Methods
-  
+
   setup do
     @path = cloned_testpath("examples/empty.git")
     @wiki = Gollum::Wiki.new(@path)
@@ -931,11 +931,11 @@ context "Frontend with empty repo" do
   teardown do
     FileUtils.rm_rf(@path)
   end
-  
+
   def app
     Precious::App
   end
-  
+
   test 'previews content on the first page of an empty wiki' do
     post '/gollum/preview', :content => 'abc', :format => 'markdown'
     assert last_response.ok?
@@ -947,12 +947,12 @@ context "Frontend with empty repo" do
     assert_equal '/gollum/create/Home', last_request.fullpath
     assert last_response.ok?
   end
-  
+
 end
 
 context 'Frontend with base path' do
   include Rack::Test::Methods
-  
+
   setup do
     @path = cloned_testpath("examples/lotr.git")
     @wiki = Gollum::Wiki.new(@path)
@@ -964,24 +964,24 @@ context 'Frontend with base path' do
   teardown do
     FileUtils.rm_rf(@path)
   end
-  
+
   test 'page with base path' do
     get '/wiki/Home'
     assert last_response.ok?
   end
-  
+
   test 'base path mathjax assets' do
     get '/wiki/Home'
     assert last_response.ok?
     assert last_response.body.include?('<script defer src="/wiki/gollum/assets/mathjax/MathJax.js?config=')
   end
-  
+
   test 'compare view' do
     get '/wiki/gollum/compare/Bilbo-Baggins.md?versions[]=f25eccd98e9b667f9e22946f3e2f945378b8a72d&versions[]=5bc1aaec6149e854078f1d0f8b71933bbc6c2e43'
     follow_redirect!
     assert last_response.ok?
     assert_equal '/wiki/gollum/compare/Bilbo-Baggins.md/5bc1aaec6149e854078f1d0f8b71933bbc6c2e43...f25eccd98e9b667f9e22946f3e2f945378b8a72d', last_request.fullpath
-    
+
     get '/wiki/gollum/compare/Bilbo-Baggins.md?versions[]=f25eccd98e9b667f9e22946f3e2f945378b8a72d'
     follow_redirect!
     assert last_response.ok?
@@ -992,7 +992,7 @@ context 'Frontend with base path' do
     assert last_response.ok?
     assert_equal '/wiki/gollum/history/Bilbo-Baggins.md', last_request.fullpath
   end
-  
+
   def app
     Precious::MapGollum.new(@base_path)
   end

--- a/test/test_migrate.rb
+++ b/test/test_migrate.rb
@@ -1,28 +1,6 @@
 # ~*~ encoding: utf-8 ~*~
 require File.expand_path(File.join(File.dirname(__FILE__), 'helper'))
 
-# Original contents of Subdir/Foo.md:
-# waa
-# [[Samwi]]
-# [[samwise gamgee.mediaWiki]]
-# [[Samwise Gamgee.mediawiki]]
-# [[Samwise Gamgee]]
-# [[Test|Samwise Gamgee#Anchor]]
-# [[Waaa|Test]]
-# [[Zaa]]
-
-# Contents of Subdir/Foo.md after successful tag migration
-result = <<EOF
-waa
-[[Samwi]]
-[[/Samwise Gamgee.mediawiki]]
-[[/Samwise Gamgee.mediawiki]]
-[[/Samwise Gamgee.md]]
-[[Test|/Samwise Gamgee.md#Anchor]]
-[[Waaa|/Bar/Test.md]]
-[[Subsub/Zaa.md]]
-EOF
-
 def load_script(**args)
   settings = {
     :run_silent => true,
@@ -31,47 +9,70 @@ def load_script(**args)
     :hyphenate => false,
     :page_file_dir => nil,
   }.merge(args)
-  
-  settings.each do |const, val|
-    const_name = const.to_s.upcase
-    Object.const_set(const_name, val) unless Object.const_defined?(const_name) && Object.const_get(const_name) == val
+
+  settings.each do |setting, val|
+    variable_name = :"@@#{setting.to_s}"
+
+    unless Object.class_variable_defined?(variable_name) && Object.class_variable_get(variable_name) == val
+      Object.class_variable_set(variable_name, val)
+    end
   end
-  
+
   script_path = File.expand_path(File.join(File.dirname(__FILE__), '../', 'bin', 'gollum-migrate-tags'))
-  
+
   Dir.chdir(@path) do
     load script_path
-  end  
+  end
 end
 
 unless ENV['CI']
-
   context '4.x -> 5.x tag migrator' do
     include Rack::Test::Methods
 
     setup do
       @path = cloned_testpath("examples/lotr_migration.git")
     end
-    
+
     test 'repair broken links' do
+      # The original contents of Subdir/Foo.md:
+      #
+      # waa
+      # [[Samwi]]
+      # [[samwise gamgee.mediaWiki]]
+      # [[Samwise Gamgee.mediawiki]]
+      # [[Samwise Gamgee]]
+      # [[Test|Samwise Gamgee#Anchor]]
+      # [[Waaa|Test]]
+      # [[Zaa]]
+      #
+      # The contents will be updated after running the migration script.
       load_script
-    
-      f = ::File.new(::File.join(@path, 'Subdir/Foo.md'), 'r')
-      assert_equal result, f.read
+
+      file = ::File.new(::File.join(@path, 'Subdir/Foo.md'), 'r')
+      assert_equal <<~FILE_CONTENTS, file.read
+        waa
+        [[Samwi]]
+        [[/Samwise Gamgee.mediawiki]]
+        [[/Samwise Gamgee.mediawiki]]
+        [[/Samwise Gamgee.md]]
+        [[Test|/Samwise Gamgee.md#Anchor]]
+        [[Waaa|/Bar/Test.md]]
+        [[Subsub/Zaa.md]]
+      FILE_CONTENTS
     end
-    
-    test 'change spaced filenames to hyphenated filenames' do    
+
+    test 'change spaced filenames to hyphenated filenames' do
       load_script(hyphenate: true)
-    
+
       f = ::File.new(::File.join(@path, 'Home.textile'), 'r')
       output = f.read
       assert_equal true, output.include?('[[Bilbo-Baggins.md]]')
       assert_equal true, output.include?('[[evil|Mordor/Eye-Of-Sauron.md]]')
     end
-    
-    test 'migration with page file dir' do      
+
+    test 'migration with page file dir' do
       load_script(page_file_dir: 'Subdir')
-      
+
       f = ::File.new(::File.join(@path, 'Subdir/Foo.md'), 'r')
       output = f.read
       assert_equal true, output.include?('[[Subsub/Zaa.md]]')
@@ -82,5 +83,4 @@ unless ENV['CI']
       FileUtils.rm_rf(@path)
     end
   end
-
 end

--- a/test/test_page_view.rb
+++ b/test/test_page_view.rb
@@ -35,7 +35,7 @@ context "Precious::Views::Page" do
     @view.instance_variable_set :@content, page.formatted_data
     @view.instance_variable_set :@h1_title, false
 
-    assert_include @view.breadcrumb, "数学 📘"
+    assert_includes @view.breadcrumb, "数学 📘"
   end
 
   test 'page <title> is the page header from content, if present' do

--- a/test/test_template_cascade.rb
+++ b/test/test_template_cascade.rb
@@ -37,7 +37,11 @@ class TestTemplateCascade < Minitest::Unit::TestCase
     get '/Home'
     assert_equal '/Home', last_request.fullpath
     assert last_response.ok?
-    assert_no_match /PAGE_OVERRIDE/, last_response.body
-    assert_no_match /NAVBAR_OVERRIDE/, last_response.body
+    refute_match /PAGE_OVERRIDE/, last_response.body
+    refute_match /NAVBAR_OVERRIDE/, last_response.body
+  end
+
+  def teardown
+    FileUtils.rm_rf(@path)
   end
 end

--- a/test/test_template_cascade.rb
+++ b/test/test_template_cascade.rb
@@ -1,47 +1,59 @@
 # ~*~ encoding: utf-8 ~*~
 require File.expand_path(File.join(File.dirname(__FILE__), 'helper'))
 
-class TestTemplateCascade < Minitest::Unit::TestCase
+context "Precious::Views::TemplateCascade" do
   include Rack::Test::Methods
 
-  def setup
+  setup do
     @path = cloned_testpath('examples/lotr.git')
     Precious::App.set(:gollum_path, @path)
-    Precious::App.set(:wiki_options, {template_dir: testpath('examples/template_cascade')})
+    Precious::App.set(
+      :wiki_options,
+      {template_dir: testpath('examples/template_cascade')}
+    )
     @wiki = Gollum::Wiki.new(@path)
   end
 
-  def teardown
+  teardown do
     FileUtils.rm_rf(@path)
+
+    Precious::App.set(:wiki_options, {template_dir: nil})
+
+    # The following line has been added to avoid order-dependent test failures.
+    # We saw issues where the class variable `@@template_priority_path` was not
+    # being reset between test cases.
+    Precious::Views::TemplateCascade.class_variable_set(
+      :@@template_priority_path,
+      nil
+    )
   end
 
   def app
-    Precious::App
+    Precious::App.new
   end
 
-  def test_overridden_page_template_is_used
+  test "overridden_page_template_is_used" do
     get '/Home'
 
     assert last_response.body.include?('PAGE_OVERRIDE')
   end
 
-  def test_overridden_navbar_partial_is_used
+  test "test_overridden_navbar_partial_is_used" do
     get '/Home'
 
     assert last_response.body.include?('NAVBAR_OVERRIDE')
   end
 
-  def test_overridden_templates_are_ignore_without_template_dir_set
+  test "test_overridden_templates_are_ignore_without_template_dir_set" do
     Precious::App.set(:wiki_options, {template_dir: nil})
 
     get '/Home'
+
     assert_equal '/Home', last_request.fullpath
+
     assert last_response.ok?
+
     refute_match /PAGE_OVERRIDE/, last_response.body
     refute_match /NAVBAR_OVERRIDE/, last_response.body
-  end
-
-  def teardown
-    FileUtils.rm_rf(@path)
   end
 end


### PR DESCRIPTION
This pull request changes the test suite to use Minitest instead of the current test framework, TestUnit. Some of the changes I made to make this switch successful are a bit obscure. If you view the changes commit-by-commit I hope that my commit messages explain the issues clearly.

I think that there are a couple of benefits that come with these changes:

**Minitest is a complete testing framework, where as TestUnit is a unit testing framework.**

Without making substantial changes to our existing test suite, I've been able to switch over to a different test framework that provides a larger featureset. For example, it has first-class support for Capybara acceptance testing, which is something we've been interested in adding anyway.

**Without additional configuration, Minitest runs our tests in a random order.**

It seems as though TestUnit was running our tests in a deterministic order. Switching to Minitest here forced me to make some changes that were clearly order-dependent test failures. I think having our tests run in a random order can help us improve our test suite long-term.