### PR TITLE
Remove fields from gemspec that should not be set

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,5 @@
 require 'rubygems'
 require 'rake'
-require 'date'
 
 #############################################################################
 #
@@ -36,14 +35,6 @@ def bump_version
   File.write("lib/#{name}.rb", old_file)
 
   new_version
-end
-
-def date
-  Date.today.to_s
-end
-
-def rubyforge_project
-  name
 end
 
 def gemspec_file
@@ -143,12 +134,9 @@ task :gemspec => :validate do
   spec = File.read(gemspec_file)
   head, manifest, tail = spec.split("  # = MANIFEST =\n")
 
-  # replace name version and date
+  # replace name and version
   replace_header(head, :name)
   replace_header(head, :version)
-  replace_header(head, :date)
-  #comment this out if your rubyforge_project has a different name
-  replace_header(head, :rubyforge_project)
 
   # determine file list from git ls-files
   files = `git ls-files`.

--- a/gollum.gemspec
+++ b/gollum.gemspec
@@ -1,12 +1,9 @@
 Gem::Specification.new do |s|
-  s.specification_version = 2 if s.respond_to? :specification_version=
   s.required_rubygems_version = Gem::Requirement.new('>= 0') if s.respond_to? :required_rubygems_version=
-  s.rubygems_version = '1.3.5'
   s.required_ruby_version = '>= 2.6'
 
   s.name              = 'gollum'
   s.version           = '5.2.3'
-  s.date              = '2021-04-18'
   s.license           = 'MIT'
 
   s.summary     = 'A simple, Git-powered wiki.'


### PR DESCRIPTION
RubyGems says not to set the value to `date`, `specification_version` and `rubygems_version`.
https://github.com/rubygems/rubygems/blob/fe96fb6e2ac5a8b6df5e852470d11fa854301eca/lib/rubygems/specification.rb#L1677-L1682
https://github.com/rubygems/rubygems/blob/fe96fb6e2ac5a8b6df5e852470d11fa854301eca/lib/rubygems/specification.rb#L750-L755
https://github.com/rubygems/rubygems/blob/fe96fb6e2ac5a8b6df5e852470d11fa854301eca/lib/rubygems/specification.rb#L536-L541

This PR removes those fields from gemspec.
And does the following:
- Fix gemspec task not to set date field.
- Remove unused codes related with rubyforge_project from gemspec task.
