### PR TITLE
Add Ruby 3.1 to the CI matrix

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [2.6, 2.7, '3.0', 3.1]
+        ruby: ['2.6', '2.7', '3.0', '3.1']
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [2.6, 2.7, 3.0]
+        ruby: [2.6, 2.7, '3.0', 3.1]
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2


### PR DESCRIPTION
This PR adds Ruby 3.1 to the CI matrix.
And enclose 3.0 in quotes to ensure that Ruby 3.0 is used correctly.
Please see https://github.com/ruby/setup-ruby/issues/252 for more details.