### PR TITLE
Add page context to template filter, resolves #1603

### DIFF
--- a/lib/gollum.rb
+++ b/lib/gollum.rb
@@ -31,8 +31,8 @@ module Gollum
 
     def self.apply_filters(wiki_page, data)
       @@filters.each do |pattern, replacement|
-        ps = replacement.parameters.length == 0 ? () : (wiki_page)
-        data.gsub!(pattern, replacement.call(*ps))
+        params = replacement.parameters.length == 0 ? () : (wiki_page)
+        data.gsub!(pattern, replacement.call(*params))
       end
       data
     end

--- a/lib/gollum.rb
+++ b/lib/gollum.rb
@@ -31,7 +31,7 @@ module Gollum
 
     def self.apply_filters(wiki_page, data)
       @@filters.each do |pattern, replacement|
-        params = replacement.parameters.length == 0 ? () : (wiki_page)
+        params = replacement.parameters.length == 0 ? nil : wiki_page
         data.gsub!(pattern, replacement.call(*params))
       end
       data

--- a/lib/gollum.rb
+++ b/lib/gollum.rb
@@ -29,9 +29,10 @@ module Gollum
       @@filters[pattern] = replacement
     end
 
-    def self.apply_filters(data)
+    def self.apply_filters(wiki_page, data)
       @@filters.each do |pattern, replacement|
-        data.gsub!(pattern, replacement.call)
+        ps = replacement.parameters.length == 0 ? () : (wiki_page)
+        data.gsub!(pattern, replacement.call(*ps))
       end
       data
     end

--- a/lib/gollum/app.rb
+++ b/lib/gollum/app.rb
@@ -369,7 +369,7 @@ module Precious
         @name = wikip.name
         @ext  = wikip.ext
         @path = wikip.path
-        @template_page = load_template(@path) if settings.wiki_options[:template_page]
+        @template_page = load_template(wikip, @path) if settings.wiki_options[:template_page]
         @allow_uploads = wikip.wiki.allow_uploads
         @upload_dest   = find_upload_dest(wikip.fullpath)
 
@@ -661,9 +661,9 @@ module Precious
       end
     end
 
-    def load_template(path)
+    def load_template(wiki_page, path)
       template_page = wiki_page(::File.join(path, '_Template')).page || wiki_page('/_Template').page
-      template_page ? Gollum::TemplateFilter.apply_filters(template_page.text_data) : nil
+      template_page ? Gollum::TemplateFilter.apply_filters(wiki_page, template_page.text_data) : nil
     end
 
     def update_wiki_page(wiki, page, content, commit, name = nil, format = nil)

--- a/test/test_app.rb
+++ b/test/test_app.rb
@@ -364,6 +364,25 @@ EOF
     Precious::App.set(:wiki_options, { :template_page => false })
   end
 
+  test "create with template filter with parameter succeed" do
+    Precious::App.set(:wiki_options, { :template_page => true })
+
+    # arrange
+    Gollum::TemplateFilter.add_filter("{{page_name}}", & -> (page) { page.name })
+    template_content = "# Daily Log, {{page_name}}"
+
+    @wiki.write_page("daily-logs/_Template",
+                     :markdown,
+                     template_content)
+    # act
+    get "/gollum/create/daily-logs/2022-04-16"
+    # assert
+    assert last_response.ok?
+    assert_match("# Daily Log, 2022-04-16", last_response.body)
+
+    Precious::App.set(:wiki_options, { :template_page => false })
+  end
+
   test "edit returns nil for non-existant page" do
     # post '/edit' fails. post '/edit/' works.
     page = 'not-real-page'

--- a/test/test_app.rb
+++ b/test/test_app.rb
@@ -344,6 +344,26 @@ EOF
     Precious::App.set(:wiki_options, { :template_page => false })
   end
 
+  test "create with template filter without parameter succeed" do
+    Precious::App.set(:wiki_options, { :template_page => true })
+
+    # arrange
+    now = Time.parse('2022-04-16')
+    Gollum::TemplateFilter.add_filter("{{today}}", & -> () { now.strftime("%Y-%m-%d") })
+    template_content = "# Daily Log, {{today}}"
+
+    @wiki.write_page("daily-logs/_Template",
+                     :markdown,
+                     template_content)
+    # act
+    get "/gollum/create/daily-logs/test"
+    # assert
+    assert last_response.ok?
+    assert_match("# Daily Log, 2022-04-16", last_response.body)
+
+    Precious::App.set(:wiki_options, { :template_page => false })
+  end
+
   test "edit returns nil for non-existant page" do
     # post '/edit' fails. post '/edit/' works.
     page = 'not-real-page'

--- a/test/test_app.rb
+++ b/test/test_app.rb
@@ -344,7 +344,7 @@ EOF
     Precious::App.set(:wiki_options, { :template_page => false })
   end
 
-  test "create with template filter without parameter succeed" do
+  test "create with template filter without parameter" do
     Precious::App.set(:wiki_options, { :template_page => true })
 
     # arrange
@@ -364,7 +364,7 @@ EOF
     Precious::App.set(:wiki_options, { :template_page => false })
   end
 
-  test "create with template filter with parameter succeed" do
+  test "create with template filter with parameter" do
     Precious::App.set(:wiki_options, { :template_page => true })
 
     # arrange


### PR DESCRIPTION
The PR #1612 is a great start to resolve #1603, it introduced the template filter.

This one is a step forward to allow accessing more context (namely `page.name`) in a template filter, as described here:  https://github.com/gollum/gollum/pull/1612#discussion_r826596006