### PR TITLE
Include `rdoc` as a dependency

### DIFF
--- a/gollum.gemspec
+++ b/gollum.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
   s.rdoc_options = ['--charset=UTF-8']
   s.extra_rdoc_files = %w[README.md LICENSE]
 
+  s.add_dependency 'rdoc', '~> 6'
   s.add_dependency 'gollum-lib', '~> 5.1'
   s.add_dependency 'kramdown', '~> 2.3'
   s.add_dependency 'kramdown-parser-gfm', '~> 1.1.0'


### PR DESCRIPTION
We've had some reports (#1342, #1809) of `rdoc` not being installed in some environments, causing Gollum to error in unpleasant ways.

This isn't an issue that's unique to Gollum, and I don't think `rdoc` should actually be a hard dependency of this project.  But since we can side-step the issue by requiring `rdoc`, something that most users who install Gollum via RubyGems would already have installed, I don't think this is a horrible solution.
