### PR TITLE
Ensure search terms in URLs are escaped

### DIFF
--- a/lib/gollum/templates/search.mustache
+++ b/lib/gollum/templates/search.mustache
@@ -18,7 +18,7 @@
   <ul>
   <div class="Box-header border-bottom p-0"></div>
   {{#results}}
-    <li class="Box-row Box-row--gray">
+    <li class="Box-row Box-row--gray search-result">
       <span class="Counter Counter--gray tooltipped tooltipped-w" aria-label="{{filename_count}} hits in filename - {{count}} hits in content">{{filename_count}} - {{count}}</span>&nbsp;
       <span class="text-bold"><a href="{{href}}">{{name}}</a></span>
       <button

--- a/lib/gollum/views/search.rb
+++ b/lib/gollum/views/search.rb
@@ -19,7 +19,7 @@ module Precious
       end
 
       def query_string
-        "&q=#{@query}"
+        "&q=%s" % CGI.escape(@query)
       end
 
       def title

--- a/test/integration/test_search.rb
+++ b/test/integration/test_search.rb
@@ -1,0 +1,76 @@
+require_relative "../capybara_helper"
+
+context "search" do
+  include Capybara::DSL
+
+  setup do
+    @path = cloned_testpath "examples/lotr.git"
+    @wiki = Gollum::Wiki.new @path
+
+    Precious::App.set :gollum_path, @path
+    Precious::App.set :wiki_options, {}
+
+    Capybara.app = Precious::App
+  end
+
+  teardown do
+    @path = nil
+    @wiki = nil
+
+    Capybara.reset_sessions!
+    Capybara.use_default_driver
+  end
+
+  test "search interface works when there are many results" do
+    visit "/"
+
+    search_term = "#find-me"
+
+    create_page name: "Result 1", content: search_term
+    create_page name: "Result 2", content: search_term
+    create_page name: "Result 3", content: search_term
+    create_page name: "Result 4", content: search_term
+    create_page name: "Result 5", content: search_term
+    create_page name: "Result 6", content: search_term
+    create_page name: "Result 7", content: search_term
+    create_page name: "Result 8", content: search_term
+    create_page name: "Result 9", content: search_term
+    create_page name: "Result 10", content: search_term
+    create_page name: "Result 11", content: search_term
+
+    fill_in "Search site", with: search_term
+    send_keys :enter
+
+    assert_includes page.text, "Search results for #find-me"
+
+    page_one_search_results = find_all ".search-result"
+    assert_equal page_one_search_results.count, 10
+
+    click_link "Next"
+    assert on_page_two?
+
+    assert_includes page.text, "Search results for #find-me"
+
+    # Regression test.
+    #
+    # We saw an issue where search terms were not encoded as URL parameters
+    # correctly in pagination links when special characters like "#" were
+    # present in the search term.
+    page_two_search_results = find_all ".search-result"
+    assert_equal page_two_search_results.count, 1
+  end
+
+  def create_page(name:, content:)
+    click_on "New"
+    fill_in "Page Name", with: name
+    click_on "OK"
+
+    find(".ace_content").click
+    send_keys content
+    click_on "Save"
+  end
+
+  def on_page_two?
+    page.current_url.include? "page_num=2"
+  end
+end


### PR DESCRIPTION
Resolves #1873. 

An issue was reported (in discussion #1872) that search terms with special characters (specifically `#`) were resulting in URLs that did not lead to any search results where there should be search results.

I was able to reproduce this issue in a feature test and fix it in the view class.
