### PR TITLE
Don't double escape url for the last modified info link

### DIFF
--- a/lib/gollum/templates/wiki_content.mustache
+++ b/lib/gollum/templates/wiki_content.mustache
@@ -47,7 +47,7 @@
 	<div id="footer" class="pt-4">
 	  {{^historical}}
 		{{^preview}}
-		  <p id="last-edit"><div class="dotted-spinner hidden"></div> <a id="page-info-toggle" data-pagepath="{{escaped_url_path}}">When was this page last modified?</a></p>
+		  <p id="last-edit"><div class="dotted-spinner hidden"></div> <a id="page-info-toggle" data-pagepath="{{path}}">When was this page last modified?</a></p>
 		  {{#allow_editing}}
 		    <p>
 		      <a id="delete-link" href="{{escaped_url_path}}" data-confirm="Are you sure you want to delete this page?"><span>Delete this Page</span></a>

--- a/test/capybara_helper.rb
+++ b/test/capybara_helper.rb
@@ -27,5 +27,3 @@ end
 def console_log(page, level = :severe)
   page.driver.browser.logs.get(:browser).select { |log| log.level == level.to_s.upcase }
 end
-
-

--- a/test/integration/test_app.rb
+++ b/test/integration/test_app.rb
@@ -1,0 +1,32 @@
+require_relative "../capybara_helper"
+
+context "pages" do
+  include Capybara::DSL
+
+  setup do
+    @path = cloned_testpath "examples/lotr.git"
+    @wiki = Gollum::Wiki.new @path
+
+
+    Precious::App.set :gollum_path, @path
+    Precious::App.set :wiki_options, {}
+
+    Capybara.app = Precious::App
+  end
+
+  test 'last modified link is correctly encoded' do
+    @wiki.write_page('Foo bar', :markdown, 'Test', {:name => 'user1', :email => 'user1'})
+    visit '/Foo bar'
+    find(:id, 'page-info-toggle').click
+    assert_includes page.text, "Last edited by user1"
+  end
+
+  teardown do
+    @path = nil
+    @wiki = nil
+
+    Capybara.reset_sessions!
+    Capybara.use_default_driver
+  end
+
+end

--- a/test/integration/test_app.rb
+++ b/test/integration/test_app.rb
@@ -15,10 +15,9 @@ context "pages" do
   end
 
   test 'last modified link is correctly encoded' do
-    @wiki.write_page('Foo bar', :markdown, 'Test', {:name => 'user1', :email => 'user1'})
-    visit '/Foo bar'
+    visit '/Samwise Gamgee'
     find(:id, 'page-info-toggle').click
-    assert_includes page.text, "Last edited by user1"
+    assert_includes page.text, "Last edited by Arran Cudbard-Bell"
   end
 
   teardown do

--- a/test/integration/test_js_errors.rb
+++ b/test/integration/test_js_errors.rb
@@ -3,7 +3,8 @@ require_relative '../capybara_helper'
 def expected_errors
   Regexp.union([
     %r{Refused to apply style from 'http:.*/gollum/create/custom.css'},
-    %r{.*/gollum/create/mathjax.config.js - Failed to load resource: the server responded with a status of 403}
+    %r{.*/gollum/create/mathjax.config.js - Failed to load resource: the server responded with a status of 403},
+    %r{Refused to execute script from .*/gollum/create/mathjax.config.js}
   ])
 end
 

--- a/test/integration/test_js_errors.rb
+++ b/test/integration/test_js_errors.rb
@@ -1,9 +1,5 @@
 require_relative '../capybara_helper'
 
-def console_log(page, level = :severe)
-  page.driver.browser.logs.get(:browser).select{|log| log.level == level.to_s.upcase }
-end
-
 def expected_errors
   Regexp.union([
     %r{Refused to apply style from 'http:.*/gollum/create/custom.css'},


### PR DESCRIPTION
Resolves #1851

Since we're passing the path to our ajax route as `data` using JQuery, it is already auto-encoded. We hence don't need to use `escaped_url_path`, but can simply use `path`. (Note: since we're using mustache's `{{ }}` to print `{{path}}`, this is aready html-escaped.)