### PR TITLE
Improve actions

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -1,9 +1,7 @@
 name: Build and Test Docker
 on:
   push:
-    branches: master
-  pull_request:
-    types: [opened, reopened]
+  pull_request: [reopened]
 env:
   CI_IMAGE: gollum-ci-img
 jobs:

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -1,5 +1,9 @@
 name: Build and Test Docker
-on: [push, pull_request]
+on:
+  push:
+    branches: master
+  pull_request:
+    types: [opened, reopened]
 env:
   CI_IMAGE: gollum-ci-img
 jobs:

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -1,7 +1,7 @@
 name: Build and Test Docker
 on:
   push:
-  pull_request: [reopened]
+  pull_request:
 env:
   CI_IMAGE: gollum-ci-img
 jobs:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,5 +1,8 @@
 name: Ruby Build
-on: [push, pull_request]
+on:
+  push:
+    branches: master
+  pull_request:
 jobs:
   jruby_build:
     name: JRuby (${{ matrix.ruby }})

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,9 +1,7 @@
 name: Ruby Build
 on:
   push:
-    branches: master
-  pull_request:
-    types: [opened, reopened]
+  pull_request: [reopened]
 jobs:
   jruby_build:
     name: JRuby (${{ matrix.ruby }})

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,5 +1,9 @@
 name: Ruby Build
-on: [push, pull_request]
+on:
+  push:
+    branches: master
+  pull_request:
+    types: [opened, reopened]
 jobs:
   jruby_build:
     name: JRuby (${{ matrix.ruby }})

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,7 +1,5 @@
 name: Ruby Build
-on:
-  push:
-  pull_request: [reopened]
+on: [push, pull_request]
 jobs:
   jruby_build:
     name: JRuby (${{ matrix.ruby }})

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [jruby-9.3.2.0]
+        ruby: [jruby-9.4.0.0]
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['2.6', '2.7', '3.0', '3.1']
+        ruby: ['2.7', '3.0', '3.1']
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ Gemfile.lock
 *.gem
 *.swp
 .*
+node_modules
 !.sprockets*
 !lib/gollum/public/gollum/stylesheets/_styles.css
 !.github*


### PR DESCRIPTION
This is to avoid the double running of tests when a new PR is opened, which apparently triggers both the `push` and `pull_requests` events. Fix is (hopefully) to run tests only on pushes to the `master` branch specifically.

As a bonus, add `node_modules` to `.gitignore`. 