### PR TITLE
Resize searchbar to match navigation buttons.

### DIFF
--- a/lib/gollum/templates/searchbar.mustache
+++ b/lib/gollum/templates/searchbar.mustache
@@ -1,3 +1,3 @@
 <form class="search-form" action="{{search_path}}" method="get" id="search-form">
-	<input type="text" class="form-control input-block" name="q" id="search-query" placeholder="Search" aria-label="Search site" autocomplete="off">
+	<input type="text" class="form-control input-block input-sm" name="q" id="search-query" placeholder="Search" aria-label="Search site" autocomplete="off">
 </form>


### PR DESCRIPTION
I just noticed that gollum's search bar was not neatly aligned with the navigation buttons.

![Screenshot 2022-12-08 at 21 48 04](https://user-images.githubusercontent.com/571173/206564978-48a55a36-cb9c-422f-9feb-e6cfe790c62a.png)

This PR fixes this by giving the search input the class "input-sm".

![Screenshot 2022-12-08 at 21 49 00](https://user-images.githubusercontent.com/571173/206565003-e405213d-bea1-426f-96ad-33df36ce76f0.png)
