### PR TITLE
Make docker-run.sh work if you're in a bare git repository

### DIFF
--- a/docker-run.sh
+++ b/docker-run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Initialize the wiki
-if [ ! -d .git ]; then
+if [ ! -d .git ] && [ "$(git rev-parse  --is-bare-repository 2>/dev/null)" != "true" ]; then
     git init
 fi
 


### PR DESCRIPTION
Hi,

Things go sideways if you're trying to use a bare repository and a docker container and I believe this change will fix it.

Creating an empty .git directory is another workaround.