### PR TITLE
Remove uglifier. Resolves #1909

### DIFF
--- a/bin/gollum
+++ b/bin/gollum
@@ -204,7 +204,7 @@ MSG
   opts.separator ''
   opts.separator '  Development:'
 
-  opts.on('--development-assets [PATH]', 'For development purposes only. Use local node modules instead of the packaged assets. Path defaults to ./node_modules.') do |path|
+  opts.on('--development-assets [PATH]', 'For development purposes only. Use assets in PATH (default: `node_modules` in the gollum project root) instead of the packaged assets.') do |path|
     if path
       module Precious
         module Assets

--- a/bin/gollum
+++ b/bin/gollum
@@ -199,19 +199,11 @@ MSG
     puts results.empty? ? 'none' : results
     exit 0
   end
-
-
+  
   opts.separator ''
   opts.separator '  Development:'
 
-  opts.on('--development-assets [PATH]', 'For development purposes only. Use assets in PATH (default: `node_modules` in the gollum project root) instead of the packaged assets.') do |path|
-    if path
-      module Precious
-        module Assets
-        end
-      end
-      ::Precious::Assets.const_set('NODE_MODULES', path)
-    end
+  opts.on('--development-assets', 'For development purposes only. Use local instead of packaged assets.') do
     wiki_options[:static] = false
   end
 end

--- a/bin/gollum
+++ b/bin/gollum
@@ -204,7 +204,14 @@ MSG
   opts.separator ''
   opts.separator '  Development:'
 
-  opts.on('--development-assets', 'For development purposes only. Use local stylesheets and javascript instead of the packaged assets.') do
+  opts.on('--development-assets [PATH]', 'For development purposes only. Use local node modules instead of the packaged assets. Path defaults to ./node_modules.') do |path|
+    if path
+      module Precious
+        module Assets
+        end
+      end
+      ::Precious::Assets.const_set('NODE_MODULES', path)
+    end
     wiki_options[:static] = false
   end
 end

--- a/gollum.gemspec
+++ b/gollum.gemspec
@@ -32,7 +32,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'octicons', '~> 12.0'
   s.add_dependency 'sprockets', '~> 3.7'
   s.add_dependency 'sass', '~> 3.5'
-  s.add_dependency 'uglifier', '~> 4.2'
   s.add_dependency 'sprockets-helpers', '~> 1.2'
   s.add_dependency 'rss', '~> 0.2.9'
   s.add_dependency 'therubyrhino', '~> 2.1.0'
@@ -44,6 +43,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'minitest-reporters', '~> 1.3.6'
   s.add_development_dependency 'mocha', '~> 1.8.0'
   s.add_development_dependency 'test-unit', '~> 3.3.0'
+  s.add_development_dependency 'uglifier', '~> 4.2'
 
   # = MANIFEST =
   s.files = %w[

--- a/lib/gollum/assets.rb
+++ b/lib/gollum/assets.rb
@@ -4,7 +4,6 @@ module Precious
   module Assets
     MANIFEST = %w(app.js editor.js mermaid.js app.css criticmarkup.css fileview.css ie7.css print.css *.png *.jpg *.svg *.eot *.ttf)
     ASSET_URL = 'gollum/assets'
-    JS_COMPRESSOR = :uglify unless defined?(JS_COMPRESSOR)
 
     def self.sprockets(dir = File.dirname(File.expand_path(__FILE__)))
       env = Sprockets::Environment.new
@@ -17,7 +16,7 @@ module Precious
       env.append_path ::File.join(dir, 'public/gollum/images')
       env.append_path ::File.join(dir, 'public/gollum/fonts')
 
-      env.js_compressor  = Precious::Assets::JS_COMPRESSOR unless Precious::App.development?
+      env.js_compressor  = ::Precious::Assets::JS_COMPRESSOR if defined?(::Precious::Assets::JS_COMPRESSOR)
       env.css_compressor = :scss
 
       env.context_class.class_eval do

--- a/lib/gollum/assets.rb
+++ b/lib/gollum/assets.rb
@@ -8,9 +8,7 @@ module Precious
     def self.sprockets(dir = File.dirname(File.expand_path(__FILE__)))
       env = Sprockets::Environment.new
 
-      env.append_path defined?(::Precious::Assets::NODE_MODULES) ?
-        ::Precious::Assets::NODE_MODULES :
-        ::File.join(dir, '../../node_modules')
+      env.append_path ENV.fetch('GOLLUM_DEV_ASSETS', ::File.join(dir, '../../node_modules'))
 
       env.append_path ::File.join(dir, 'public/gollum/javascript')
       env.append_path ::File.join(dir, 'public/gollum/stylesheets/')

--- a/lib/gollum/assets.rb
+++ b/lib/gollum/assets.rb
@@ -10,7 +10,7 @@ module Precious
 
       env.append_path defined?(::Precious::Assets::NODE_MODULES) ?
         ::Precious::Assets::NODE_MODULES :
-        ::File.join(Dir.pwd, 'node_modules')
+        ::File.join(dir, '../../node_modules')
 
       env.append_path ::File.join(dir, 'public/gollum/javascript')
       env.append_path ::File.join(dir, 'public/gollum/stylesheets/')

--- a/lib/gollum/assets.rb
+++ b/lib/gollum/assets.rb
@@ -8,7 +8,9 @@ module Precious
     def self.sprockets(dir = File.dirname(File.expand_path(__FILE__)))
       env = Sprockets::Environment.new
 
-      env.append_path ::File.join(dir, '../../node_modules')
+      env.append_path defined?(::Precious::Assets::NODE_MODULES) ?
+        ::Precious::Assets::NODE_MODULES :
+        ::File.join(Dir.pwd, 'node_modules')
 
       env.append_path ::File.join(dir, 'public/gollum/javascript')
       env.append_path ::File.join(dir, 'public/gollum/stylesheets/')


### PR DESCRIPTION
As described in #1909, we only use the `uglifier` gem when generating the packaged assets. This PR moves it to the development dependencies.

Additionally, I have added the ability to specify a custom location for the `node_modules` directory when using the `--development-assets` option.