### PR TITLE
Move from Uglifier to Terser

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -248,10 +248,10 @@ task :precompile do
       "It's possible that you just need to install `yarn` on your system."
   end
 
-  require 'uglifier'
+  require 'terser'
   module Precious
     module Assets
-      JS_COMPRESSOR = ::Uglifier.new(harmony: true)
+      JS_COMPRESSOR = ::Terser.new
     end
   end
   

--- a/gollum.gemspec
+++ b/gollum.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'minitest-reporters', '~> 1.3.6'
   s.add_development_dependency 'mocha', '~> 1.8.0'
   s.add_development_dependency 'test-unit', '~> 3.3.0'
-  s.add_development_dependency 'uglifier', '~> 4.2'
+  s.add_development_dependency 'terser', '~> 1.1'
 
   # = MANIFEST =
   s.files = %w[


### PR DESCRIPTION
`uglifier` hasn't been updated for three years and has poor support for ES6. Precompiling newer versions of e.g. mermaid with uglifier leads to errors. This PR switches to the more modern `terser` gem for JS minification.