### PR TITLE
page.rb: remove unnecessary attr_reader

### DIFF
--- a/lib/gollum/views/page.rb
+++ b/lib/gollum/views/page.rb
@@ -4,7 +4,7 @@ module Precious
       include HasPage
       include HasMath
 
-      attr_reader :content, :page, :header, :footer, :preview, :historical, :version
+      attr_reader :page, :header, :footer, :preview, :historical, :version
       
       VALID_COUNTER_STYLES = ['decimal', 'decimal-leading-zero', 'arabic-indic', 'armenian', 'upper-armenian',
         'lower-armenian', 'bengali', 'cambodian', 'khmer', 'cjk-decimal', 'devanagari', 'georgian', 'gujarati', 'gurmukhi',


### PR DESCRIPTION
The `content` method is being re-defined below.