### PR TITLE
Improve utf-8 test

### DIFF
--- a/test/test_app.rb
+++ b/test/test_app.rb
@@ -57,9 +57,12 @@ context "Frontend" do
                      {name: 'user1', email: 'user1'})
 
     get 'utfh1'
-    expected = "<h2 class=\"editable\"><a class=\"anchor\" (href|id)=\"(#)?한글\" (href|id)=\"(#)?한글\"></a>한글</h2>"
 
-    assert_match /#{expected}/, last_response.body
+    doc = Nokogiri::HTML(last_response.body)
+    anchor = doc.css('h2.editable a.anchor')
+    assert_equal anchor.attr('id').value, "한글"
+    assert_equal anchor.attr('href').value, "#한글"
+    assert_equal doc.css('h2.editable').children.last.to_s.strip, "한글"
   end
 
   test 'rss feed' do


### PR DESCRIPTION
This test failed on JRuby recently because of a change in behaviour to nokogiri. It took me quite a while to figure out what exactly was broken because it seemed like there might be an ut8 issue, but really the test was only failing because it's trying to strictly match whitespace, and the exact whitespace used by nokogiri had changed. I've rewritten the test to be more robust.

Note: we still have a test guarding against wrong use of whitespace in  https://github.com/gollum/gollum/blob/master/test/test_app.rb#L22.