### PR TITLE
Fix mustache

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Run gollum from Docker
         run: |
           git clone test/examples/lotr.git /tmp/lotr.git
-          RUNNER_TRACKING_ID="" docker run --rm -p 4567:4567 -v /tmp/lotr.git:/wiki -e CI=true ${{ env.CI_IMAGE }} --mathjax --user $(id -u) &
+          RUNNER_TRACKING_ID="" docker run --user $(id -u) --rm -p 4567:4567 -v /tmp/lotr.git:/wiki -e CI=true ${{ env.CI_IMAGE }} --mathjax &
           sleep 10
           netstat -lt
       - name: Run capybara tests against Dockerized instance

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Run gollum from Docker
         run: |
           git clone test/examples/lotr.git /tmp/lotr.git
-          RUNNER_TRACKING_ID="" docker run --rm -p 4567:4567 -v /tmp/lotr.git:/wiki -e CI=true ${{ env.CI_IMAGE }} --mathjax &
+          RUNNER_TRACKING_ID="" docker run --rm -p 4567:4567 -v /tmp/lotr.git:/wiki -e CI=true ${{ env.CI_IMAGE }} --mathjax --user $(id -u) &
           sleep 10
           netstat -lt
       - name: Run capybara tests against Dockerized instance

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['2.7', '3.1']
+        ruby: ['2.7', '3.1', '3.2.1']
     steps:
       - name: Install required system dependencies
         run: |

--- a/gollum.gemspec
+++ b/gollum.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'kramdown-parser-gfm', '~> 1.1.0'
   s.add_dependency 'sinatra', '~> 3.0'
   s.add_dependency 'sinatra-contrib', '~> 3.0'
-  s.add_dependency 'mustache-sinatra', '>= 1.0.1', '< 2'
+  s.add_dependency 'mustache-sinatra', '~> 2.0'
   s.add_dependency 'useragent', '~> 0.16.2'
   s.add_dependency 'gemojione', '~> 4.1'
   s.add_dependency 'octicons', '~> 12.0'

--- a/lib/gollum/app.rb
+++ b/lib/gollum/app.rb
@@ -15,6 +15,7 @@ require 'gollum'
 require 'gollum/assets'
 require 'gollum/views/helpers'
 require 'gollum/views/helpers/locale_helpers'
+require 'gollum/views/template_cascade'
 require 'gollum/views/layout'
 require 'gollum/views/editable'
 require 'gollum/views/has_page'
@@ -22,7 +23,6 @@ require 'gollum/views/has_user_icons'
 require 'gollum/views/has_math'
 require 'gollum/views/pagination'
 require 'gollum/views/rss.rb'
-require 'gollum/views/template_cascade'
 
 ['sassc', 'sassc-embedded'].each do |gem|
   require gem if Gem::Specification.find {|spec| spec.name == gem}
@@ -118,7 +118,6 @@ module Precious
       @default_keybinding = settings.wiki_options.fetch(:default_keybinding, 'default')
 
       if settings.wiki_options[:template_dir]
-        Precious::Views::Layout.extend Precious::Views::TemplateCascade
         Precious::Views::Layout.template_priority_path = settings.wiki_options[:template_dir]
       end
 

--- a/lib/gollum/app.rb
+++ b/lib/gollum/app.rb
@@ -13,9 +13,12 @@ require 'pathname'
 
 require 'gollum'
 require 'gollum/assets'
+
+# Requirements for loading the layout view:
 require 'gollum/views/helpers'
 require 'gollum/views/helpers/locale_helpers'
 require 'gollum/views/template_cascade'
+
 require 'gollum/views/layout'
 require 'gollum/views/editable'
 require 'gollum/views/has_page'

--- a/lib/gollum/views/layout.rb
+++ b/lib/gollum/views/layout.rb
@@ -9,9 +9,22 @@ module Precious
       include Precious::Views::SprocketsHelpers
       include Precious::Views::RouteHelpers
       include Precious::Views::OcticonHelpers
-      
+
       attr_reader :name, :path
 
+      self.extend Precious::Views::TemplateCascade
+
+      # Method should track lib/mustache.rb from Mustache project.
+      def partial(name)
+        path = self.class.first_path_available(name)
+        begin
+          File.read(path)
+        rescue
+          raise if raise_on_context_miss?
+          ""
+        end
+      end
+      
       def escaped_name
         CGI.escape(@name)
       end

--- a/lib/gollum/views/layout.rb
+++ b/lib/gollum/views/layout.rb
@@ -3,16 +3,13 @@ require 'cgi'
 module Precious
   module Views
     class Layout < Mustache
-      include Rack::Utils
       include Sprockets::Helpers
       include Precious::Views::AppHelpers
       include Precious::Views::LocaleHelpers
       include Precious::Views::SprocketsHelpers
       include Precious::Views::RouteHelpers
       include Precious::Views::OcticonHelpers
-
-      alias_method :h, :escape_html
-
+      
       attr_reader :name, :path
 
       def escaped_name

--- a/lib/gollum/views/template_cascade.rb
+++ b/lib/gollum/views/template_cascade.rb
@@ -2,7 +2,7 @@ module Precious
   module Views
     module TemplateCascade
       def template_priority_path
-        @@template_priority_path
+        @@template_priority_path ||= nil
       end
 
       def template_priority_path=(path)
@@ -23,17 +23,6 @@ module Precious
       # Method should track lib/mustache/settings.rb from Mustache project.
       def template_file
         @template_file || first_path_available(template_name)
-      end
-
-      # Method should track lib/mustache.rb from Mustache project.
-      def partial(name)
-        path = first_path_available(name)
-        begin
-          File.read(path)
-        rescue
-          raise if raise_on_context_miss?
-          ""
-        end
       end
     end
   end


### PR DESCRIPTION
The `mustache-sinatra` gem just received a bump release, which now utillizes the latest `mustache`. Unfortunately, this has suddenly exposed `gollum` to breaking changes in the latest `mustache`. I found two:

## Broken call to View#escape

Error: `NoMethodError private method escape called for <<Precious::Views::Create: ...`.

**Diagnosis**:  in the latest `mustache`, views are expected to have an `escape` instead of an `escapeHTML` method. We were using the `escapeHTML` method provided by the `Rack::Utils` modules. By including that module, we also include a private `#escape` method, which mustache is now attempting to call.

**Fix**: instead of including `Rack::Utils`, just use the default `Mustache#escape`, which uses `CGI.escapeHTML`. Overriding the `#escape` method is only necessary for providing custom (non-HTML) escaping.

## Broken template cascades

Our logic for template cascading fails, causing a test failure for using custom partials inside a custom template (`"test_overridden_navbar_partial_is_used"` in `test_template_cascade.rb`).

**Diagnosis**: we provided a custom *class* method `Layout.partial`, but the newest version of mustache ended up calling an *instance* method `Page#partial`, i.e. the mustache default. So our overriding logic was simply not being called.

**Fix**: providing the necessary instance method `#partial` which provides the necessary overriding logic. I have still implemented the helper methods as class methods.

@bartkamphorst I would appreciate a review of this fix, since I'm not really familiar with the template cascade functionality.

This fix would only be included in the next major release of gollum. Should we backport a fix for `5.x`, pinning `mustache` to an older version?
