### PR TITLE
Add browser tests for Asciidoctor rendering

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,21 +2,6 @@ source 'https://rubygems.org'
 
 gem 'warbler', platforms: :jruby
 
-# FIXME:
-#
-# There's an issue in 1.12.5 that causes XHTML elements to be generated badly,
-# causing Gollum's test suite to fail.[1] The issue has been fixed upstream,
-# but we're still waiting for a new Nokogiri point release.
-#
-# However, 1.12.5 is a security patch, so we don't want end users to use an
-# older version of Nokogiri. But this is safe to do in our CI environment.
-#
-# Once there's a new Nokogiri release, we can remove this dependency and JRuby
-# CI should pass normally again.
-#
-# Note that Nokogiri 1.11+ does not support Ruby v2.4.x anymore. So to make our
-# current CI workflows pass, we should only try to install this version of
-# Nokogiri for newer Ruby versions.
 
 group :test do
   gem 'selenium-webdriver', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 gem 'warbler', platforms: :jruby
 
+gem 'asciidoctor'
 
 group :test do
   gem 'selenium-webdriver', require: false

--- a/test/integration/test_asciidoctor.rb
+++ b/test/integration/test_asciidoctor.rb
@@ -1,0 +1,92 @@
+require_relative "../capybara_helper"
+
+context "pages using Asciidoctor" do
+  include Capybara::DSL
+
+  setup do
+    @path = cloned_testpath "examples/lotr.git"
+    @wiki = Gollum::Wiki.new @path
+
+    Precious::App.set :gollum_path, @path
+    Precious::App.set :wiki_options, {}
+
+    Capybara.app = Precious::App
+  end
+
+  test 'Asciidoctor links are rendered correctly' do
+    visit "/"
+
+    within "#head" do
+      click_on "New"
+    end
+
+    assert page.text.include? "Create New Page"
+
+    fill_in "Page Name", with: "My Asciidoctor article"
+    click_on "OK"
+
+    assert page.text.include? "Create New Page"
+    assert asciidoc_renderer_available?
+
+    # FIXME:
+    # We should be able to use `#select` to select the AsciiDoc markup option.
+    # But it doesn't seem to work:
+    #
+    #     select "AsciiDoc", from: "Markup"
+    #
+    # This makes me think there's an accessibility issue with this <select>
+    # dropdown, but I'm not sure what it is.
+    #
+    markup_format_selector = find "select#wiki_format"
+    markup_format_selector.select "AsciiDoc"
+
+    add_page_content <<~TEXT
+      This page content will test that our AsciiDoc renderer renders documents
+      well.
+
+      Here is a typical HTTP hyperlink:
+      link:https://github.com/gollum/gollum[gollum/gollum on GitHub]
+
+      Here is a Matrix link:
+      link:matrix:u/foo:example.org[matrix link example]
+
+      Here is a magnet link:
+      link:magnet:?xt=urn:sha1:ABCDEFGHIJK[magnet link example]
+    TEXT
+
+    click_on "Save"
+
+    assert page.body.include?(<<~TEXT.strip)
+      Here is a typical HTTP hyperlink:
+      <a href="https://github.com/gollum/gollum">gollum/gollum on GitHub</a>
+    TEXT
+
+    # FIXME
+    skip 'The assertions after this line will fail until #1959 is resolved:' \
+      'https://github.com/gollum/gollum/issues/1959'
+
+    assert page.body.include?(<<~TEXT.strip)
+      Here is a Matrix link:
+      <a href="matrix:u/foot:example.org">matrix link example</a>
+    TEXT
+
+    assert page.body.include?(<<~TEXT.strip)
+      Here is a magnet link:
+      <a href="magnet:?xt=urn:sha1:ABCDEFGHIJK">magnet link example</a>
+    TEXT
+  end
+
+  def add_page_content text
+    # Ensure the main editor is in focus before adding text.
+    find(".ace_content").click
+
+    page.send_keys text
+  end
+
+  def asciidoc_renderer_available?
+    within "select#wiki_format" do
+      asciidoc_option = find "option[data-ext='adoc']"
+      !asciidoc_option[:class].match? /disabled/
+    end
+  end
+end


### PR DESCRIPTION
This pull request reproduces the issue reported in #1959, although it doesn't resolve it. When we resolve the issue, we can un-skip the end of the test to ensure that this is true.

Unrelatedly, I found a stale `FIXME` comment and removed it while I was editing the Gemfile.
