### PR TITLE
Style Note and Warn macros and inject requested Octicon icons for Flash and Icon macros.

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -45,7 +45,7 @@ jobs:
           ruby-version: 3.1
           bundler-cache: true
       - name: Install Chromedriver
-        uses: nanasess/setup-chromedriver@v1
+        uses: nanasess/setup-chromedriver@v2
       - run: |
           export DISPLAY=:99
           chromedriver --url-base=/wd/hub &

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Run gollum from Docker
         run: |
           git clone test/examples/lotr.git /tmp/lotr.git
-          RUNNER_TRACKING_ID="" docker run --rm -p 4567:4567 -v /tmp/lotr.git:/wiki -e CI=true ${{ env.CI_IMAGE }} --mathjax &
+          RUNNER_TRACKING_ID="" docker run --user $(id -u) --rm -p 4567:4567 -v /tmp/lotr.git:/wiki -e CI=true ${{ env.CI_IMAGE }} --mathjax &
           sleep 10
           netstat -lt
       - name: Run capybara tests against Dockerized instance

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -60,7 +60,7 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v2
       - name: Install Chromedriver
-        uses: nanasess/setup-chromedriver@v1
+        uses: nanasess/setup-chromedriver@v2
       - run: |
           export DISPLAY=:99
           chromedriver --url-base=/wd/hub &

--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,6 @@ gem 'warbler', platforms: :jruby
 # current CI workflows pass, we should only try to install this version of
 # Nokogiri for newer Ruby versions.
 
-gem 'gollum-lib', path: "/Users/bart/Documents/Rails Projects/temp/gollum-lib"
 
 group :test do
   gem 'selenium-webdriver', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,8 @@ gem 'warbler', platforms: :jruby
 # current CI workflows pass, we should only try to install this version of
 # Nokogiri for newer Ruby versions.
 
+gem 'gollum-lib', path: "/Users/bart/Documents/Rails Projects/temp/gollum-lib"
+
 group :test do
   gem 'selenium-webdriver', require: false
   gem 'capybara', require: false

--- a/gollum.gemspec
+++ b/gollum.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rack-test', '~> 0.6.3'
   s.add_development_dependency 'shoulda', '~> 3.6.0'
   s.add_development_dependency 'minitest-reporters', '~> 1.3.6'
-  s.add_development_dependency 'mocha', '~> 1.8.0'
+  s.add_development_dependency 'mocha', '~> 2.0'
   s.add_development_dependency 'test-unit', '~> 3.3.0'
   s.add_development_dependency 'terser', '~> 1.1'
 

--- a/lib/gollum/app.rb
+++ b/lib/gollum/app.rb
@@ -192,6 +192,15 @@ module Precious
         end
       end
 
+      include Precious::Views::OcticonHelpers
+      get '/octicon/:name' do
+        begin
+          [200, {'Content-Type' => 'image/svg'}, rocticon_css(params['name'])]
+        rescue RuntimeError
+          not_found
+        end
+      end
+
       get '/emoji/:name' do
         begin
           [200, {'Content-Type' => 'image/png'}, emoji(params['name'])]

--- a/lib/gollum/public/gollum/javascript/gollum.js.erb
+++ b/lib/gollum/public/gollum/javascript/gollum.js.erb
@@ -7,6 +7,26 @@ function brokenAvatarImage(image){
   return true;
 }
 
+// Find all divs with `data-gollum-icon` name specified and
+// try to inject the corresponding octicon
+function injectOcticons(){ 
+  $("div[data-gollum-icon]").each(function(index, div){
+    var div;
+    var octicon = $(div).data('gollum-icon');
+    $.ajax({
+      url: '/gollum/octicon/' + octicon,
+      success: function(data) {
+        $(div).prepend(data);
+      },
+      error: function(data, textStatus, errorThrown) {
+        $(div).prepend('<img src="Error.src?raw" title="Requested octicon does not exist." /> ');
+      }
+    })
+  });
+}
+
+
+
 // Get path for named route, prefixing baseUrl if necessary
 // Uses the route definitions in /lib/gollum/views/helpers.rb.
 // For example, routePath('delete') is equivalent to 'delete_path' in the mustache templates.
@@ -220,6 +240,9 @@ $(document).ready(function() {
     }
   }
 
+  // Inject Octicons
+  injectOcticons();
+  
   // Set time in local time
   if (showLocalTime) {
     $(function() {
@@ -431,6 +454,7 @@ $(document).ready(function() {
         var mainDiv = $('#wiki-wrapper', data);
         $('.tabnav-div#preview-content').html(mainDiv);
         preparePage();
+        injectOcticons();
         enable_code_blocks();
         if (sectionAnchor ) { 
           if ( sectionHeading = $('a' + '#' + sectionAnchor+'.anchor')[0] ) {

--- a/lib/gollum/public/gollum/javascript/gollum.js.erb
+++ b/lib/gollum/public/gollum/javascript/gollum.js.erb
@@ -19,7 +19,7 @@ function injectOcticons(){
         $(div).prepend(data);
       },
       error: function(data, textStatus, errorThrown) {
-        $(div).prepend('<img src="Error.src?raw" title="Requested octicon does not exist." /> ');
+        $(div).prepend('<img class="mr-2" src="Error.src?raw" title="Requested octicon does not exist." /> ');
       }
     })
   });

--- a/lib/gollum/public/gollum/stylesheets/_base.scss
+++ b/lib/gollum/public/gollum/stylesheets/_base.scss
@@ -6,3 +6,7 @@ $font-console: Inconsolata, Consolas, "Liberation Mono", 'Monaco', 'Andale Mono'
 
 // Borders
 $border-standard: 1px solid #ddd;
+
+// Icon size
+$gollum-icon-width: 24px;
+$gollum-icon-height: 24px;

--- a/lib/gollum/public/gollum/stylesheets/template.scss.erb
+++ b/lib/gollum/public/gollum/stylesheets/template.scss.erb
@@ -181,7 +181,7 @@ nav.actions {
   display: inline-block;
   position: relative;
   padding-right: 0.5em;
-  align-items: center;
+  vertical-align: middle;
   width: 24px;
   height: 24px;
 }

--- a/lib/gollum/public/gollum/stylesheets/template.scss.erb
+++ b/lib/gollum/public/gollum/stylesheets/template.scss.erb
@@ -175,3 +175,31 @@ nav.actions {
    }
 }
 
+/* `gollum`-provided CSS for the note and warning macros. */
+.flash.gollum-note::before {
+  content: url('data:image/svg+xml;utf8,<%= rocticon_css(:info) %>');
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  padding-right: 0.5em;
+  width: 24px;
+  height: 24px;
+}
+
+.flash.gollum-warning::before {
+  content: url('data:image/svg+xml;utf8,<%= rocticon_css(:alert) %>');
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  padding-right: 0.5em;
+  width: 24px;
+  height: 24px;
+}
+
+/* `gollum`-provided CSS for the default size of octicons. */
+.octicon {
+    width: 24px;
+    height: 24px;
+}
+
+

--- a/lib/gollum/public/gollum/stylesheets/template.scss.erb
+++ b/lib/gollum/public/gollum/stylesheets/template.scss.erb
@@ -176,24 +176,21 @@ nav.actions {
 }
 
 /* `gollum`-provided CSS for the note and warning macros. */
-.flash.gollum-note::before {
-  content: url('data:image/svg+xml;utf8,<%= rocticon_css(:info) %>');
+
+.flash::before {
   display: inline-block;
   position: relative;
-  vertical-align: middle;
   padding-right: 0.5em;
+  align-items: center;
   width: 24px;
   height: 24px;
 }
 
+.flash.gollum-note::before {
+  content: url('data:image/svg+xml;utf8,<%= rocticon_css(:info) %>');
+}
 .flash.gollum-warning::before {
   content: url('data:image/svg+xml;utf8,<%= rocticon_css(:alert) %>');
-  display: inline-block;
-  position: relative;
-  vertical-align: middle;
-  padding-right: 0.5em;
-  width: 24px;
-  height: 24px;
 }
 
 /* `gollum`-provided CSS for the default size of octicons. */

--- a/lib/gollum/public/gollum/stylesheets/template.scss.erb
+++ b/lib/gollum/public/gollum/stylesheets/template.scss.erb
@@ -180,10 +180,11 @@ nav.actions {
 .flash::before {
   display: inline-block;
   position: relative;
-  padding-right: 0.5em;
+  padding-right: 0.7em;
   vertical-align: middle;
-  width: 24px;
-  height: 24px;
+  width: $gollum-icon-width;
+  height: $gollum-icon-height;
+  padding-bottom: 2px;
 }
 
 .flash.gollum-note::before {
@@ -194,9 +195,9 @@ nav.actions {
 }
 
 /* `gollum`-provided CSS for the default size of octicons. */
-.octicon {
-    width: 24px;
-    height: 24px;
+.gollum-icon .octicon, .flash .octicon {
+    width: $gollum-icon-width;
+    height: $gollum-icon-height;
 }
 
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -4,7 +4,7 @@ require 'shoulda'
 require 'minitest/autorun'
 require 'minitest/reporters'
 require 'minitest/spec'
-require 'mocha/setup'
+require 'mocha/minitest'
 require 'fileutils'
 require 'tmpdir'
 


### PR DESCRIPTION
This PR accompanies https://github.com/gollum/gollum-lib/pull/441, which eliminates the octicons gem from gollum-lib. This PR ensures that
* `Warn` and `Note` macros are styled with a default Octicon using a `::before` pseudo-element;
* Icon and Flash macros are styled with an Octicon of the user's choice. 

The latter works through jQuery html injection and a new `octicon` route, which uses the existing `OcticonHelpers` to lookup and prepare the appropriate octicon svg. 

![Screenshot 2023-04-29 at 19 28 24](https://user-images.githubusercontent.com/571173/235315942-398ad966-3c99-4cc6-ba9a-c9a8b8a8190c.png)

If a requested icon name is not available, a broken img link is inserted instead (with a helpful `title`), to signal to the user that something went wrong.

![Screenshot 2023-04-29 at 19 27 29](https://user-images.githubusercontent.com/571173/235315966-f37a7716-d3e0-42db-92a2-b09d29708be2.png)

Open issues:
- [x] Alignment of the `::before` icons is a little wonky. 

![Screenshot 2023-04-29 at 19 27 22](https://user-images.githubusercontent.com/571173/235316008-31e9ab73-c263-49c8-9cc7-7c99a2afedbf.png)

@benjaminwil Any suggestions on how to improve the alignment with the text?

