### PR TITLE
Add openssh client to docker image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ RUN apk add --update \
             bash \
             git \
             libc6-compat \
+            openssh \
             shadow \
     && rm -rf /var/cache/apk/* \
     && groupmod -g $GID www-data \

--- a/LATEST_CHANGES.md
+++ b/LATEST_CHANGES.md
@@ -2,3 +2,4 @@
 
 * Add support for Mermaid diagrams (@dometto).
 * Add support for downloading page sources with ?raw (@tstein).
+* Add openssh client to docker images for ssh: repo support. (@jagerkin).


### PR DESCRIPTION
Add the openssh alpine package to the docker image to allow ssh connected git repositories.
Issue: https://github.com/gollum/gollum/issues/1981