### PR TITLE
Do not encode slashes in redirects. Resolves #1979 .

### DIFF
--- a/lib/gollum/app.rb
+++ b/lib/gollum/app.rb
@@ -612,7 +612,7 @@ module Precious
     private
 
     def redirect_to(redirect_path, fullpath, query_params)
-        redirect to("#{encodeURIComponent(redirect_path)}?redirected_from=#{encodeURIComponent(fullpath)}#{query_params}")
+        redirect to("#{encodeURI(redirect_path)}?redirected_from=#{encodeURI(fullpath)}#{query_params}")
     end
 
     def page_does_not_exist()

--- a/lib/gollum/helpers.rb
+++ b/lib/gollum/helpers.rb
@@ -32,6 +32,12 @@ module Precious
     def remove_leading_and_trailing_slashes(str)
       str.sub(%r{^(/+)}, '').sub(%r{/+$}, '')
     end
+    
+    # https://stackoverflow.com/questions/65423458/ruby-2-7-says-uri-escape-is-obsolete-what-replaces-it/65462786#65462786
+    # Encode URI while leaving slashes intact
+    def encodeURI(uri)
+      encodeURIComponent(uri).gsub('%2F', '/')
+    end
 
     # Remove all slashes from the start of string.
     # Remove all double slashes


### PR DESCRIPTION
This PR resolves #1979 by ensuring that slashes in redirect paths are not encoded. For the future, a more systematic approach might be desired, such as using the [addressable](https://github.com/sporkmonger/addressable) gem for encoding URIs while preserving slashes. 