### PR TITLE
When uploads are allowed, do not interfere with dragging and dropping of text in Ace editor. Resolves #1953.

### DIFF
--- a/lib/gollum/public/gollum/javascript/editor/gollum.editor.js
+++ b/lib/gollum/public/gollum/javascript/editor/gollum.editor.js
@@ -306,6 +306,11 @@
               formData = new FormData();
           formData.append('file', file);
           
+          if (Object.prototype.toString.call(file) != '[object File]') {
+            $editorBody.removeClass('uploading');
+            return;
+          }
+          
           $.ajax({
             url: routePath('upload_file'),
             data: formData,


### PR DESCRIPTION
This PR resolves #1953 . 

Turns out that dragging and dropping of text is allowed by Ace out of the box. So our custom code to handle drag and drop file uploads was interfering with that feature, causing the `500` return status and corresponding message. The proposed fix is to check whether the dropped object is a File. If it isn't, then the code will return and let Ace do its thing (i.e. drop the dragged text into the editor). 