### PR TITLE
[WIP] Improve tabindex for navigation bar on Firefox.

### DIFF
--- a/lib/gollum/templates/navbar.mustache
+++ b/lib/gollum/templates/navbar.mustache
@@ -10,39 +10,23 @@
     {{>mobilenav}}
   </div>
 
-  <div class="TableObject-item hide-sm hide-md">
-    <a class="btn btn-sm" id="minibutton-home" href="{{page_route}}">
-      Home
-    </a>
+  <div class="TableObject-item hide-sm hide-md" tabindex="0">
+    <a id="minibutton-home" class="btn btn-sm" href="{{page_route}}">Home</a>
   </div>
 
-  <div
-    class="TableObject-item TableObject-item--primary px-2"
-    {{^search}}style="visibility:hidden"{{/search}}
-  >
+  <div class="TableObject-item TableObject-item--primary px-2"
+    {{^search}}style="visibility:hidden"{{/search}} >
     {{>searchbar}}
   </div>
 
   <div class="TableObject-item hide-sm hide-md">
     <div class="BtnGroup d-flex">
       {{#overview}}
-        <a
-          class="btn BtnGroup-item btn-sm"
-          href="{{overview_path}}"
-          id="minibutton-overview"
-        >
-          Overview
-        </a>
+        <a href="{{overview_path}}" class="btn BtnGroup-item btn-sm" id="minibutton-overview"><div tabindex="0">Overview</div></a>
       {{/overview}}
 
       {{#latest_changes}}
-        <a
-          class="btn BtnGroup-item btn-sm"
-          href="{{latest_changes_path}}"
-          id="minibutton-latest-changes"
-        >
-          Latest Changes
-        </a>
+        <a href="{{latest_changes_path}}" class="btn BtnGroup-item btn-sm" id="minibutton-latest-changes"><div tabindex="0">Latest Changes</div></a>
       {{/latest_changes}}
     </div>
   </div>
@@ -50,39 +34,25 @@
   <div class="TableObject-item px-2">
     <div class="BtnGroup d-flex">
       {{#history}}
-        <a
-          class="btn BtnGroup-item btn-sm hide-sm hide-md"
-          href="{{history_path}}/{{escaped_url_path}}/{{version}}"
-          id="minibutton-history"
-        >
-          History
+        <a href="{{history_path}}/{{escaped_url_path}}/{{version}}" id="minibutton-history" class="btn BtnGroup-item btn-sm hide-sm hide-md">
+          <div tabindex="0">History</div>
         </a>
       {{/history}}
 
       {{#allow_editing}}
         {{#allow_uploads}}
-          <button
-            class="btn BtnGroup-item btn-sm hide-sm hide-md
-              minibutton-upload-page"
-          >
+          <button class="btn BtnGroup-item btn-sm hide-sm hide-md minibutton-upload-page">
             Upload
           </button>
         {{/allow_uploads}}
 
         {{#editable}}
-          <button
-            class="btn BtnGroup-item btn-sm hide-sm hide-md
-              minibutton-rename-page"
-          >
+          <button class="btn BtnGroup-item btn-sm hide-sm hide-md minibutton-rename-page">
             Rename
           </button>
-          <a
-            class="btn BtnGroup-item btn-sm hide-sm hide-md"
-            href="{{edit_path}}/{{escaped_url_path}}"
-            id="minibutton-edit-page"
-          >
-            Edit
-          </a>
+            <a href="{{edit_path}}/{{escaped_url_path}}" id="minibutton-edit-page" class="btn BtnGroup-item btn-sm hide-sm hide-md">
+              <div tabindex="0">Edit</div>
+            </a>
         {{/editable}}
       {{/allow_editing}}
     </div>
@@ -91,18 +61,18 @@
   {{#allow_editing}}
     {{#editable}}
       <div class="TableObject-item">
-        <a class="btn btn-primary btn-sm minibutton-new-page" href="#">
+        <button class="btn btn-primary btn-sm minibutton-new-page">
           New
-        </a>
+        </button>
       </div>
     {{/editable}}
 
     {{^editable}}
       {{#newable}}
         <div class="TableObject-item">
-          <a class="btn btn-primary btn-sm minibutton-new-page" href="#">
+          <button class="btn btn-primary btn-sm minibutton-new-page">
             New
-          </a>
+          </button>
         </div>
       {{/newable}}
     {{/editable}}


### PR DESCRIPTION
This PR improves gollum's tabbing behavior on Firefox on OS X. 

On current `master`, not all buttons from the navigation bar are "tabbable" in Firefox 116.0.1 on OS X.  

![Screenshot 2023-08-14 at 16 10 44](https://github.com/gollum/gollum/assets/571173/bb39aa9e-a0c3-41f8-821f-c62253531a93)

The difference can be explained by looking at the underlying HTML: some buttons are actual `button`s (or divs) while others are `<a>` links that are styled as buttons. Those latter ones do not get focus, not even when `tabindex` is set explicitly to "0" (follow default tabbable order) or "1". 

Apparently, this behavior is caused by Firefox being true to [OS X preferences](https://stackoverflow.com/questions/11704828/how-to-allow-keyboard-focus-of-links-in-firefox). It can be "solved" by changing those preferences in OS X and/or changing some setting in Firefox. Alternatively, we can get more uniform behavior by either:

1. Changing all `<a>` elements into proper `button` elements. Upside: uniformity. Downside: the buttons that used to be links will need some `onClick` behavior to mimic the link behavior (i.e., setting `window.location.href`). That means all buttons will require JS to work.
2. Wrapping some of the `<a>` text in a `div` with `tabindex="0"` set. Upside: links will continue to work as they did before. Downside: less uniformity, as technically the tab focus will shift to the internal `div` and not to the button itself. 

![Screenshot 2023-08-15 at 13 42 36](https://github.com/gollum/gollum/assets/571173/8a4f8617-063c-4417-aa67-0c5b0f71c945)

I've implemented the second option, but I'm open to change course and go the first route. Let me know what you think! 

TODO:

- [ ] Test on Chrome
- [ ] Test on MS Edge