### PR TITLE
Don't run jobs on trivial changes

### DIFF
--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -3,6 +3,10 @@ on:
   push:
     branches:
       - master
+    paths-ignore:
+      - '**.md'
+      - '**.txt'
+      - 'contrib/**'
   release:
       types: [published]
 jobs:

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -1,7 +1,15 @@
 name: Build and Test Docker
 on:
   push:
+    paths-ignore:
+      - '**.md'
+      - '**.txt'
+      - 'contrib/**'
   pull_request:
+    paths-ignore:
+      - '**.md'
+      - '**.txt'
+      - 'contrib/**'
 env:
   CI_IMAGE: gollum-ci-img
 jobs:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,7 +2,15 @@ name: Ruby Build
 on:
   push:
     branches: master
+    paths-ignore:
+      - '**.md'
+      - '**.txt'
+      - 'contrib/**'
   pull_request:
+    paths-ignore:
+      - '**.md'
+      - '**.txt'
+      - 'contrib/**'
 jobs:
   jruby_build:
     name: JRuby (${{ matrix.ruby }})


### PR DESCRIPTION
Resolves #1948

This PR utilizes path filters to prevent jobs from running when the affected files in a PR or push *all* match the filters. So if only a combination of .md or .txt files are committed, the job does not run. The purpose of this is a) to not lose valuable time waiting for lights to turn green when this is not necessary 😃 and b) not to publish images to Dockerhub unnecessarily. (At this point, when we update the Readme, a new image is published and it looks like everyone's image is out of date.)

This PR enables this behavior for:

* testing
* docker build testing
* deploying the docker image

Please sanity check whether this is what we want, and whether there are any other significant path patterns tht we should exclude.

Unfortunately it looks like [there is no way to reuse the list of excluded paths in GitHub Actions](https://github.com/orgs/community/discussions/37645#discussioncomment-3995632)