### PR TITLE
Handle 409 gracefully

### DIFF
--- a/lib/gollum/app.rb
+++ b/lib/gollum/app.rb
@@ -288,7 +288,7 @@ module Precious
           @message = e.message
           mustache :error
         rescue Gollum::DuplicatePageError
-          halt 409 # Signal conflict
+          halt 409, "The file you are trying to upload already exists." # Signal conflict
         end
       end
 
@@ -373,7 +373,6 @@ module Precious
       end
 
       get '/create/*' do
-        puts "GET CREATE PARAMS: #{params.inspect}"
         forbid unless @allow_editing
         wikip = wiki_page(params[:splat].first)
         @name = wikip.name

--- a/lib/gollum/public/gollum/javascript/gollum.js.erb
+++ b/lib/gollum/public/gollum/javascript/gollum.js.erb
@@ -560,6 +560,9 @@ $(document).ready(function() {
           if (data.status == 412) {
             $('#gollum-editor-submit').attr('disabled', false)
             alert('Someone else has modified this page while you were editing it. Please store your version on disk outside of the browser, reload this page and reapply your modifications.');
+          } else if (data.status == 409) {
+            console.log(errorThrown)
+            alert('Error updating page: ' + textStatus + ' ' + errorThrown);
           } else {
             alert('Error updating page: ' + textStatus + ' ' + errorThrown);
           }  

--- a/lib/gollum/public/gollum/javascript/gollum.js.erb
+++ b/lib/gollum/public/gollum/javascript/gollum.js.erb
@@ -560,11 +560,8 @@ $(document).ready(function() {
           if (data.status == 412) {
             $('#gollum-editor-submit').attr('disabled', false)
             alert('Someone else has modified this page while you were editing it. Please store your version on disk outside of the browser, reload this page and reapply your modifications.');
-          } else if (data.status == 409) {
-            console.log(errorThrown)
-            alert('Error updating page: ' + textStatus + ' ' + errorThrown);
           } else {
-            alert('Error updating page: ' + textStatus + ' ' + errorThrown);
+            alert('Error updating page: ' + data.responseText);
           }  
         }
       });

--- a/test/test_app.rb
+++ b/test/test_app.rb
@@ -119,6 +119,15 @@ context "Frontend" do
     assert_equal last_response.status, 412
   end
 
+  test "duplicate page error when editing extension to match already existing page" do
+    page_1 = @wiki.page('A.md')
+    contents = page_1.raw_data
+    page_2 = @wiki.write_page('A', :txt, contents)
+    post "/gollum/edit/A.txt", :content => 'Orcs and such', :page => 'A.txt',
+         :format => :markdown, :message => 'def', :etag => page_1.sha
+    assert_equal last_response.status, 409
+  end
+
   test "edit page with empty message" do
     page_1 = @wiki.page('A')
     post "/gollum/edit/A", :content => 'abc', :page => 'A',


### PR DESCRIPTION
A `DuplicatePageError` is thrown when attempting to change the file extension of an exiting page to that of another already exististing page. That is, when: 

* A.md exists
* A.txt exists
* And we attempt to rename A.txt to A.md in the editor

This PR handles the resulting exception gracefully and returns a `409` in that case. It also ensures the error message is shown in the dialog that is triggered when pressing 'Save'