### PR TITLE
Add git configuration to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,9 @@ RUN apk add --update \
             shadow \
     && rm -rf /var/cache/apk/* \
     && groupmod -g $GID www-data \
-    && adduser -u $UID -S www-data -G www-data
+    && adduser -u $UID -S www-data -G www-data \
+    && git config --file /home/www-data/.gitconfig --add safe.directory /wiki \
+    && chown www-data:www-data /home/www-data/.gitconfig
 
 COPY docker-run.sh /docker-run.sh
 RUN chmod +x /docker-run.sh

--- a/LATEST_CHANGES.md
+++ b/LATEST_CHANGES.md
@@ -13,4 +13,4 @@
 
 ## Fixes & Improvements
 
-* Fix: add git configuration for `/wiki` as safe directory. #2006
+* Fix (Docker image): add git configuration for `/wiki` as safe directory. #2006

--- a/LATEST_CHANGES.md
+++ b/LATEST_CHANGES.md
@@ -10,3 +10,7 @@
 * Add support for downloading page sources with ?raw (@tstein).
 * Add openssh client to docker images for ssh: repo support. (@jagerkin).
 * Add support for mathematical typesetting using KaTeX (@dometto). Users can now choose between MathJax and KaTeX with the --math flag.
+
+## Fixes & Improvements
+
+* Fix: add git configuration for `/wiki` as safe directory. #2006


### PR DESCRIPTION
Adds a `.gitconfig` containing the proper setting for `safe.directory` to allow the container user to load git configs under the `/wiki` directory. 

Fixes #2006 
