### PR TITLE
Improve and localize the "edit" view partial

### DIFF
--- a/lib/gollum/locales/en.yml
+++ b/lib/gollum/locales/en.yml
@@ -16,6 +16,10 @@ en:
     comparing_versions_of: Comparing versions of
     comparing_from: "Comparing %{before} to %{after}"
     revert: Revert Changes
+  precious/views/edit:
+    edit: Edit
+    preview: Preview
+    title: "Editing %{title}"
   precious/views/error:
     error: Error
   precious/views/history:

--- a/lib/gollum/templates/edit.mustache
+++ b/lib/gollum/templates/edit.mustache
@@ -8,10 +8,10 @@
   </div>
 <div class="tabnav">
   <nav class="tabnav-tabs">
-    <button href="#" id="edit" class="tabnav-tab selected" aria-current="page">
+    <button id="edit" class="tabnav-tab selected" aria-current="page">
       {{t.edit}}
     </button>
-    <button href="#" id="preview" class="tabnav-tab">{{t.preview}}</button>
+    <button id="preview" class="tabnav-tab">{{t.preview}}</button>
   </nav>
 </div>
   <div class="tabnav-div" id="edit-content">{{>editor}}</div>

--- a/lib/gollum/templates/edit.mustache
+++ b/lib/gollum/templates/edit.mustache
@@ -3,15 +3,15 @@
     {{>navbar}}
 
     <h1 class="header-title text-center text-md-left py-4">
-      Editing <strong>{{title}}</strong>
+      {{t.title}}
     </h1>
   </div>
 <div class="tabnav">
   <nav class="tabnav-tabs">
     <button href="#" id="edit" class="tabnav-tab selected" aria-current="page">
-      Edit
+      {{t.edit}}
     </button>
-    <button href="#" id="preview" class="tabnav-tab">Preview</button>
+    <button href="#" id="preview" class="tabnav-tab">{{t.preview}}</button>
   </nav>
 </div>
   <div class="tabnav-div" id="edit-content">{{>editor}}</div>

--- a/lib/gollum/templates/edit.mustache
+++ b/lib/gollum/templates/edit.mustache
@@ -6,14 +6,19 @@
       {{t.title}}
     </h1>
   </div>
-<div class="tabnav">
-  <nav class="tabnav-tabs">
-    <button id="edit" class="tabnav-tab selected" aria-current="page">
-      {{t.edit}}
-    </button>
-    <button id="preview" class="tabnav-tab">{{t.preview}}</button>
-  </nav>
-</div>
+
+  <div class="tabnav">
+    <nav class="tabnav-tabs">
+      <button id="edit" class="tabnav-tab selected" aria-current="page">
+        {{t.edit}}
+      </button>
+
+      <button id="preview" class="tabnav-tab">
+        {{t.preview}}
+      </button>
+    </nav>
+  </div>
+
   <div class="tabnav-div" id="edit-content">{{>editor}}</div>
 	<div class="tabnav-div" id="preview-content"></div>
 </div>

--- a/test/capybara_helper.rb
+++ b/test/capybara_helper.rb
@@ -28,6 +28,33 @@ def console_log(page, level = :severe)
   page.driver.browser.logs.get(:browser).select { |log| log.level == level.to_s.upcase }
 end
 
+def create_page(title:, content:)
+  visit "/"
+
+  click_on "New"
+  fill_in "Page Name", with: title
+  click_on "OK"
+
+  assert_includes page.text, "Create New Page"
+
+  page_title_field = find "input#gollum-editor-page-title"
+  assert_includes page_title_field.value, title
+
+  within "div.ace_content" do
+    send_keys content
+    assert page.text, content
+  end
+
+  assert page.current_path.start_with? "/gollum/create"
+
+  click_on "Save"
+
+  using_wait_time 10 do
+    escaped_title = title.gsub(" ", "%20")
+    assert page.current_path, "/#{escaped_title}.md"
+  end
+end
+
 def wait_for_ajax
   # https://thoughtbot.com/blog/automatically-wait-for-ajax-with-capybara
   Timeout.timeout(Capybara.default_max_wait_time) do

--- a/test/integration/test_editor.rb
+++ b/test/integration/test_editor.rb
@@ -21,6 +21,32 @@ context "editor interface" do
     Capybara.use_default_driver
   end
 
+  test "editor 'edit' and 'preview' panes render editor and preview, respectively" do
+    create_page title: "Just another test page...", content: <<~TEXT
+      After this page has been created, we will assert that this content is
+      rendered as part of the page preview.
+    TEXT
+
+    current_page_title = find "h1.header-title"
+    assert current_page_title, "Just another test page..."
+
+    click_on "Edit" # Open the editor for the current page.
+
+    editor_container = find ".ace_content"
+    assert editor_container.visible?
+
+    click_on "Preview"
+    refute editor_container.visible?
+
+    within "#wiki-content" do
+      assert_includes page.text,
+        "this content is rendered as part of the page preview"
+    end
+
+    click_on "Edit"
+    assert editor_container.visible?
+  end
+
   test "editor renders help panel" do
     visit "/create/new-article"
 

--- a/test/integration/test_page.rb
+++ b/test/integration/test_page.rb
@@ -78,31 +78,4 @@ context "viewing a wiki page" do
 
     assert search_field.value, "a juicy fish, so nice and fresh"
   end
-
-  def create_page(title:, content:)
-    visit "/"
-
-    click_on "New"
-    fill_in "Page Name", with: title
-    click_on "OK"
-
-    assert_includes page.text, "Create New Page"
-
-    page_title_field = find "input#gollum-editor-page-title"
-    assert_includes page_title_field.value, title
-
-    within "div.ace_content" do
-      send_keys content
-      assert page.text, content
-    end
-
-    assert page.current_path.start_with? "/gollum/create"
-
-    click_on "Save"
-
-    using_wait_time 10 do
-      escaped_title = title.gsub(" ", "%20")
-      assert page.current_path, "/#{escaped_title}.md"
-    end
-  end
 end


### PR DESCRIPTION
This small change started to localize the "edit" view partial.

While I was looking at this partial I realized that a) it was indented in an unconventional way and b) its buttons had `href` attributes, which is not something that `<button>`s have in valid HTML documents.
