### PR TITLE
Fix JRuby CI runs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [jruby-9.4.3.0]
+        ruby: [jruby-9.4.4.0]
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3


### PR DESCRIPTION
The JRuby build that our CI pipeline uses comes from [`ruby/ruby-builder`][^1]. The Ruby version specified in our CI configuration was 9.4.3.0, which hasn't been rebuilt and re-released on `ruby/ruby-builder` since June 2023. Since October 2023, CI runs fail because of an issue with Psych 5.1.1[^2]:

    NameError: cannot load (ext) (org.jruby.ext.psych.PsychLibrary)
      org/jruby/ext/jruby/JRubyUtilLibrary.java:219:in `load_ext'
      /home/runner/work/gollum/gollum/vendor/bundle/jruby/3.1.0/gems/psych-5.1.1-java/lib/psych.rb:7:in `<main>'
      org/jruby/RubyKernel.java:1071:in `require'
      /home/runner/.rubies/jruby-9.4.3.0/lib/ruby/stdlib/rubygems/core_ext/kernel_require.rb:85:in `require'
      /home/runner/.rubies/jruby-9.4.3.0/lib/ruby/stdlib/rubygems.rb:610:in `load_yaml'
      /home/runner/.rubies/jruby-9.4.3.0/lib/ruby/stdlib/rubygems/config_file.rb:346:in `load_file'
      /home/runner/.rubies/jruby-9.4.3.0/lib/ruby/stdlib/rubygems/config_file.rb:189:in `initialize'
      org/jruby/RubyClass.java:904:in `new'
      /home/runner/.rubies/jruby-9.4.3.0/lib/ruby/stdlib/rubygems.rb:331:in `configuration'
      /home/runner/.rubies/jruby-9.4.3.0/lib/ruby/stdlib/bundler/fetcher.rb:248:in `connection'
      /home/runner/.rubies/jruby-9.4.3.0/lib/ruby/stdlib/bundler/fetcher.rb:94:in `initialize'
      org/jruby/RubyClass.java:904:in `new'

And I think that continuing to use this old June 2023-built JRuby means that this cache key will always get a hit:

    setup-ruby-bundler-cache-v6-ubuntu-22.04-x64-jruby-9.4.3.0-wd-/home/runner/work/gollum/gollum-with--without--only--Gemfile.lock-9cf03e77b9c4eabac62cb684d5aedd235ef3cc35c45aa257823f0291dff56644

And I am hoping that using the newly-built JRuby 9.4.4.0 from October 2023 lets us side-step this failure by busting that cache key and letting us installed Psych 5.1.1.1 which was specifically released to resolve an issue with Psych and JRuby.

[^1]: https://github.com/ruby/ruby-builder
[^2]: https://github.com/gollum/gollum/actions/runs/6540126411/job/17929146783