### PR TITLE
Deprecate RACK_ENV in favour of APP_ENV

### DIFF
--- a/LATEST_CHANGES.md
+++ b/LATEST_CHANGES.md
@@ -3,6 +3,7 @@
 # Breaking Changes
 
 * Docker image: removed deprecated automatic activation of --mathjax. Pass '--math mathjax' to continue using mathjax, or '--math' to use KaTeX (see below).
+* RACK_ENV is ignored, please use APP_ENV instead (@svoop).
 
 ## New features
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Gollum is a simple wiki system built on top of Git. A Gollum Wiki is simply a gi
 	* Can be displayed in all versions, reverted, etc.
 * Gollum strives to be [compatible](https://github.com/gollum/gollum/wiki/5.0-release-notes#compatibility-option) with [GitHub](https://docs.github.com/en/communities/documenting-your-project-with-wikis/about-wikis) and [GitLab](https://docs.gitlab.com/ee/user/project/wiki/#create-or-edit-wiki-pages-locally) wikis.
   * Just clone your GitHub/GitLab wiki and view and edit it locally!
-	
+
 * Gollum supports advanced functionality like:
   * [UML diagrams](https://github.com/gollum/gollum/wiki#plantuml-diagrams)
   * [BibTeX and Citation support](https://github.com/gollum/gollum/wiki/BibTeX-and-Citations)
@@ -49,7 +49,7 @@ Ruby is best installed either via [RVM](https://rvm.io/) or a package manager of
 	```
 	gem install gollum
 	```
-	
+
 Installation examples for individual systems can be seen [here](https://github.com/gollum/gollum/wiki/Installation).
 
 To run, simply:
@@ -113,6 +113,13 @@ Gollum can also be run alongside a CAS (Central Authentication Service) SSO (sin
 ### Service
 
 Gollum can also be run as a service. More on that [over here](https://github.com/gollum/gollum/wiki/Gollum-as-a-service).
+
+## ENVIRONMENT
+
+Gollum uses the environment variable `APP_ENV` primarily to control how the underlying Sinatra app behaves:
+
+* `development` – reload the app on every request
+* `production` – load the app only once
 
 ## CONFIGURATION
 

--- a/bin/gollum
+++ b/bin/gollum
@@ -205,7 +205,7 @@ MSG
     puts results.empty? ? 'none' : results
     exit 0
   end
-  
+
   opts.separator ''
   opts.separator '  Development:'
 
@@ -282,7 +282,12 @@ if options[:irb]
   end
 else
   require 'gollum/app'
-  Precious::App.set(:environment, ENV.fetch('RACK_ENV', :production).to_sym)
+  # TODO: Remove RACK_ENV fallback once gollum-7 is released (4 lines)
+  if ENV['RACK_ENV'] && !ENV['APP_ENV']
+    warn "[DEPRECATION] RACK_ENV will be ignored as of gollum-6.0.0, please use APP_ENV instead."
+    ENV['APP_ENV'] = ENV['RACK_ENV']
+  end
+  Precious::App.set(:environment, ENV.fetch('APP_ENV', :production).to_sym)
   Precious::App.set(:gollum_path, gollum_path)
   Precious::App.set(:wiki_options, wiki_options)
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -28,7 +28,7 @@ else
   Gollum::GIT_ADAPTER = RUBY_PLATFORM == 'java' ? 'rjgit' : 'rugged'
 end
 
-ENV['RACK_ENV'] = 'test'
+ENV['APP_ENV'] = 'test'
 require 'gollum'
 require 'gollum/app'
 


### PR DESCRIPTION
Say goodbye for the often misused `RACK_ENV` in favour of `APP_ENV` (like Sinatra does). A deprecation warning is printed if only `RACK_ENV` is set and Golllum has not yet reached version 6.

Related issue: #2029
