### PR TITLE
Docker semver supports

### DIFF
--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -13,21 +13,32 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Set deploy name to master
-        if: github.ref == 'refs/heads/master'
-        run: |
-          echo "DEPLOY_NAME=gollumwiki/gollum:master" >> $GITHUB_ENV
-      - name: Set deploy name to release version
-        if: startsWith(github.ref, 'refs/tags/')
-        run: |
-          echo "DEPLOY_NAME=gollumwiki/gollum:${{ github.ref_name }}" >> $GITHUB_ENV
       - name: Check Out Repo
         uses: actions/checkout@v2
-      - name: Login
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: |
+            gollumwiki/gollum
+            ghcr.io/gollum/gollum
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
+      - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      - name: Login to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v1
@@ -46,7 +57,8 @@ jobs:
           file: ./Dockerfile
           builder: ${{ steps.buildx.outputs.name }}
           push: true
-          tags: ${{ env.DEPLOY_NAME }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
           platforms: linux/amd64, linux/arm64


### PR DESCRIPTION
Append docker semver support to using like:
```bash
docker pull gollumwiki/gollum
docker pull gollumwiki/gollum:latest
docker pull gollumwiki/gollum:5.3.2         # Concrete version
docker pull gollumwiki/gollum:5.3           # Concrete minor version with latest hotfixes
docker pull gollumwiki/gollum:5             # Concrete major version with latest minor updates and hotfixes
docker pull gollumwiki/gollum:db4adc2       # Concrete commit

docker pull ghcr.io/gollum/gollum:5.3       # Use GitHub Container Registry as alternative registry
```