### PR TITLE
Fix: GitHub Actions trigger for docker-deploy workflow

### DIFF
--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -3,12 +3,12 @@ on:
   push:
     branches:
       - master
+    tags:
+      - "*"
     paths-ignore:
       - '**.md'
       - '**.txt'
       - 'contrib/**'
-  release:
-      types: [published]
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -17,12 +17,13 @@ jobs:
         uses: actions/checkout@v2
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v5
         with:
           images: |
             gollumwiki/gollum
             ghcr.io/gollum/gollum
           tags: |
+            type=ref,event=branch,pattern=master
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}


### PR DESCRIPTION
Fix for gollum/gollum#2032

I apologize for the wait and the mistake I made in the previous PR.

[docker/metadata-action@v5](https://github.com/docker/metadata-action/tree/v5) can't handle `release` trigger, but works with `tags` trigger that are fire when created release.

Now the deployment is configured according to the following scheme:
- when push to `master`, creating images with tags `master` and `sha-{sha}`
- when push tags, creating images with tags `master`, `sha-{sha}`, `latest` and all semver variants 

---

> [!IMPORTANT]  
> Please create hotfix release `5.3.3` after merge PR for generating semver tags for image
> Otherwise only the `master` and `sha` tags will be created