### PR TITLE
Support for more languages: chinese

### DIFF
--- a/LATEST_CHANGES.md
+++ b/LATEST_CHANGES.md
@@ -11,6 +11,7 @@
 * Add support for downloading page sources with ?raw (@tstein).
 * Add openssh client to docker images for ssh: repo support. (@jagerkin).
 * Add support for mathematical typesetting using KaTeX (@dometto). Users can now choose between MathJax and KaTeX with the --math flag.
+* Add support for more languages (such as: Chinese).
 
 ## Fixes & Improvements
 

--- a/lib/gollum.rb
+++ b/lib/gollum.rb
@@ -16,8 +16,9 @@ module Gollum
   VERSION = '5.3.0'
   KEYBINDINGS = ['default', 'vim', 'emacs']
   
-  ::I18n.available_locales = [:en]
+  ::I18n.available_locales = [:en, :cn]
   ::I18n.load_path = Dir[::File.expand_path("../gollum/locales",  __FILE__) + "/*.yml"]
+  ::I18n.default_locale = :en
 
   def self.assets_path
     ::File.expand_path('gollum/public', ::File.dirname(__FILE__))

--- a/lib/gollum/locales/cn.yml
+++ b/lib/gollum/locales/cn.yml
@@ -1,0 +1,103 @@
+cn:
+  create:
+    title: 创建新的页面
+    edit: 编辑
+    preview: 预览
+  navbar:
+    home_button: 首页
+    overview_button: 总览
+    latest_changes_button: 修改记录
+    history_button: 历史版本
+    upload_button: 上传文件
+    rename_button: 重命名
+    edit_button: 编辑
+    new_button: 新建
+  searchbar:
+    placeholder: 搜索
+    aria:
+      label: 站内搜索
+  wiki_content:
+    last_edit: 显示最后修改信息
+    delete_link:
+      title: 删除页面
+      confirm: 确定要删除此页面吗？
+  editor:
+    restore_button:
+      value: 恢复
+      prompt: 自动保存可用，单击按钮恢复。
+    function_bar:
+      heading1:
+        value: 标题1
+        title: 一级标题
+      heading2:
+        value: 标题2
+        title: 二级标题
+      heading3:
+        value: 标题3
+        title: 三级标题
+      link: 链接
+      image: 图片
+      bold: 加粗
+      italic: 斜体
+      code: 代码块
+      unordered_list: 无序列表
+      ordered_list: 有序列表
+      blockquote: 引用块
+      horizontal_rule: 水平标尺
+      accept_selected_criticMarkup: 接受选定的标注
+      reject_selected_criticMarkup: 拒绝选定的标注
+      reverse_text_direction: 反转文本方向
+      help: 帮助
+      keybinding: 设置按键绑定
+      wiki_format: 设置此页面的格式
+      rendering_unavailable_for: 渲染不可用
+    save_button:
+      value: 保存
+      title: 保存当前更改
+    cancel_button:
+      value: 取消
+      title: 取消编辑
+      confirm: 取消编辑可能会导致当前已编辑内容丢失。您确定要继续吗？
+    note:
+      title: "提示："
+      content: "此页面将创建在 %{path} 目录中。"
+  pagination:
+    aria:
+      label: 页码
+      next_page: 下一页
+      previous_page: 上一页
+    next: 前进
+    previous: 后退
+  precious/views/compare:
+    back_to_page_history: 返回历史
+    back_to_top: 回到顶部
+    comparison_of: 比较
+    comparing_versions_of: "%{name} 的版本差异"
+    comparing_from: "%{before} 和 %{after}"
+    revert: 撤销更改
+  precious/views/edit:
+    edit: 编辑
+    preview: 预览
+    title: "编辑 %{title}"
+  precious/views/error:
+    error: 错误
+  precious/views/history:
+    browse_in_history_description: 查看此版本
+    compare_revisions: 比较差异
+    history_for: "%{name} 的历史版本"
+  precious/views/latest_changes:
+    title: 修改记录 (所有页面)
+  precious/views/layout:
+    title: 主页
+  precious/views/overview:
+    back_to_top: 回到顶部
+    delete_confirmation: "确定要删除 %{name} 吗？"
+    no_pages_in: "%{ref} 中没有页面。"
+    title: "%{ref} 总览"
+  precious/views/search:
+    aria:
+      show_all: Show all hits on this page
+    back_to_top: 回到顶部
+    no_results: 找不到任何您要搜索的内容。
+    search_results_for: "%{query} 的搜索结果"
+    title: "%{query} 的搜索结果"

--- a/lib/gollum/locales/en.yml
+++ b/lib/gollum/locales/en.yml
@@ -1,7 +1,66 @@
 en:
+  create:
+    title: Create New Page
+    edit: Edit
+    preview: Preview
+  navbar:
+    home_button: Home
+    overview_button: Overview
+    latest_changes_button: Latest Changes
+    history_button: History
+    upload_button: Upload
+    rename_button: Rename
+    edit_button: Edit
+    new_button: New
+  searchbar:
+    placeholder: Search
+    aria:
+      label: Search site
+  wiki_content:
+    last_edit: When was this page last modified?
+    delete_link:
+      title: Delete this Page
+      confirm: Are you sure you want to delete this page?
   editor:
+    restore_button:
+      value: Restore Text
+      prompt: Autosaved text is available. Click the button to restore it.
     function_bar:
+      heading1:
+        value: H1
+        title: Heading 1
+      heading2:
+        value: H2
+        title: Heading 2
+      heading3:
+        value: H3
+        title: Heading 3
+      link: Link
+      image: Image
+      bold: Bold
+      italic: Italic
+      code: Code
+      unordered_list: Unordered list
+      ordered_list: Ordered list
+      blockquote: Blockquote
+      horizontal_rule: Horizontal rule
+      accept_selected_criticMarkup: Accept Selected CriticMarkup
+      reject_selected_criticMarkup: Reject Selected CriticMarkup
+      reverse_text_direction: Reverse Text Direction
       help: Help
+      keybinding: Set your preferred keybinding
+      wiki_format: Set this page's format to
+      rendering_unavailable_for: Rendering unavailable for
+    save_button:
+      value: Save
+      title: Save current changes
+    cancel_button:
+      value: Cancel
+      title: Cancel editing
+      confirm: Cancelling may result in data loss. Are you sure you wish to proceed?
+    note:
+      title: "NOTE:"
+      content: "This page will be created within the %{path} directory."
   pagination:
     aria:
       label: Pagination
@@ -13,7 +72,7 @@ en:
     back_to_page_history: Back to Page History
     back_to_top: Back to Top
     comparison_of: Comparison of
-    comparing_versions_of: Comparing versions of
+    comparing_versions_of: "Comparing versions of %{name}"
     comparing_from: "Comparing %{before} to %{after}"
     revert: Revert Changes
   precious/views/edit:
@@ -25,7 +84,7 @@ en:
   precious/views/history:
     browse_in_history_description: Browse the page at this point in the history
     compare_revisions: Compare Revisions
-    history_for: History for
+    history_for: "History for %{name}"
   precious/views/latest_changes:
     title: Latest Changes (Globally)
   precious/views/layout:
@@ -33,13 +92,12 @@ en:
   precious/views/overview:
     back_to_top: Back to Top
     delete_confirmation: "Are you sure you want to delete %{name}?"
-    no_pages_in: There are no pages in
-    on: "on"
+    no_pages_in: "There are no pages in on %{ref}."
     title: "Overview of %{ref}"
   precious/views/search:
     aria:
       show_all: Show all hits on this page
     back_to_top: Back to Top
-    no_results: There are no results for your search
-    search_results_for: Search results for
+    no_results: There are no results for your search.
+    search_results_for: "Search results for %{query}"
     title: "Search results for %{query}"

--- a/lib/gollum/templates/compare.mustache
+++ b/lib/gollum/templates/compare.mustache
@@ -3,10 +3,7 @@
     {{>navbar}}
 
     <h1 class="header-title text-center text-md-left py-4">
-      <span class="f1-light color-fg-subtle">
-        {{t.comparing_versions_of}}
-      </span>
-      {{name}}
+      {{t.comparing_versions_of}}
     </h1>
   </div>
 

--- a/lib/gollum/templates/create.mustache
+++ b/lib/gollum/templates/create.mustache
@@ -3,16 +3,16 @@
     {{>navbar}}
 
     <h1 class="header-title text-center text-md-left py-4">
-      Create New Page
+      {{tt.create.title}}
     </h1>
   </div>
 <div id="wiki-content" class="create edit">
   <div class="tabnav">
     <nav class="tabnav-tabs" aria-label="Toggle edit or preview mode">
       <a href="#" id="edit" class="tabnav-tab selected" aria-current="page">
-        Edit
+        {{tt.create.edit}}
       </a>
-      <a href="#" id="preview" class="tabnav-tab">Preview</a>
+      <a href="#" id="preview" class="tabnav-tab">{{tt.create.preview}}</a>
     </nav>
   </div>
 

--- a/lib/gollum/templates/editor.mustache
+++ b/lib/gollum/templates/editor.mustache
@@ -11,7 +11,7 @@
     <label for="page" class="jaws">Page Title</label>
     <input class="form-control mb-2 input-lg input-block text-bold f5" placeholder="Page title" type="text" name="page" id="gollum-editor-page-title" value="{{page_name}}">
     {{#has_path}}
-    <p class="path_note"><strong>NOTE:</strong> This page will be created within the &quot;<strong>{{path}}</strong>&quot; directory</p>
+    <p class="path_note"><strong>{{tt.editor.note.title}}</strong> {{tt.editor.note.content}}</p>
     {{/has_path}}
   </div>
   {{/is_create_page}}
@@ -24,37 +24,37 @@
   <div id="gollum-editor-function-bar" class="border-bottom clearfix mb-2">
     <div id="gollum-editor-function-buttons" class="overflow-auto no-wrap">
       <div class="BtnGroup">
-        <button class="btn btn-sm BtnGroup-item function-button" id="function-h1" title="Heading 1">h1</button>
-        <button class="btn btn-sm BtnGroup-item function-button" id="function-h2" title="Heading 2">h2</button>
-        <button class="btn btn-sm BtnGroup-item function-button" id="function-h3" title="Heading 3">h3</button>
+        <button class="btn btn-sm BtnGroup-item function-button" id="function-h1" title="{{tt.editor.function_bar.heading1.title}}">{{tt.editor.function_bar.heading1.value}}</button>
+        <button class="btn btn-sm BtnGroup-item function-button" id="function-h2" title="{{tt.editor.function_bar.heading2.title}}">{{tt.editor.function_bar.heading2.value}}</button>
+        <button class="btn btn-sm BtnGroup-item function-button" id="function-h3" title="{{tt.editor.function_bar.heading3.title}}">{{tt.editor.function_bar.heading3.value}}</button>
       </div>
 
       <div class="BtnGroup">
-        <button class="btn btn-sm BtnGroup-item function-button" id="function-link" title="Link">{{#octicon}}link{{/octicon}}</button>
-        <button class="btn btn-sm BtnGroup-item function-button" id="function-image" title="Image">{{#octicon}}image{{/octicon}}</button>
+        <button class="btn btn-sm BtnGroup-item function-button" id="function-link" title="{{tt.editor.function_bar.link}}">{{#octicon}}link{{/octicon}}</button>
+        <button class="btn btn-sm BtnGroup-item function-button" id="function-image" title="{{tt.editor.function_bar.image}}">{{#octicon}}image{{/octicon}}</button>
       </div>
 
       <div class="BtnGroup">
-        <button class="btn btn-sm BtnGroup-item function-button" id="function-bold" title="Bold">{{#octicon}}bold{{/octicon}}</button>
-        <button class="btn btn-sm BtnGroup-item function-button" id="function-italic" title="Italic">{{#octicon}}italic{{/octicon}}</button>
-        <button class="btn btn-sm BtnGroup-item function-button" id="function-code" title="Code">{{#octicon}}code{{/octicon}}</button>
+        <button class="btn btn-sm BtnGroup-item function-button" id="function-bold" title="{{tt.editor.function_bar.bold}}">{{#octicon}}bold{{/octicon}}</button>
+        <button class="btn btn-sm BtnGroup-item function-button" id="function-italic" title="{{tt.editor.function_bar.italic}}">{{#octicon}}italic{{/octicon}}</button>
+        <button class="btn btn-sm BtnGroup-item function-button" id="function-code" title="{{tt.editor.function_bar.code}}">{{#octicon}}code{{/octicon}}</button>
       </div>
 
       <div class="BtnGroup">
-        <button class="btn btn-sm BtnGroup-item function-button" id="function-ul" title="Unordered list">{{#octicon}}list-unordered{{/octicon}}</button>
-        <button class="btn btn-sm BtnGroup-item function-button" id="function-ol" title="Ordered list">{{#octicon}}list-ordered{{/octicon}}</button>
-        <button class="btn btn-sm BtnGroup-item function-button" id="function-blockquote" title="Blockquote">{{#octicon}}quote{{/octicon}}</button>
-        <button class="btn btn-sm BtnGroup-item function-button" id="function-hr" title="Horizontal rule">{{#octicon}}horizontal-rule{{/octicon}}</button>
+        <button class="btn btn-sm BtnGroup-item function-button" id="function-ul" title="{{tt.editor.function_bar.unordered_list}}">{{#octicon}}list-unordered{{/octicon}}</button>
+        <button class="btn btn-sm BtnGroup-item function-button" id="function-ol" title="{{tt.editor.function_bar.ordered_list}}">{{#octicon}}list-ordered{{/octicon}}</button>
+        <button class="btn btn-sm BtnGroup-item function-button" id="function-blockquote" title="{{tt.editor.function_bar.blockquote}}">{{#octicon}}quote{{/octicon}}</button>
+        <button class="btn btn-sm BtnGroup-item function-button" id="function-hr" title="{{tt.editor.function_bar.horizontal_rule}}">{{#octicon}}horizontal-rule{{/octicon}}</button>
       </div>
 
       {{#critic_markup}}
       <div class="BtnGroup">
-        <button class="btn btn-sm BtnGroup-item function-button" id="function-critic-accept" title="Accept Selected CriticMarkup">{{#octicon}}plus{{/octicon}}</button>
-        <button class="btn btn-sm BtnGroup-item function-button" id="function-critic-reject" title="Reject Selected CriticMarkup">{{#octicon}}dash{{/octicon}}</button>
+        <button class="btn btn-sm BtnGroup-item function-button" id="function-critic-accept" title="{{tt.editor.function_bar.accept_selected_criticMarkup}}">{{#octicon}}plus{{/octicon}}</button>
+        <button class="btn btn-sm BtnGroup-item function-button" id="function-critic-reject" title="{{tt.editor.function_bar.reject_selected_criticMarkup}}">{{#octicon}}dash{{/octicon}}</button>
       </div>
       {{/critic_markup}}
 
-      <button class="btn btn-sm function-button" id="function-text-direction" title="Reverse Text Direction">{{#octicon}}arrow-both{{/octicon}}</button>
+      <button class="btn btn-sm function-button" id="function-text-direction" title="{{tt.editor.function_bar.reverse_text_direction}}">{{#octicon}}arrow-both{{/octicon}}</button>
       
       <button
         aria-label="{{tt.editor.function_bar.help}}"
@@ -79,7 +79,7 @@
           <div id="keybinding" class="SelectMenu BasicSelect">
             <div class="SelectMenu-modal">
               <header class="SelectMenu-header">
-                <h3 class="SelectMenu-title text-left">Set your preferred keybinding</h3>
+                <h3 class="SelectMenu-title text-left">{{tt.editor.function_bar.keybinding}}</h3>
               </header>
               <div class="SelectMenu-list">
                 {{#keybindings}}
@@ -106,7 +106,7 @@
           <div id="wiki_format" class="SelectMenu BasicSelect">
             <div class="SelectMenu-modal">
               <header class="SelectMenu-header">
-                <h3 class="SelectMenu-title text-left">Set this page's format to</h3>
+                <h3 class="SelectMenu-title text-left">{{tt.editor.function_bar.wiki_format}}</h3>
               </header>
               <div class="SelectMenu-list">
                 {{#formats}}
@@ -118,7 +118,7 @@
                 </button>
                 {{/enabled}}
                 {{/formats}}
-                <div class="SelectMenu-divider text-left">Rendering unavailable for</div>
+                <div class="SelectMenu-divider text-left">{{tt.editor.function_bar.rendering_unavailable_for}}</div>
                 {{#formats}}
                 {{^enabled}}
                 <button class="SelectMenu-item" value="{{id}}" data-ext="{{ext}}" role="menuitemcheckbox" {{#selected}}aria-checked="true"{{/selected}} disabled>
@@ -159,8 +159,8 @@
     </div>
   </div>
   <div id="gollum-autorecover-msg" class="flash my-2" hidden>
-      Autosaved text is available. Click the button to restore it.
-      <button id="gollum-autorecover-button" class="btn btn-sm primary flash-action">Restore Text</button>
+      {{tt.editor.restore_button.prompt}}
+      <button id="gollum-autorecover-button" class="btn btn-sm primary flash-action">{{tt.editor.restore_button.value}}</button>
   </div>
     <textarea id="gollum-editor-body" class="form-control text-mono"
      data-markup-lang="{{format}}" name="content" class="mousetrap">{{content}}</textarea>
@@ -206,8 +206,8 @@
 
     <span class="jaws"><br></span>
 		<div class="form-actions">
-    	<input type="submit" id="gollum-editor-submit" class="btn btn-primary" value="Save" title="Save current changes">
-    	<a id="gollum-editor-cancel" class="btn" type="button" title="Cancel editing" onClick="if(confirm('Cancelling may result in data loss. Are you sure you wish to proceed?')) { window.history.back()}">Cancel</a>
+    	<input type="submit" id="gollum-editor-submit" class="btn btn-primary" value="{{tt.editor.save_button.value}}" title="{{tt.editor.save_button.title}}">
+    	<a id="gollum-editor-cancel" class="btn" type="button" title="{{tt.editor.cancel_button.title}}" onClick="if(confirm('{{tt.editor.cancel_button.confirm}}')) { window.history.back()}">{{tt.editor.cancel_button.value}}</a>
 		</div>
   </fieldset>
 </form>

--- a/lib/gollum/templates/history.mustache
+++ b/lib/gollum/templates/history.mustache
@@ -3,10 +3,7 @@
   {{>navbar}}
 
   <h1 class="header-title text-center text-md-left py-4">
-    <span class="f1-light color-fg-subtle">
-      {{t.history_for}}
-    </span>
-    {{name}}
+    {{t.history_for}}
   </h1>
 </div>
 

--- a/lib/gollum/templates/navbar.mustache
+++ b/lib/gollum/templates/navbar.mustache
@@ -14,7 +14,7 @@
     <button class="btn btn-sm" id="minibutton-home" 
       onclick="window.location.href='{{page_route}}';"
     >
-      Home
+      {{tt.navbar.home_button}}
     </button>
   </div>
 
@@ -33,7 +33,7 @@
           onclick="window.location.href='{{overview_path}}';"
           id="minibutton-overview"
         >
-          Overview
+          {{tt.navbar.overview_button}}
         </button>
       {{/overview}}
 
@@ -43,7 +43,7 @@
           onclick="window.location.href='{{latest_changes_path}}';"
           id="minibutton-latest-changes"
         >
-          Latest Changes
+          {{tt.navbar.latest_changes_button}}
         </button>
       {{/latest_changes}}
     </div>
@@ -57,7 +57,7 @@
           onclick="window.location.href='{{history_path}}/{{escaped_url_path}}/{{version}}';"
           id="minibutton-history"
         >
-          History
+          {{tt.navbar.history_button}}
         </button>
       {{/history}}
 
@@ -66,7 +66,7 @@
           <button
             class="btn BtnGroup-item btn-sm hide-sm hide-md minibutton-upload-page"
           >
-            Upload
+            {{tt.navbar.upload_button}}
           </button>
         {{/allow_uploads}}
 
@@ -74,14 +74,14 @@
           <button
             class="btn BtnGroup-item btn-sm hide-sm hide-md minibutton-rename-page"
           >
-            Rename
+            {{tt.navbar.rename_button}}
           </button>
           <button
             class="btn BtnGroup-item btn-sm hide-sm hide-md"
             onclick="window.location.href='{{edit_path}}/{{escaped_url_path}}';"
             id="minibutton-edit-page"
           >
-            Edit
+            {{tt.navbar.edit_button}}
           </button>
         {{/editable}}
       {{/allow_editing}}
@@ -92,7 +92,7 @@
     {{#editable}}
       <div class="TableObject-item">
         <button class="btn btn-primary btn-sm minibutton-new-page">
-          New
+          {{tt.navbar.new_button}}
         </button>
       </div>
     {{/editable}}
@@ -101,7 +101,7 @@
       {{#newable}}
         <div class="TableObject-item">
           <button class="btn btn-primary btn-sm minibutton-new-page">
-            New
+            {{tt.navbar.new_button}}
           </button>
         </div>
       {{/newable}}

--- a/lib/gollum/templates/overview.mustache
+++ b/lib/gollum/templates/overview.mustache
@@ -42,9 +42,6 @@
 {{#no_results}}
   <p id="no-results">
     {{t.no_pages_in}}
-    <strong>{{current_path}}</strong>
-    {{t.on}}
-    <strong>{{ref}}</strong>.
   </p>
 {{/no_results}}
 

--- a/lib/gollum/templates/search.mustache
+++ b/lib/gollum/templates/search.mustache
@@ -3,10 +3,7 @@
     {{>navbar}}
 
     <h1 class="header-title text-center text-md-left py-4">
-      <span class="f1-light color-fg-subtle">
-        {{t.search_results_for}}
-      </span>
-      {{name}}
+      {{t.search_results_for}}
     </h1>
   </div>
 
@@ -41,7 +38,7 @@
 
 {{#no_results}}
   <p id="no-results">
-    {{t.no_results}} <strong>{{query}}</strong>.
+    {{t.no_results}}
   </p>
 {{/no_results}}
 

--- a/lib/gollum/templates/searchbar.mustache
+++ b/lib/gollum/templates/searchbar.mustache
@@ -1,3 +1,3 @@
 <form class="search-form" action="{{search_path}}" method="get" id="search-form">
-	<input type="text" class="form-control input-block input-sm" name="q" id="search-query" placeholder="Search" aria-label="Search site" autocomplete="off">
+	<input type="text" class="form-control input-block input-sm" name="q" id="search-query" placeholder="{{tt.searchbar.placeholder}}" aria-label="{{tt.searchbar.aria.label}}" autocomplete="off">
 </form>

--- a/lib/gollum/templates/wiki_content.mustache
+++ b/lib/gollum/templates/wiki_content.mustache
@@ -47,10 +47,10 @@
 	<div id="footer" class="pt-4">
 	  {{^historical}}
 		{{^preview}}
-		  <p id="last-edit"><div class="dotted-spinner hidden"></div> <a id="page-info-toggle" data-pagepath="{{path}}">When was this page last modified?</a></p>
+		  <p id="last-edit"><div class="dotted-spinner hidden"></div> <a id="page-info-toggle" data-pagepath="{{path}}">{{tt.wiki_content.last_edit}}</a></p>
 		  {{#allow_editing}}
 		    <p>
-		      <a id="delete-link" href="{{escaped_url_path}}" data-confirm="Are you sure you want to delete this page?"><span>Delete this Page</span></a>
+		      <a id="delete-link" href="{{escaped_url_path}}" data-confirm="{{tt.wiki_content.delete_link.confirm}}"><span>{{tt.wiki_content.delete_link.title}}</span></a>
 		    </p>
 	      {{/allow_editing}}
 		{{/preview}}

--- a/test/gollum/views/test_locale_helper.rb
+++ b/test/gollum/views/test_locale_helper.rb
@@ -15,7 +15,7 @@ describe Precious::Views::LocaleHelpers do
   end
 
   def setup
-    I18n.available_locales = [:en, :de]
+    I18n.available_locales = [:en, :de, :cn]
     I18n.load_path = Dir[File.expand_path("test/support/locales" + "/*.yml")]
   end
 

--- a/test/integration/test_localization.rb
+++ b/test/integration/test_localization.rb
@@ -23,7 +23,7 @@ context 'Localized frontend' do
     assert_includes page.text,
       'Search results for something-to-return-no-results'
     assert_includes page.text,
-      'There are no results for your search something-to-return-no-results.'
+      'There are no results for your search.'
 
     click_on 'Back to Top'
 

--- a/test/support/locales/cn.yml
+++ b/test/support/locales/cn.yml
@@ -1,0 +1,8 @@
+cn:
+  test_class:
+    author_info:
+      full: 作者 %{author} 来自 %{location}
+    has_invalid_argument: 欢迎使用 %{no_matching_method}
+    hello_world: 你好世界
+  nonexistent_test_class:
+    never_called: 从未调用


### PR DESCRIPTION
This patch can support more languages, such as chinese.

```ruby
  ::I18n.default_locale = :cn
```

You just need to add a new line in the configuration to achieve the following effect.

![image](https://github.com/gollum/gollum/assets/23275497/5c860e2d-5385-4adb-a4e8-ecce8ff31252)

I have added more content in the locales(gollum/lib/gollum/locales) to achieve better results.

I hope more people can contribute their mother tongue.