### PR TITLE
Re-read base_path after loading config file

### DIFF
--- a/LATEST_CHANGES.md
+++ b/LATEST_CHANGES.md
@@ -16,3 +16,4 @@
 ## Fixes & Improvements
 
 * Fix (Docker image): add git configuration for `/wiki` as safe directory. #2006
+* Fix: use `base_path` as set in config file.

--- a/bin/gollum
+++ b/bin/gollum
@@ -296,6 +296,8 @@ else
     # otherwise it will be relative to the CWD
     cfg = File.join(Dir.getwd, cfg) unless cfg.slice(0) == File::SEPARATOR
     require cfg
+    # The options may have been updated. Reload them.
+    wiki_options = Precious::App.wiki_options
   end
 
   base_path = wiki_options[:base_path]


### PR DESCRIPTION
Bug fix: Setting base_path in the config file didn't have any effect.

The config file was being loaded, but it wasn't being used to update the wiki_options local variable, so the config file wasn't affecting the base_path.

This change updates the wiki_options local variable after the config file is read. Now, the base_path can be set using the config file.
