### PR TITLE
fix: MapGollum should handle superfluous slashes in base_path

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.1
+          ruby-version: 3.2.1
           bundler-cache: true
       - name: Install Chromedriver
         uses: nanasess/setup-chromedriver@v2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['2.7', '3.1', '3.2.1']
+        ruby: ['3.1.4', '3.2.1', '3.3']
     steps:
       - name: Install required system dependencies
         run: |
@@ -55,6 +55,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
+          rubygems: 3.5.14
           bundler-cache: true
       - name: Run tests
         run: bundle exec rake
@@ -79,7 +80,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.1'
+          ruby-version: '3.2.1'
           bundler-cache: true
       - name: Run tests
         run: bundle exec rake test:capybara

--- a/lib/gollum/app.rb
+++ b/lib/gollum/app.rb
@@ -55,17 +55,19 @@ module Precious
 
   # For use with the --base-path option.
   class MapGollum
+  include Precious::Helpers
     def initialize(base_path)
+      base_route = "/#{remove_leading_and_trailing_slashes(base_path)}"
       @mg = Rack::Builder.new do
 
-        map "/#{base_path}" do
+        map base_route do
           run Precious::App
         end
         map '/' do
-          run Proc.new { [302, { 'Location' => "/#{base_path}" }, []] }
+          run Proc.new { [302, { 'Location' => base_route }, []] }
         end
         map '/*' do
-          run Proc.new { [302, { 'Location' => "/#{base_path}" }, []] }
+          run Proc.new { [302, { 'Location' => base_route }, []] }
         end
 
       end


### PR DESCRIPTION
Resolves #2050.

As reported in #2050 setting `base_path: /wiki` doesn't work, while `base_path: wiki` does work. It appears this is because the `MapGollum` class is setting the base route to `/#{base_path}`, so when passing in `/wiki`, the actual route being served is `//wiki`, not `/wiki`. By contrast, setting `--base-path /wiki` on the commandline works because the leading slash is being stripped [here[(https://github.com/gollum/gollum/blob/master/bin/gollum#L76C1-L77C1).

This PR attempts to solve the issue by handling extra slashes in the `MapGollum` class.