### PR TITLE
fix #2059: Rack::Server class has moved to the rackup gem

### DIFF
--- a/bin/gollum
+++ b/bin/gollum
@@ -293,9 +293,9 @@ else
   if base_path.nil?
     Precious::App.run!(options)
   else
-    require 'rack'
+    require 'rackup'
 
-    # Rack::Handler does not work with Ctrl + C. Use Rack::Server instead.
-    Rack::Server.new(:app => Precious::MapGollum.new(base_path), :Port => options[:port], :Host => options[:bind]).start
+    # Rackup::Handler does not work with Ctrl + C. Use Rackup::Server instead.
+    Rackup::Server.new(:app => Precious::MapGollum.new(base_path), :Port => options[:port], :Host => options[:bind]).start
   end
 end

--- a/gollum.gemspec
+++ b/gollum.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'gollum-lib', '~> 6.0'
   s.add_dependency 'kramdown', '~> 2.3'
   s.add_dependency 'kramdown-parser-gfm', '~> 1.1.0'
+  s.add_dependency 'rack', '>= 3.0'
   s.add_dependency 'rackup', '~> 2.1'
   s.add_dependency 'sinatra', '~> 4.0'
   s.add_dependency 'sinatra-contrib', '~> 4.0'


### PR DESCRIPTION
Resolves #2059.

In `/bin/gollum` we try to instantiate the `Rack::Server` class, but it turns out [that class has been moved](https://github.com/rack/rack/blob/main/UPGRADE-GUIDE.md#binrackup-rackserver-rackhandlerand--racklobster-were-moved-to-a-separate-gem) to a different gem (`rackup`, which we already depend on).