### PR TITLE
Use static assets when APP_ENV is development.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -181,6 +181,8 @@ git push ../lotr.git/ master
 
 Gollum uses [yarn](https://yarnpkg.com/) and [sprockets](https://github.com/rails/sprockets) to manage assets. By default, Gollum uses the precompiled static assets that are packaged with the gem (under `lib/gollum/public/assets`). If you're making changes to Gollum's JavaScript or (S)CSS assets, you might want to develop by calling `gollum` with the `--development-assets` flag. This will cause the application to use the unpackaged assets that you are editing (under `lib/gollum/public/gollum/` and in your local `node_modules` directory), so you can test and tweak. Once you are satisfied with your changes, it's time to [update the static assets](#updating-static-assets)!
 
+You can also enable the use of development assets by setting the `APP_ENV` environment variable to `gollum_development`: for example, with `APP_ENV=gollum_development bundle exec gollum ...`.
+
 For convenience, Gollum also allows developers to set a custom location for `node_modules` (by default expected to be in the root of the project) when using `--development-assets`. Set the `GOLLUM_DEV_ASSETS` environment variable to do this, e.g.: `GOLLUM_DEV_ASSETS=/path/to/my/node_modules gollum --development-assets`
 
 ## Updating static assets

--- a/lib/gollum/app.rb
+++ b/lib/gollum/app.rb
@@ -103,7 +103,7 @@ module Precious
     }
 
     # Sinatra error handling
-    configure :development, :staging do
+    configure :development, :staging, :gollum_development do
       enable :show_exceptions, :dump_errors
       disable :raise_errors, :clean_trace
     end
@@ -138,7 +138,7 @@ module Precious
       @mermaid = settings.wiki_options.fetch(:mermaid, true)
       Gollum::Filter::Code.language_handlers.delete(/mermaid/) unless @mermaid
 
-      @use_static_assets = settings.wiki_options.fetch(:static, settings.environment != :development)
+      @use_static_assets = settings.wiki_options.fetch(:static, settings.environment != :gollum_development)
       @static_assets_path = settings.wiki_options.fetch(:static_assets_path, ::File.join(File.dirname(__FILE__), 'public/assets'))
       @mathjax_path = ::File.join(File.dirname(__FILE__), 'public/gollum/javascript/MathJax')
 


### PR DESCRIPTION
Resolves #2049.

@benjaminwil I tried to implement your suggestion of logging whether static assets are being used, but if I add a `puts` statement [here](https://github.com/gollum/gollum/blob/master/lib/gollum/app.rb#L141) it displays on every page load.

We could alternatively do the same check (`wiki_options.fetch(:static, settings.environment != :gollum_development)`) in `bin/gollum`, but that duplicates that line. Additionally, adding a warning in `bin/gollum` would not produce the warning when running gollum with a `config.ru`. Do you have any suggestions, or shall we just leave it like this?