### PR TITLE
Fix failing JRuby CI workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,6 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: jruby-9.4
-          bundler: 1.17.3
           bundler-cache: true
       - name: Run tests
         run: bundle exec rake

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: jruby-9.4.0.0
+          ruby-version: jruby-9.4
           bundler: 1.17.3
           bundler-cache: true
       - name: Run tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     name: Create Release
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
+      - name: Check out repository code
         uses: actions/checkout@v3
       - name: Set up Java
         uses: actions/setup-java@v2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [jruby-9.4.4.0]
+        ruby: [jruby-9.4]
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -36,6 +36,9 @@ jobs:
           bundler-cache: true
       - name: Run tests
         run: bundle exec rake
+      - name: Create WAR executable
+        run: bundle exec warble runnable war ${{ github.workspace }}/Gemfile
+
   mri_build:
     name: Ruby (${{ matrix.ruby }})
     runs-on: ubuntu-latest
@@ -59,6 +62,7 @@ jobs:
           bundler-cache: true
       - name: Run tests
         run: bundle exec rake
+
   selenium:
     name: Selenium on MRI
     runs-on: ubuntu-latest


### PR DESCRIPTION
The GitHub Actions "Create Release" workflow failed to build the JRuby release for Gollum v6.0.1.

This is a bit confusing to me, since the release step failed to pass the test run (`bundle exec rake`), which was passing as part of the "Ruby Build" workflow. The only difference I've noticed between the two workflow configurations was the version of Bundler used.

## Failed "Create Release" run

```
Run bundle exec rake
  bundle exec rake
  shell: /usr/bin/bash -e {0}
  env:
    JAVA_HOME: /opt/hostedtoolcache/Java_Temurin-Hotspot_jdk/17.0.11-9/x64
/home/runner/.rubies/jruby-9.4.0.0/bin/jruby -I"lib:lib:test:." /home/runner/work/gollum/gollum/vendor/bundle/jruby/3.1.0/gems/rake-13.2.1/lib/rake/rake_test_loader.rb "test/gollum/views/test_locale_helper.rb" "test/test_allow_editing.rb" "test/test_app.rb" "test/test_app_helpers.rb" "test/test_compare.rb" "test/test_history_view.rb" "test/test_latest_changes_view.rb" "test/test_local_time_option.rb" "test/test_migrate.rb" "test/test_overview_view.rb" "test/test_page_view.rb" "test/test_rss_view.rb" "test/test_template_cascade.rb" "test/test_unicode.rb" 
/home/runner/work/gollum/gollum/vendor/bundle/jruby/3.1.0/gems/rack-3.1.7/lib/rack/show_exceptions.rb:19: warning: already initialized constant Rack::ShowExceptions::CONTEXT
/home/runner/work/gollum/gollum/vendor/bundle/jruby/3.1.0/gems/rack-3.1.7/lib/rack/show_exceptions.rb:21: warning: already initialized constant Rack::ShowExceptions::Frame
LoadError: load error: rack/show_exceptions -- java.lang.NoSuchMethodError: 'org.joni.Region org.joni.Region.newRegion(int, int)'
           require at org/jruby/RubyKernel.java:1057
            <main> at /home/runner/work/gollum/gollum/vendor/bundle/jruby/3.1.0/gems/sinatra-4.0.0/lib/sinatra/show_exceptions.rb:3
           require at org/jruby/RubyKernel.java:1057
            <main> at /home/runner/work/gollum/gollum/vendor/bundle/jruby/3.1.0/gems/sinatra-4.0.0/lib/sinatra/base.rb:22
           require at org/jruby/RubyKernel.java:1057
  <module:Sinatra> at /home/runner/work/gollum/gollum/vendor/bundle/jruby/3.1.0/gems/sinatra-4.0.0/lib/sinatra/main.rb:28
            <main> at /home/runner/work/gollum/gollum/vendor/bundle/jruby/3.1.0/gems/sinatra-4.0.0/lib/sinatra/main.rb:3
           require at org/jruby/RubyKernel.java:1057
            <main> at /home/runner/work/gollum/gollum/vendor/bundle/jruby/3.1.0/gems/sinatra-4.0.0/lib/sinatra.rb:3
           require at org/jruby/RubyKernel.java:1057
            <main> at /home/runner/work/gollum/gollum/lib/gollum/app.rb:4
           require at org/jruby/RubyKernel.java:1057
            <main> at /home/runner/work/gollum/gollum/test/helper.rb:33
           require at org/jruby/RubyKernel.java:1057
  require_relative at org/jruby/RubyKernel.java:1084
            <main> at /home/runner/work/gollum/gollum/test/gollum/views/test_locale_helper.rb:1
           require at org/jruby/RubyKernel.java:1057
            <main> at /home/runner/work/gollum/gollum/vendor/bundle/jruby/3.1.0/gems/rake-13.2.1/lib/rake/rake_test_loader.rb:21
            select at org/jruby/RubyArray.java:2891
            <main> at /home/runner/work/gollum/gollum/vendor/bundle/jruby/3.1.0/gems/rake-13.2.1/lib/rake/rake_test_loader.rb:6
... 21 levels...
rake aborted!
Command failed with status (1): [ruby -I"lib:lib:test:." /home/runner/work/gollum/gollum/vendor/bundle/jruby/3.1.0/gems/rake-13.2.1/lib/rake/rake_test_loader.rb "test/gollum/views/test_locale_helper.rb" "test/test_allow_editing.rb" "test/test_app.rb" "test/test_app_helpers.rb" "test/test_compare.rb" "test/test_history_view.rb" "test/test_latest_changes_view.rb" "test/test_local_time_option.rb" "test/test_migrate.rb" "test/test_overview_view.rb" "test/test_page_view.rb" "test/test_rss_view.rb" "test/test_template_cascade.rb" "test/test_unicode.rb" ]
org/jruby/ext/monitor/Monitor.java:82:in `synchronize'
org/jruby/ext/monitor/Monitor.java:82:in `synchronize'
/home/runner/work/gollum/gollum/vendor/bundle/jruby/3.1.0/gems/rake-13.2.1/exe/rake:27:in `<main>'
/home/runner/.rubies/jruby-9.4.0.0/bin/bundle:25:in `<main>'
Tasks: TOP => default => test
(See full trace by running task with --trace)
Error: Process completed with exit code 1.
```