### PR TITLE
Mathjax deprecation typo

### DIFF
--- a/LATEST_CHANGES.md
+++ b/LATEST_CHANGES.md
@@ -5,3 +5,4 @@
 * Use static assets when `APP_ENV` is `development` (@dometto)
 * Explicitly require Rack 3 or greater (@dometto)
 * Let the `--base-path` wiki option handle prefixed and suffixed slashes in path values. (i.e. `--base-path /my-wiki`) (@dometto)
+* Fixed a typo in the deprecation message for `--mathjax` (@DavidForster)

--- a/bin/gollum
+++ b/bin/gollum
@@ -121,7 +121,7 @@ MSG
     puts "To set a custom configuration for #{wiki_options[:math]} please add it to \'#{default_math_config}\' and commit it to the repo."
   end
   opts.on('--mathjax', 'Enable rendering of mathematical equations via mathjax.') do |mode|
-    puts 'DEPRECATION WARNING: --mathjax. This switch will be removed in the future. Please use: "--math matjax".'
+    puts 'DEPRECATION WARNING: --mathjax. This switch will be removed in the future. Please use: "--math mathjax".'
     puts "If you are using a custom mathjax.config.js, please remame it to #{default_math_config}."
     wiki_options[:math] = :mathjax
     wiki_options[:math_config] = default_math_config


### PR DESCRIPTION
Fixing a small typo in the deprecation message for the command line option `--mathjax`. The message states to use `--math matjax`, which is mis-spelled and should be `--math mathjax`.