### PR TITLE
Resolve "Build and Test Docker" CI failures

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -45,8 +45,6 @@ jobs:
           cache-to: type=local,dest=/tmp/.buildx-cache
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}
-      - name: docker state
-        run: docker image ls
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -54,10 +52,6 @@ jobs:
           bundler-cache: true
       - name: Install Chromedriver
         uses: nanasess/setup-chromedriver@v2
-      - run: |
-          export DISPLAY=:99
-          chromedriver --url-base=/wd/hub &
-          sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 & # optional
       - name: Run Capybara tests against a Dockerized Gollum instance
         run: |
           export GOLLUM_CAPYBARA_URL="http://127.0.0.1:4567"

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -19,19 +19,23 @@ jobs:
       - name: Install required system dependencies
         run: |
           sudo apt-get install -y libyaml-dev
+
       - name: Check Out Repo
         uses: actions/checkout@v2
+
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v1
-      - name: Cache docker layers
+
+      - name: Cache Docker layers
         uses: actions/cache@v2
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
-      - name: Build
+
+      - name: Build Docker image
         id: docker_build
         uses: docker/build-push-action@v2
         with:
@@ -43,15 +47,19 @@ jobs:
           outputs: type=docker
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
-      - name: Image digest
+
+      - name: Print Docker image digest (SHA256)
         run: echo ${{ steps.docker_build.outputs.digest }}
+
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.2
           bundler-cache: true
+
       - name: Install Chromedriver
         uses: nanasess/setup-chromedriver@v2
+
       - name: Run Capybara tests against a Dockerized Gollum instance
         run: |
           export GOLLUM_CAPYBARA_URL="http://127.0.0.1:4567"

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.2.1
+          ruby-version: 3.2
           bundler-cache: true
       - name: Install Chromedriver
         uses: nanasess/setup-chromedriver@v2
@@ -58,11 +58,23 @@ jobs:
           export DISPLAY=:99
           chromedriver --url-base=/wd/hub &
           sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 & # optional
-      - name: Run gollum from Docker
+      - name: Run Capybara tests against a Dockerized Gollum instance
         run: |
-          git clone test/examples/lotr.git /tmp/lotr.git
-          RUNNER_TRACKING_ID="" docker run --user $(id -u) --rm -p 4567:4567 -v /tmp/lotr.git:/wiki -e CI=true ${{ env.CI_IMAGE }} --math katex &
-          sleep 10
-          netstat -lt
-      - name: Run capybara tests against Dockerized instance
-        run: "GOLLUM_CAPYBARA_URL=http://127.0.0.1:4567 bundle exec rake test:capybara"
+          export GOLLUM_CAPYBARA_URL="http://127.0.0.1:4567"
+          export RUNNER_TRACKING_ID=""
+          export WIKI_ROOT="/tmp/lotr.git"
+
+          # Clone a test wiki to run tests against.
+          #
+          git clone test/examples/lotr.git "$WIKI_ROOT"
+
+          # Run a daemonized Docker instance in a normal way, then run tests.
+          #
+          docker run \
+            --detach \
+            --user $(id -u) \
+            --rm \
+            --publish 4567:4567 \
+            --volume "$WIKI_ROOT":/wiki \
+            ${{ env.CI_IMAGE }} --math katex
+          bundle exec rake test:capybara

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -21,11 +21,11 @@ jobs:
           sudo apt-get install -y libyaml-dev
 
       - name: Check Out Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Cache Docker layers
         uses: actions/cache@v2
@@ -37,7 +37,7 @@ jobs:
 
       - name: Build Docker image
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: ./
           file: ./Dockerfile


### PR DESCRIPTION
There appears to be a new issue with the "Run gollum from Docker" step of the Build and Test Docker CI workflow.

Example of step failing:

```
  git clone test/examples/lotr.git /tmp/lotr.git
  RUNNER_TRACKING_ID="" docker run --user $(id -u) --rm -p 4567:4567 -v /tmp/lotr.git:/wiki -e CI=true gollum-ci-img --math katex &
  sleep 10
  netstat -lt
  shell: /usr/bin/bash -e {0}
  env:
    CI_IMAGE: gollum-ci-img
Cloning into '/tmp/lotr.git'...
done.
To set a custom configuration for katex please add it to 'math.config.js' and commit it to the repo.
/usr/local/bundle/gems/rackup-2.2.1/lib/rackup/handler.rb:81:in `pick': Couldn't find handler for: puma, falcon, thin. (LoadError)
	from /usr/local/bundle/gems/sinatra-4.1.0/lib/sinatra/base.rb:1627:in `run!'
	from /usr/local/bundle/gems/gollum-6.0.1/bin/gollum:294:in `<top (required)>'
	from /usr/local/bundle/bin/gollum:25:in `load'
	from /usr/local/bundle/bin/gollum:25:in `<main>'
Active Internet connections (only servers)
Proto Recv-Q Send-Q Local Address           Foreign Address         State      
tcp        0      0 0.0.0.0:8084            0.0.0.0:*               LISTEN     
tcp        0      0 localhost:42691         0.0.0.0:*               LISTEN     
tcp        0      0 0.0.0.0:ssh             0.0.0.0:*               LISTEN     
tcp        0      0 localhost:domain        0.0.0.0:*               LISTEN     
tcp6       0      0 localhost:42691         [::]:*                  LISTEN     
tcp6       0      0 [::]:ssh                [::]:*                  LISTEN     
```

Example of step passing:

```
  git clone test/examples/lotr.git /tmp/lotr.git
  RUNNER_TRACKING_ID="" docker run --user $(id -u) --rm -p 4567:4567 -v /tmp/lotr.git:/wiki -e CI=true gollum-ci-img --math katex &
  sleep 10
  netstat -lt
  shell: /usr/bin/bash -e {0}
  env:
    CI_IMAGE: gollum-ci-img
Cloning into '/tmp/lotr.git'...
done.
To set a custom configuration for katex please add it to 'math.config.js' and commit it to the repo.
[2024-11-16 12:29:05] INFO  WEBrick 1.9.0
[2024-11-16 12:29:05] INFO  ruby 3.1.6 (2024-05-29) [x86_64-linux-musl]
== Sinatra (v4.0.0) has taken the stage on 4567 for production with backup from WEBrick
[2024-11-16 12:29:05] INFO  WEBrick::HTTPServer#start: pid=1 port=4567
Active Internet connections (only servers)
Proto Recv-Q Send-Q Local Address           Foreign Address         State      
tcp        0      0 0.0.0.0:4567            0.0.0.0:*               LISTEN     
tcp        0      0 0.0.0.0:8084            0.0.0.0:*               LISTEN     
tcp        0      0 localhost:43579         0.0.0.0:*               LISTEN     
tcp        0      0 localhost:domain        0.0.0.0:*               LISTEN     
tcp        0      0 0.0.0.0:ssh             0.0.0.0:*               LISTEN     
tcp6       0      0 [::]:4567               [::]:*                  LISTEN     
tcp6       0      0 [::]:ssh                [::]:*                  LISTEN     
tcp6       0      0 localhost:43579         [::]:*                  LISTEN     
```

While I don't understand what changed to expose this issue exactly, I am suspicious of these commands:

```
  RUNNER_TRACKING_ID="" docker run --user $(id -u) --rm -p 4567:4567 -v /tmp/lotr.git:/wiki -e CI=true gollum-ci-img --math katex &
  sleep 10
  netstat -lt
```

I noticed:

1. CI runs would always take ten seconds longer than it needed to take.
2. We were only using `netstat` output for debugging purposes.
3. The tests continued to run, 100% of them errorring out, because `netstat` still exited with a 0 status, letting the run tasks continue.

So I was able to resolve all of these issues:

- Use `docker run --detach` to ensure that the Docker instance starts normally before continuing.
- No sleep is required anymore.
- The test run will never be run if the Docker instance fails to start.

While I was editing the workflow, I took the time to perform some other maintenance. See the commit messages for more information.