### PR TITLE
Resolve JRuby CI failures

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,6 +11,7 @@ on:
       - '**.md'
       - '**.txt'
       - 'contrib/**'
+
 jobs:
   jruby_build:
     name: JRuby (${{ matrix.ruby }})
@@ -21,9 +22,6 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3
-      - name: List files in the repository
-        run: |
-          ls ${{ github.workspace }}
       - name: Set up Java
         uses: actions/setup-java@v2
         with:
@@ -51,9 +49,6 @@ jobs:
           sudo apt-get install -y libyaml-dev
       - name: Check out repository code
         uses: actions/checkout@v2
-      - name: List files in the repository
-        run: |
-          ls ${{ github.workspace }}
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -78,9 +73,6 @@ jobs:
           export DISPLAY=:99
           chromedriver --url-base=/wd/hub &
           sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 & # optional
-      - name: List files in the repository
-        run: |
-          ls ${{ github.workspace }}
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,17 @@ source 'https://rubygems.org'
 
 gem 'warbler', git: 'https://github.com/jruby/warbler' if RUBY_PLATFORM == 'java'
 
+# FIXME: There is an upstream JRuby 9.4.9.0 issue with `psych` and the latest
+# version of `jar-dependencies`. The issue will be resolved with the release of
+# 9.4.10.0. Then, we can remove this `jar-dependencies` dependency lock.
+#
+# Gollum end users using JRuby may need to add this lock to their own project
+# Gemfiles, too, unfortunately. :-(
+#
+# For more information, see: https://github.com/jruby/jruby/issues/8488
+#
+gem 'jar-dependencies', '< 0.5'
+
 group :test do
   gem 'selenium-webdriver', require: false
   gem 'capybara', require: false

--- a/LATEST_CHANGES.md
+++ b/LATEST_CHANGES.md
@@ -2,4 +2,4 @@
 
 ## Fixes & Improvements
 * Fixed a typo in the deprecation message for `--mathjax` (@DavidForster)
-* Update Mermaid to 11.1
+* Update Mermaid to 11.4

--- a/test/test_app.rb
+++ b/test/test_app.rb
@@ -58,11 +58,14 @@ context "Frontend" do
 
     get 'utfh1'
 
-    doc = Nokogiri::HTML(last_response.body)
-    anchor = doc.css('h2.editable a.anchor')
-    assert_equal anchor.attr('id').value, "한글"
-    assert_equal anchor.attr('href').value, "#한글"
-    assert_equal doc.css('h2.editable').children.last.to_s.strip, "한글"
+    document = Nokogiri::HTML(last_response.body)
+
+    heading = document.css 'h2.editable'
+    assert_equal heading.text, "한글"
+
+    heading_anchor = heading.at 'a'
+    assert_equal heading_anchor['id'], "한글"
+    assert_equal heading_anchor['href'], "#한글"
   end
 
   test 'rss feed' do


### PR DESCRIPTION
This pull request collects some changes to make JRuby CI runs pass. (I may throw in some other CI quality-of-life improvements.)

## jar-dependencies version constraint

There is currently an issue in JRuby 9.4.9.0 because of the open-ended version requirement of `jar-depedencies` in the `psych` gem. The issue results in Gollum and its test suite being completely broken with this `Gem::LoadError`:

```
Gem::LoadError: You have already activated jar-dependencies 0.4.1,
but your Gemfile requires jar-dependencies 0.5.1. Since 
jar-dependencies is a default gem, you can either remove your
dependency on it or try updating to a newer version of bundler
that supports jar-dependencies as a default gem.
```

The issue is discussed here: https://github.com/jruby/jruby/issues/8488

And it will be resolved when 9.4.10.0 is released.

If your Gollum project is affected by this issue, you can add a `"jar-dependencies", "< 0.5"` version constraint to your project's Gemfile.

## Weird test failure

A new, weird test failure appeared for JRuby CI runs only. Changing how the test is written was the easiest fix.