### PR TITLE
Introduce directory permission check to docker-run.sh script (#2084)

### DIFF
--- a/LATEST_CHANGES.md
+++ b/LATEST_CHANGES.md
@@ -3,3 +3,4 @@
 ## Fixes & Improvements
 * Fixed a typo in the deprecation message for `--mathjax` (@DavidForster)
 * Update Mermaid to 11.4
+* Add wiki permission check to docker run script

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+# Check if /wiki directory exists and is writable
+if [ ! -d "/wiki" ] || [ ! -w "/wiki" ]; then
+  echo "Error: /wiki directory does not exist or is not writable. Adjust permissions to mapped host volume. Exiting ..."
+  exit 1
+else
+  echo "The /wiki directory exists and is writable. Continuing ..."
+fi
+
 # Initialize the wiki
 if [ ! -d .git ] && [ "$(git rev-parse  --is-bare-repository 2>/dev/null)" != "true" ]; then
     git init

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -2,10 +2,9 @@
 
 # Check if /wiki directory exists and is writable
 if [ ! -d "/wiki" ] || [ ! -w "/wiki" ]; then
-  echo "Error: /wiki directory does not exist or is not writable. Adjust permissions to mapped host volume. Exiting ..."
-  exit 1
+  echo "Warning: /wiki directory does not exist or is not writable. Adjust permissions to mapped host volume."
 else
-  echo "The /wiki directory exists and is writable. Continuing ..."
+  echo "The /wiki directory exists and is writable."
 fi
 
 # Initialize the wiki


### PR DESCRIPTION
1. Please clearly explain the purpose of your PR. Let us know if it introduces a new feature, an enhancement, or fixes a bug.
Enhancement Proposal:
For docker images starting with 6.0 a non-root user needs the correct permissions to the mapped host volume:
`-v /path/to/git/directory/on/host:wiki`. If these are not set correctly, the docker container will continue to run, but the web page will not work.
This introduces a short check at the beginning of docker-run.sh to check for existence and writeability of the volume. If true, continue with the script, if false, exit. For both conditions issue a message describing success or failure.

2. Please link any issues that your PR addresses.
Inspired by #2084

3. If your PR changes any of the CSS or JavaScript under `lib/gollum/public`, don't forget to update the static asssets as explained [here](https://github.com/gollum/gollum/blob/master/CONTRIBUTING.md#updating-static-assets).
No changes to CSS/JavaScript

Added to [LATEST_CHANGES.md](https://github.com/gollum/gollum/blob/master/LATEST_CHANGES.md)