### PR TITLE
Update Ruby in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.1-alpine AS builder
+FROM ruby:3.3-alpine AS builder
 
 RUN apk add --update \
             --no-cache \
@@ -28,7 +28,7 @@ WORKDIR /app
 COPY . /app
 RUN bundle exec rake install
 
-FROM ruby:3.1-alpine
+FROM ruby:3.3-alpine
 
 ARG UID=${UID:-1000}
 ARG GID=${GID:-1000}


### PR DESCRIPTION
Update the version of ruby used in the docker image from `3.1` to `3.3`. We are already testing Gollum against 3.3, so this should be fine, and potentially improve performance a bit.