### PR TITLE
Resolve Dockerfile warnings re: $UID, $GID

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,8 @@ RUN bundle exec rake install
 
 FROM ruby:3.1-alpine
 
-ARG UID=${UID:-1000}
-ARG GID=${GID:-1000}
+ARG UID=1000
+ARG GID=1000
 
 COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
 


### PR DESCRIPTION
Our build-and-test GitHub Action raised warnings about these environment variables:

    UndefinedVar: Usage of undefined variable '$UID'
    More info: https://docs.docker.com/go/dockerfile/rule/undefined-var/

After readings about `ARG` more, it appears our Dockerfile was using it incorrectly[^1]:

    An ARG instruction can optionally include a default value:

        FROM busybox
        ARG user1=someuser
        ARG buildno=1
        # ...

    If an ARG instruction has a default value and if there is no value
    passed at build-time, the builder uses the default.

This commit resolves the issues.

[^1]: https://docs.docker.com/reference/dockerfile/#arg
