### PR TITLE
Improve the write test in docker-run.sh to ensure actual write permissions on the mounted volume.

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -28,7 +28,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Cache Docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -1,10 +1,14 @@
 #!/bin/bash
 
+wiki_is_writable(){
+  tempfile="$(mktemp -p . 2>/dev/null)" && rm "$tempfile"
+}
+
 # Check if /wiki directory exists and is writable
-if [ ! -d "/wiki" ] || [ ! -w "/wiki" ]; then
-  echo "Warning: /wiki directory does not exist or is not writable. Adjust permissions to mapped host volume."
-else
+if [ -d "/wiki" ] && wiki_is_writable; then
   echo "The /wiki directory exists and is writable."
+else
+  echo "Warning: /wiki directory does not exist or is not writable. Adjust permissions to mapped host volume."
 fi
 
 # Initialize the wiki
@@ -21,4 +25,4 @@ if [ ${GOLLUM_AUTHOR_EMAIL:+1} ]; then
 fi
 
 # Start gollum service
-exec gollum $@
+exec gollum "$@"

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 wiki_is_writable(){
-  tempfile="$(mktemp -p . 2>/dev/null)" && rm "$tempfile"
+  tempfile="$(mktemp -p /wiki 2>/dev/null)" && rm "$tempfile"
 }
 
 # Check if /wiki directory exists and is writable


### PR DESCRIPTION
This PR solves the following issue, namely that checking for write permissions on the running docker container with `[ ! -w /wiki ]` would not be accurate when write permissions on the local volume were not granted to the docker user. 

The scenario is this: a local directory, say `wikidir` has owner `user` and permissions `600` and is mounted in docker. Docker is told that the mounted volume directory is owned by `www-dir` with permissions `600`. However, user `www-dir` is not allowed to actually write to the volume due to the local permissions on the host. The `-w` check only looks at permissions, which _seem_ to allow writing to the mounted volume when it is in fact not allowed, while the check in this PR actually attempts a write action.

