### PR TITLE
Fix .war generation in release.yml and update actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,15 @@ jobs:
         run: bundle exec rake
       - name: Create war
         run: bundle exec warble runnable war ${{ github.workspace }}/Gemfile
+      - name: Verify that .war has been built
+        run: ls gollum.war
+      - name: Calculate digest for gollum.war
+        run: sha256sum gollum.war > gollum.war.digest.txt && cat gollum.war.digest.txt
+      - name: Add URL of current workflow run to the digest file 
+        run: |
+          echo "You can also find this SHA sum in the build that generated this version of gollum.war:" >> gollum.war.digest.txt
+          echo "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> gollum.war.digest.txt
+          cat gollum.war.digest.txt
       - name: Create Release
         id: create_release
         uses: softprops/action-gh-release@v1
@@ -39,3 +48,4 @@ jobs:
           files: |
             gollum.war
             LICENSE
+            gollum.war.digest.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v3
       - name: Set up Java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
           cat gollum.war.digest.txt
       - name: Create Release
         id: create_release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.ref_name }}
           name: Release ${{ github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           ruby-version: jruby-9.4
           bundler-cache: true
+          bundler: 2.5
       - name: Run tests
         run: bundle exec rake
       - name: Create war


### PR DESCRIPTION
Resolves #2091

This PR resolves the problem that `gollum.war` was no longer being built automatically on a new release. I've also added some updates and a feature, since I was editing and testing the workflow file anyway:

* explicitly set `bundler` version. Using https://github.com/nektos/act to test the worklow locally, I noticed that `bundler 2.3` was being used. Locally, I had `bundler 2.5`, and with that version I managed to build the .war successfully.
* Update actions `ruby/setup-ruby` and `softprops/action-gh-release` to their latest versions
* Update to the latest version of the `temurin` JRE
* Create a sha256 sum for the created `gollum.war` file. This sum is echo'd and written to a digest file, which will be attached to the release. The digest file also contains a URL to the workflow run, so that users can verify that the checksum matches the automatically built artifact. The latter adds some security/verifiability since technically, we could upload a malocious `gollum.war` binary and checksum to the release.

