### PR TITLE
Update sassc-embedded

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,10 +19,7 @@ group :test do
 end
 
 group :development do
-  unless RUBY_PLATFORM.match(/linux-musl$/)
-    gem 'sassc',  '~> 2.4'
-    gem 'sassc-embedded', '~> 1.54'
-  end
+  gem 'sassc-embedded', '~> 1.80'
 end
 
 gemspec

--- a/lib/gollum/assets.rb
+++ b/lib/gollum/assets.rb
@@ -19,6 +19,19 @@ module Precious
       env.js_compressor  = ::Precious::Assets::JS_COMPRESSOR if defined?(::Precious::Assets::JS_COMPRESSOR)
       env.css_compressor = :sassc
 
+      options = {
+        sass_config: {
+          quiet_deps: true,
+          silence_deprecations: [
+            'global-builtin',
+            'import'
+          ]
+        }
+      }
+
+      env.register_transformer 'text/sass', 'text/css', Sprockets::SasscProcessor.new(options)
+      env.register_transformer 'text/scss', 'text/css', Sprockets::ScsscProcessor.new(options)
+
       env.context_class.class_eval do
         def base_url
           self.class.class_variable_get(:@@base_url)


### PR DESCRIPTION
This PR updates `sassc-embedded` to latest version. Also:

- Remove `sassc` to speed up `bundle install` for development, as latest `sassc-embedded` already bundles necessary code from `sassc`.
- Add options to silence `import` and `global-builtin` deprecations.