### PR TITLE
Update docker-deploy.yml: don't trigger on push to master

### DIFF
--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -1,8 +1,9 @@
 name: Deploy docker
 on:
   push:
-    branches:
-      - master
+    # This workflow will be triggered by the `precompile-assets` workflow on pushes to `master`
+    # branches:
+    #   - master
     tags:
       - "*"
     paths-ignore:


### PR DESCRIPTION
After merging https://github.com/gollum/gollum/pull/2094, the precompile-assets workflow will trigger docker-deploy. To avoid duplicate runs of this workflow, we can remove the push-to-master trigger here.

So at present the workflow logic looks as follows:

* Push to `master`: triggers `precompile-asset`, which triggers `docker-deploy`
* Push a new tag: triggers `docker-deploy`, but not `precompile-assets`.
* Push to a different branch: nothing happens. :)

Would appreciate a quick check if this makes sense!