### PR TITLE
Attempt to fix integration tests

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -59,6 +59,10 @@ jobs:
 
       - name: Install Chromedriver
         uses: nanasess/setup-chromedriver@v2
+      - run: |
+          export DISPLAY=:99
+          chromedriver --url-base=/wd/hub &
+          sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 & # optional
 
       - name: Run Capybara tests against a Dockerized Gollum instance
         run: |

--- a/test/integration/test_localization.rb
+++ b/test/integration/test_localization.rb
@@ -15,28 +15,35 @@ context 'Localized frontend' do
 
   test 'can visit search results page' do
     visit '/gollum/search'
-
-    fill_in('Search', with: 'something-to-return-no-results')
-      .native
-      .send_keys(:return)
-
-    assert_includes page.text,
-      'Search results for something-to-return-no-results'
-    assert_includes page.text,
-      'There are no results for your search.'
-
-    click_on 'Back to Top'
+    using_wait_time 10 do
+      fill_in('Search', with: "something-to-return-no-results")
+    end
+    send_keys :return
+    
+    using_wait_time 10 do
+      assert_includes page.text,
+        'Search results for something-to-return-no-results'
+      assert_includes page.text,
+        'There are no results for your search.'
+      click_on 'Back to Top'
+    end
 
     visit '/gollum/search'
 
-    fill_in('Search', with: 'Bilbo').native.send_keys(:return)
+    using_wait_time 10 do
+      fill_in('Search site', with: "Bilbo")
+    end
+    send_keys :return
+    
+    using_wait_time 10 do
+      assert_includes page.text, 'Search results for Bilbo'
+      click_on 'Show all hits on this page'
+      click_on 'Bilbo-Baggins.md'
+    end
 
-    assert_includes page.text, 'Search results for Bilbo'
-
-    click_on 'Show all hits on this page'
-    click_on 'Bilbo-Baggins.md'
-
-    assert page.current_path, '/Bilbo-Baggins.md'
+    using_wait_time 10 do
+      assert page.current_path, '/Bilbo-Baggins.md'
+    end
   end
 
   test 'can visit overview page' do


### PR DESCRIPTION
 Integration tests are failing consistently on CI and hit-or-miss locally. This suggested a wait time issue. Indeed, it looks as if in some cases the search form was being submitted before the 'send_keys' operation was completed. Added explicit wait time to fix this.