### PR TITLE
Add yarn.lock to precompile assets workflow

### DIFF
--- a/.github/workflows/precompile-assets.yaml
+++ b/.github/workflows/precompile-assets.yaml
@@ -40,6 +40,7 @@ jobs:
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
           git config user.name github-actions[bot]
           git add -A lib/gollum/public/assets
+          git add yarn.lock
           git commit -m 'Precompile assets'
           git push
           # Pushing with the implict token won't trigger another workflow,


### PR DESCRIPTION
I *think* we want to also commit changes to `yarn.lock` that result from running the precompile workflow. Sanity check appreciated :)