### PR TITLE
Update Ruby versions in CI workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['3.1.4', '3.2.1', '3.3']
+        ruby: ['3.2.1', '3.3', '3.4']
     steps:
       - name: Install required system dependencies
         run: |


### PR DESCRIPTION
Ruby 3.1 is end of life, drop it in favour of 3.4