### PR TITLE
Test that `[[include:]]` works with absolute paths

### DIFF
--- a/test/capybara_helper.rb
+++ b/test/capybara_helper.rb
@@ -28,6 +28,14 @@ def console_log(page, level = :severe)
   page.driver.browser.logs.get(:browser).select { |log| log.level == level.to_s.upcase }
 end
 
+# Creates a page as a user might in the browser. Results in a page being created
+# and navigated to.
+#
+# @param title [String] A page title or the full path to the desired output
+#   file relative to the wiki's root. For example, both "Page" and
+#   "Path/To/My/Page.md" are valid titles.
+# @param content [String] The page's content.
+# @return [Void]
 def create_page(title:, content:)
   visit "/"
 
@@ -38,7 +46,8 @@ def create_page(title:, content:)
   assert_includes page.text, "Create New Page"
 
   page_title_field = find "input#gollum-editor-page-title"
-  assert_includes page_title_field.value, title
+
+  assert_includes page_title_field.value, title.split("/").last
 
   within "div.ace_content" do
     send_keys content

--- a/test/integration/test_page.rb
+++ b/test/integration/test_page.rb
@@ -21,6 +21,25 @@ context "viewing a wiki page" do
     Capybara.use_default_driver
   end
 
+  test "include with an absolute path ([[include:/with-absolute-path]])" do
+    create_page title: "Subdirectory 1/Some content", content: <<~TEXT
+      Paragraph one from 'Some content' page.
+
+      Paragraph two from 'Some content' page.
+    TEXT
+
+    create_page title: "Subdirectory 2/Page with another page included", content: <<~TEXT
+      This page uses the `[[include:<path>]]` tag to include content from
+      another wiki page.
+
+      [[include:/Subdirectory 1/Some content.md]]
+    TEXT
+
+    assert_includes page.text, "Page with another page included"
+    assert_includes page.text, "Paragraph one from 'Some content' page."
+    assert_includes page.text, "Paragraph two from 'Some content' page."
+  end
+
   test "'copy to clipboard' functionality on code blocks" do
     create_page title: "Page with code block", content: <<~TEXT
       This page includes a code block. In this test, we will use the provided


### PR DESCRIPTION
This pull request verifies that the `gollum-lib` 6.1.0 resolves the #2153 issue by adding test coverage for the `[[include:<absolute-path>]]` helper tag.

We actually resolved the bug described by this issue as part of the 6.0 `gollum-lib` release. However, due to the order of the commits, it seems that the `gollum-lib` source did not include the fix. You can verify this by downloading a copy of `gollum-lib` at version 6.0 from RubyGems and checking the source code for the contents of https://github.com/gollum/gollum-lib/pull/452. You will see, as I did, that this diff is not in the 6.0 release.
